### PR TITLE
Row perf

### DIFF
--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -259,8 +259,6 @@ class SnowflakeChunkDownloader(object):
             self._connection._connect_timeout,
             DEFAULT_REQUEST_TIMEOUT
         )
-        data = self._connection.rest.fetch(u'get', url, headers,
+        return self._connection.rest.fetch(u'get', url, headers,
             timeouts=timeouts, is_raw_binary=True,
-            is_raw_binary_iterator=False, use_ijson=self._use_ijson)
-        return iter([self._cursor.row_to_python(x) if x is not None else None
-                     for x in data])
+            is_raw_binary_iterator=True, use_ijson=self._use_ijson)

--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -70,7 +70,8 @@ class SnowflakeChunkDownloader(object):
                                            self._chunk_size)
 
         for idx, chunk in enumerate(chunks):
-            logger.info(u"queued chunk %d: rowCount=%s" % (idx, chunk[u'rowCount']))
+            logger.info(u"queued chunk %d: rowCount=%s", idx,
+                        chunk[u'rowCount'])
             self._chunks[idx] = SnowflakeChunk(
                 url=chunk[u'url'],
                 result_data=None,

--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -70,8 +70,7 @@ class SnowflakeChunkDownloader(object):
                                            self._chunk_size)
 
         for idx, chunk in enumerate(chunks):
