### PR TITLE
setup.py: use less restrictive cryptography>=1.7,<1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'pycryptodome>=3.2',
         'pyOpenSSL==16.2.0',
         'cffi==1.9.1',
-        'cryptography==1.7.2',
+        'cryptography>=1.7,<1.8',
         'pyasn1',
         'pyasn1-modules',
         'ijson',


### PR DESCRIPTION
Sometimes there is no need or possibility (because of the package or setup-specific issues) to change the cryptography minor versions. This allows us to be less restrictive.