### PR TITLE
Py2k syntaxerror fix

### DIFF
--- a/network.py
+++ b/network.py
@@ -604,7 +604,8 @@ class SnowflakeRestful(object):
 
         return ret
 
-    def fetch(self, method, full_url, headers, *, data=None, timeout=None, **kwargs):
+    def fetch(self, method, full_url, headers, data=None, timeout=None,
+              **kwargs):
         """ Curried API request with session management. """
         if timeout is not None and 'timeouts' in kwargs:
             raise TypeError("Mutually exclusive args: timeout, timeouts")


### PR DESCRIPTION
I can't get py2k installs to work but I validated the `python -m py_compile *.py` in the project root is now clean.