-            logger.info(u"queued chunk: url=%s, rowCount=%s",
-                        chunk[u'url'], chunk[u'rowCount'])
+            logger.info(u"queued chunk %d: rowCount=%s" % (idx, chunk[u'rowCount']))
             self._chunks[idx] = SnowflakeChunk(
                 url=chunk[u'url'],
                 result_data=None,

--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -96,8 +96,7 @@ class SnowflakeChunkDownloader(object):
     def __init__(self, chunks, connection, cursor, qrmk, chunk_headers,
                  prefetch_slots=DEFAULT_CLIENT_RESULT_PREFETCH_SLOTS,
                  prefetch_threads=DEFAULT_CLIENT_RESULT_PREFETCH_THREADS,
-                 use_ijson=False, row_filter=None):
-        self._row_filter = row_filter
+                 use_ijson=False):
         self._pre_init(chunks, connection, cursor, qrmk, chunk_headers,
                        prefetch_slots=prefetch_slots,
                        prefetch_threads=prefetch_threads,
@@ -263,5 +262,5 @@ class SnowflakeChunkDownloader(object):
         data = self._connection.rest.fetch(u'get', url, headers,
             timeouts=timeouts, is_raw_binary=True,
             is_raw_binary_iterator=False, use_ijson=self._use_ijson)
-        return iter([self._row_filter(x) if x is not None else None
+        return iter([self._cursor.row_to_python(x) if x is not None else None
                      for x in data])

--- a/connection.py
+++ b/connection.py
@@ -6,6 +6,7 @@
 import re
 import sys
 import uuid
+import warnings
 from io import StringIO
 from threading import Lock
 from time import strptime
@@ -256,7 +257,7 @@ class SnowflakeConnection(object):
         u"""
         Connects to the database
         """
-        self.logger.info(u'connect')
+        self.logger.debug(u'connect')
         if len(kwargs) > 0:
             self.__config(**kwargs)
 
@@ -332,7 +333,7 @@ class SnowflakeConnection(object):
         u"""Creates a cursor object. Each statement should create a new cursor
         object.
         """
-        self.logger.info(u'cursor')
+        self.logger.debug(u'cursor')
         if not self._con:
             Error.errorhandler_wrapper(
                 self, None, DatabaseError,
@@ -387,7 +388,7 @@ class SnowflakeConnection(object):
         Executes post connection process
         """
         # load current session info
-        self.logger.info(u'__post connection')
+        self.logger.debug(u'__post connection')
         """
         NOTE: abort detached query mode is TRUE by default
 
@@ -416,7 +417,6 @@ class SnowflakeConnection(object):
         u"""
         Opens a new network connection
         """
-        self.logger.info(u'opening a connection')
         self._con = network.SnowflakeRestful(
             host=self._host,
             port=self._port,
@@ -475,7 +475,7 @@ class SnowflakeConnection(object):
         u"""
         Sets the parameters
         """
-        self.logger.info(u'__config')
+        self.logger.debug(u'__config')
         for name, value in kwargs.items():
             if name == u'sequence_counter':
                 self.sequence_counter = value
@@ -527,12 +527,11 @@ class SnowflakeConnection(object):
             # remove region subdomain
             self._account = self._account[0:self._account.find(u'.')]
 
-        self.logger.info(u'insecure_mode: %s', self._insecure_mode)
         if self._insecure_mode:
-            self.logger.info(u'WARNING: THIS CONNECTION IS IN INSECURE '
-                             u'MODE. IT MEANS THE CERTIFICATE WILL BE '
-                             u'VALIDATED BUT THE CERTIFICATE REVOCATION '
-                             u'STATUS WILL NOT BE CHECKED.')
+            warnings.warn(u'THIS CONNECTION IS IN INSECURE MODE. IT MEANS '
+                          u'THE CERTIFICATE WILL BE VALIDATED BUT THE '
+                          u'CERTIFICATE REVOCATION STATUS WILL NOT BE '
+                          u'CHECKED.')
         if not self._insecure_mode and self._protocol == u'https' and \
                         self._account not in TEST_ACCOUNTS:
             if IS_OLD_PYTHON():
@@ -550,7 +549,7 @@ class SnowflakeConnection(object):
         u"""
         Executes a query with a sequence counter.
         """
-        self.logger.info(u'_cmd_query')
+        self.logger.debug(u'_cmd_query')
         data = {
             u'sqlText': sql,
             u'asyncExec': _no_results,
@@ -562,8 +561,8 @@ class SnowflakeConnection(object):
             data[u'isInternal'] = is_internal
         client = u'sfsql_file_transfer' if is_file_transfer else u'sfsql'
 
-        if self.logger.getEffectiveLevel() <= logging.INFO:
-            self.logger.info(
+        if self.logger.getEffectiveLevel() <= logging.DEBUG:
+            self.logger.debug(
                 u'sql=[%s], sequence_id=[%s], is_file_transfer=[%s]',
                 u' '.join(
                     line.strip() for line in
@@ -588,9 +587,8 @@ class SnowflakeConnection(object):
         Cancels the query by the sequence counter. The sequence counter
         is used to identify the query submitted by the client.
         """
-        self.logger.info(u'_cancel_query')
-        self.logger.debug(
-            u'sql=[%s], sequence_id=[%s]', sql, sequence_counter)
+        self.logger.debug(u'_cancel_query sql=[%s], sequence_id=[%s]' % (sql,
+                          sequence_counter))
         url_parameters = {u'requestId': TO_UNICODE(uuid.uuid4())}
 
         return self._con.request(

--- a/connection.py
+++ b/connection.py
@@ -587,8 +587,8 @@ class SnowflakeConnection(object):
         Cancels the query by the sequence counter. The sequence counter
         is used to identify the query submitted by the client.
         """
-        self.logger.debug(u'_cancel_query sql=[%s], sequence_id=[%s]' % (sql,
-                          sequence_counter))
+        self.logger.debug(u'_cancel_query sql=[%s], sequence_id=[%s]', sql,
+                          sequence_counter)
         url_parameters = {u'requestId': TO_UNICODE(uuid.uuid4())}
 
         return self._con.request(

--- a/converter.py
+++ b/converter.py
@@ -5,7 +5,7 @@
 #
 import decimal
 import time
-from datetime import datetime, timedelta, tzinfo, date
+from datetime import datetime, timedelta, tzinfo
 from logging import getLogger
 
 import pytz

--- a/converter.py
+++ b/converter.py
@@ -39,9 +39,9 @@ class SnowflakeConverter(object):
         self._use_numpy = kwargs.get('use_numpy', False) and numpy is not None
 
         self.logger = getLogger(__name__)
-        self.logger.info('use_sfbinaryformat: %s, use_numpy: %s',
-                         self._use_sfbinaryformat,
-                         self._use_numpy)
+        self.logger.debug('use_sfbinaryformat: %s, use_numpy: %s',
+                          self._use_sfbinaryformat,
+                          self._use_numpy)
 
     def set_parameters(self, parameters):
         self._parameters = {}

--- a/converter.py
+++ b/converter.py
@@ -278,11 +278,9 @@ class SnowflakeConverter(object):
             tzinfo_value = pytz.timezone(self.get_parameter(u'TIMEZONE'))
         except pytz.exceptions.UnknownTimeZoneError:
             self.logger.warn('converting to tzinfo_value failed')
-            try:
-                # tzlocal is optional.
-                import tzlocal
+            if tzlocal is not None:
                 tzinfo_value = tzlocal.get_localzone()
-            except:
+            else:
                 tzinfo_value = pytz.timezone('UTC')
 
         try:

--- a/cursor.py
+++ b/cursor.py
@@ -403,7 +403,7 @@ class SnowflakeCursor(object):
         u"""
         Executes a command/query
         """
-        self.logger.info(u'executing SQL/command')
+        self.logger.debug(u'executing SQL/command')
         if self.is_closed():
             Error.errorhandler_wrapper(
                 self.connection, self,
@@ -456,7 +456,7 @@ class SnowflakeCursor(object):
         self.logger.debug(u'sfqid=%s', self._sfqid)
 
         if ret[u'success']:
-            self.logger.info(u'SUCCESS')
+            self.logger.debug(u'SUCCESS')
             data = ret[u'data']
             if u'finalDatabaseName' in data:
                 self._connection._database = data[u'finalDatabaseName']

--- a/cursor.py
+++ b/cursor.py
@@ -532,6 +532,23 @@ class SnowflakeCursor(object):
         self._current_chunk_row = iter(data.get(u'rowset'))
         self._current_chunk_row_count = len(data.get(u'rowset'))
 
+        self._description = []
+        self._column_idx_to_name = {}
+        self._column_converter = []
+        for idx, column in enumerate(data[u'rowtype']):
+            self._column_idx_to_name[idx] = column[u'name']
+            type_value = FIELD_NAME_TO_ID[column[u'type'].upper()]
+            self._description.append((column[u'name'],
+                                      type_value,
+                                      None,
+                                      column[u'length'],
+                                      column[u'precision'],
+                                      column[u'scale'],
+                                      column[u'nullable']))
+            self._column_converter.append(
+                self._connection.converter.to_python_method(
+                    column[u'type'].upper(), column, data.get(u'version', 0)))
+
         if u'chunks' in data:
             chunks = data[u'chunks']
             self._chunk_count = len(chunks)
@@ -554,23 +571,7 @@ class SnowflakeCursor(object):
                 chunks, self._connection, self, qrmk, chunk_headers,
                 prefetch_slots=self._client_result_prefetch_slots,
                 prefetch_threads=self._client_result_prefetch_threads,
-                use_ijson=use_ijson)
-        self._description = []
-        self._column_idx_to_name = {}
-        self._column_converter = []
-        for idx, column in enumerate(data[u'rowtype']):
-            self._column_idx_to_name[idx] = column[u'name']
-            type_value = FIELD_NAME_TO_ID[column[u'type'].upper()]
-            self._description.append((column[u'name'],
-                                      type_value,
-                                      None,
-                                      column[u'length'],
-                                      column[u'precision'],
-                                      column[u'scale'],
-                                      column[u'nullable']))
-            self._column_converter.append(
-                self._connection.converter.to_python_method(
-                    column[u'type'].upper(), column))
+                use_ijson=use_ijson, row_filter=self._row_to_python)
 
         if is_dml:
             updated_rows = 0
@@ -686,7 +687,7 @@ class SnowflakeCursor(object):
                     self._chunk_downloader = None
                     self._chunk_count = 0
                     self._current_chunk_row = iter(())
-            return self._row_to_python(row) if row is not None else None
+            return row
 
         except IndexError:
             # returns None if the iteration is completed so that iter() stops
@@ -850,26 +851,25 @@ class SnowflakeCursor(object):
         """
         idx = 0
         for col in row:
-            if col is not None:
-                try:
-                    conv_method, conv_ctx = self._column_converter[idx]
-                    row[idx] = conv_method(col, conv_ctx)
-                except Exception as e:
-                    col_desc = self._description[idx]
-                    msg = u'Failed to convert: ' \
-                          u'field {name}: {type}::{value}, Error: ' \
-                          u'{error}'.format(
-                        name=col_desc[0],
-                        type=FIELD_ID_TO_NAME[col_desc[1]],
-                        value=col,
-                        error=e
-                    )
-                    self.logger.exception(msg)
-                    Error.errorhandler_wrapper(
-                        self.connection, self, InterfaceError, {
-                            u'msg': msg,
-                            u'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
-                        })
+            conv = self._column_converter[idx]
+            try:
+                row[idx] = col if conv is None or col is None else conv(col)
+            except Exception as e:
+                col_desc = self._description[idx]
+                msg = u'Failed to convert: ' \
+                      u'field {name}: {type}::{value}, Error: ' \
+                      u'{error}'.format(
+                    name=col_desc[0],
+                    type=FIELD_ID_TO_NAME[col_desc[1]],
+                    value=col,
+                    error=e
+                )
+                self.logger.exception(msg)
+                Error.errorhandler_wrapper(
+                    self.connection, self, InterfaceError, {
+                        u'msg': msg,
+                        u'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
+                    })
             idx += 1
         return tuple(row)
 
@@ -899,27 +899,25 @@ class DictCursor(SnowflakeCursor):
         res = {}
         idx = 0
         for col in row:
-            value = col
-            if col is not None:
-                try:
-                    conv_method, conv_ctx = self._column_converter[idx]
-                    value = conv_method(col, conv_ctx)
-                except Exception as e:
-                    col_desc = self._description[idx]
-                    msg = u'Failed to convert: ' \
-                          u'field {name}: {type}::{value}, Error: ' \
-                          u'{error}'.format(
-                        name=col_desc[0],
-                        type=FIELD_ID_TO_NAME[col_desc[1]],
-                        value=col,
-                        error=e
-                    )
-                    self.logger.exception(msg)
-                    Error.errorhandler_wrapper(
-                        self.connection, self, InterfaceError, {
-                            u'msg': msg,
-                            u'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
-                        })
-            res[self._column_idx_to_name[idx]] = value
+            col_name = self._column_idx_to_name[idx]
+            conv = self._column_converter[idx]
+            try:
+                res[col_name] = col if conv is None or col is None else conv(col)
+            except Exception as e:
+                col_desc = self._description[idx]
+                msg = u'Failed to convert: ' \
+                      u'field {name}: {type}::{value}, Error: ' \
+                      u'{error}'.format(
+                    name=col_desc[0],
+                    type=FIELD_ID_TO_NAME[col_desc[1]],
+                    value=col,
+                    error=e
+                )
+                self.logger.exception(msg)
+                Error.errorhandler_wrapper(
+                    self.connection, self, InterfaceError, {
+                        u'msg': msg,
+                        u'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
+                    })
             idx += 1
         return res

--- a/cursor.py
+++ b/cursor.py
@@ -546,9 +546,7 @@ class SnowflakeCursor(object):
 
         self._chunk_index = 0
         self._chunk_count = 0
-        self._current_chunk_row = iter(
-            [self.row_to_python(x) if x is not None else None
-             for x in data.get(u'rowset')])
+        self._current_chunk_row = iter(data.get(u'rowset'))
         self._current_chunk_row_count = len(data.get(u'rowset'))
 
         if u'chunks' in data:
@@ -689,7 +687,7 @@ class SnowflakeCursor(object):
                     self._chunk_downloader = None
                     self._chunk_count = 0
                     self._current_chunk_row = iter(())
-            return row
+            return self._row_to_python(row) if row is not None else None
 
         except IndexError:
             # returns None if the iteration is completed so that iter() stops
@@ -844,7 +842,7 @@ class SnowflakeCursor(object):
                                        ProgrammingError,
                                        errorvalue)
 
-    def row_to_python(self, row):
+    def _row_to_python(self, row):
         """
         Converts data in row if required.
 
@@ -896,7 +894,7 @@ class DictCursor(SnowflakeCursor):
     def __init__(self, connection):
         SnowflakeCursor.__init__(self, connection)
 
-    def row_to_python(self, row):
+    def _row_to_python(self, row):
         # see the base class
         res = {}
         idx = 0

--- a/network.py
+++ b/network.py
@@ -201,7 +201,7 @@ class SnowflakeRestful(object):
                      passcode_in_password=False, saml_response=None,
                      mfa_callback=None, password_callback=None,
                      session_parameters=None):
-        logger.info(u'authenticate')
+        logger.debug(u'authenticate')
 
         if token and master_token:
             self._token = token
@@ -241,7 +241,7 @@ class SnowflakeRestful(object):
         }
 
         body = copy.deepcopy(body_template)
-        logger.info(u'saml: %s', saml_response is not None)
+        logger.debug(u'saml: %s', saml_response is not None)
         if saml_response:
             body[u'data'][u'RAW_SAML_RESPONSE'] = saml_response
         else:

--- a/sfbinaryformat.py
+++ b/sfbinaryformat.py
@@ -6,11 +6,8 @@
 from base64 import (b16encode, standard_b64encode, b16decode)
 
 
-def binary_to_python(string):
-    """
-    Converts a Snowflake binary value into a "bytes" object.
-    """
-    return b16decode(string)
+# Converts a Snowflake binary value into a "bytes" object.
+binary_to_python = b16decode
 
 
 def binary_to_snowflake(binary_value):

--- a/ssl_wrap_socket.py
+++ b/ssl_wrap_socket.py
@@ -8,6 +8,8 @@
 # and added OCSP validator on the top.
 #
 
+import warnings
+
 """
 Insecure mode flag. OCSP validation will be skipped if True
 """
@@ -471,13 +473,13 @@ def ssl_wrap_socket_with_ocsp(
         ca_certs=ca_certs, server_hostname=server_hostname,
         ssl_version=ssl_version)
     logger = getLogger(__name__)
-    logger.info(u'insecure_mode: %s, '
-                u'OCSP response cache file name: %s, '
-                u'PROXY_HOST: %s, PROXY_PORT: %s, PROXY_USER: %s '
-                u'PROXY_PASSWORD: %s',
-                FEATURE_INSECURE_MODE,
-                FEATURE_OCSP_RESPONSE_CACHE_FILE_NAME,
-                PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD)
+    logger.debug(u'insecure_mode: %s, '
+                 u'OCSP response cache file name: %s, '
+                 u'PROXY_HOST: %s, PROXY_PORT: %s, PROXY_USER: %s '
+                 u'PROXY_PASSWORD: %s',
+                 FEATURE_INSECURE_MODE,
+                 FEATURE_OCSP_RESPONSE_CACHE_FILE_NAME,
+                 PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD)
     if not FEATURE_INSECURE_MODE:
         v = SnowflakeOCSP(
             proxies=set_proxies(PROXY_HOST, PROXY_PORT, PROXY_USER,
@@ -492,10 +494,10 @@ def ssl_wrap_socket_with_ocsp(
                         server_hostname)),
                 errno=ER_SERVER_CERTIFICATE_REVOKED)
     else:
-        logger.info(u'WARNING: THIS CONNECTION IS IN INSECURE '
-                    u'MODE. IT MEANS THE CERTIFICATE WILL BE '
-                    u'VALIDATED BUT THE CERTIFICATE REVOCATION '
-                    u'STATUS WILL NOT BE CHECKED.')
+        warnings.warn(u'THIS CONNECTION IS IN INSECURE '
+                      u'MODE. IT MEANS THE CERTIFICATE WILL BE '
+                      u'VALIDATED BUT THE CERTIFICATE REVOCATION '
+                      u'STATUS WILL NOT BE CHECKED.')
 
     return ret
 


### PR DESCRIPTION
Micro optimizations for hot path code used to convert JSON raw data to native python data structures.  Most of the optimizations come from reducing function call overhead (by way of closures) and by more efficient use of `datetime.datetime` factories like `fromtimestamp()`. 

EDIT: Benchmarks.

In a micro benchmark with heavy datetime data sets and S3 downloads cached I see the following numbers..

Stock - Py3.5: 21.9s
Stock - Py3.6: 17.0s
This PR - Py3.5: 12.7s (72% faster)
This PR - Py3.6: 9.5s (79% faster)

These number are for 500k rows and include startup times.  The actual row processing speeds are over 100% faster.