### PR TITLE
SNOW-31396: Attempt to fix large PUT and GET tests.

### DIFF
--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -260,6 +260,7 @@ class SnowflakeChunkDownloader(object):
             self._connection._connect_timeout,
             DEFAULT_REQUEST_TIMEOUT
         )
-        return self._connection.rest.fetch(u'get', url, headers,
+        return self._connection.rest.fetch(
+            u'get', url, headers,
             timeouts=timeouts, is_raw_binary=True,
             is_raw_binary_iterator=True, use_ijson=self._use_ijson)

--- a/compat.py
+++ b/compat.py
@@ -9,6 +9,8 @@ import sys
 
 from six import string_types, text_type, binary_type, PY2
 
+from snowflake.connector.constants import UTF8
+
 NUM_DATA_TYPES = []
 try:
     import numpy
@@ -18,8 +20,6 @@ try:
                       numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
 except:
     numpy = None
-
-from snowflake.connector.constants import UTF8
 
 STR_DATA_TYPE = string_types
 UNICODE_DATA_TYPE = text_type

--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -31,7 +31,8 @@ from .file_compression_type import FileCompressionType
 from .s3_util import (SnowflakeS3FileEncryptionMaterial, SnowflakeS3Util,
                       RESULT_STATUS_DOWNLOADED,
                       RESULT_STATUS_ERROR, RESULT_STATUS_UPLOADED,
-                      RESULT_STATUS_RENEW_TOKEN)
+                      RESULT_STATUS_RENEW_TOKEN,
+                      RESULT_STATUS_NOT_FOUND_FILE)
 
 S3_FS = u'S3'
 LOCAL_FS = u'LOCAL_FS'

--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -334,24 +334,7 @@ class SnowflakeFileTransferAgent(object):
             if meta[u'stage_location_type'] == LOCAL_FS:
                 SnowflakeFileTransferAgent.upload_one_file_to_local(meta)
             else:  # S3
-                for _ in range(10):
-                    # retry
-                    SnowflakeS3Util.upload_one_file_to_s3(meta)
-                    if meta[u'result_status'] == RESULT_STATUS_UPLOADED:
-                        for _ in range(10):
-                            if SnowflakeS3Util.exists(
-                                    meta) == RESULT_STATUS_NOT_FOUND_FILE:
-                                sleep(1)  # wait 1 second
-                                logger.debug('not found. double checking...')
-                                continue
-                            break
-                        else:
-                            # not found. retry with the outer loop
-                            logger.debug('not found. gave up. reuploading...')
-                            continue
-                    break
-                else:
-                    raise Exception("file was not uploaded")
+                SnowflakeS3Util.upload_one_file_to_s3_with_retry(meta)
             logger.info(
                 u'done: status=%s, file=%s, real file=%s',
                 meta[u'result_status'],

--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -245,7 +245,7 @@ class SnowflakeFileTransferAgent(object):
                 len_file_metas
 
             self.logger.debug(
-                u'uploading files idx: {0} to {1}'.format(idx, end_of_idx))
+                u'uploading files idx: {0}/{1}'.format(idx+1, end_of_idx))
 
             target_meta = file_metas[idx:end_of_idx]
             while True:
@@ -287,6 +287,8 @@ class SnowflakeFileTransferAgent(object):
         idx = 0
         len_file_metas = len(file_metas)
         while idx < len_file_metas:
+            self.logger.debug(
+                u'uploading files idx: {0}/{1}'.format(idx+1, len_file_metas))
             result = SnowflakeFileTransferAgent.upload_one_file(
                 file_metas[idx])
             if result[u'result_status'] == RESULT_STATUS_RENEW_TOKEN:

--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -31,8 +31,7 @@ from .file_compression_type import FileCompressionType
 from .s3_util import (SnowflakeS3FileEncryptionMaterial, SnowflakeS3Util,
                       RESULT_STATUS_DOWNLOADED,
                       RESULT_STATUS_ERROR, RESULT_STATUS_UPLOADED,
-                      RESULT_STATUS_RENEW_TOKEN,
-                      RESULT_STATUS_NOT_FOUND_FILE)
+                      RESULT_STATUS_RENEW_TOKEN)
 
 S3_FS = u'S3'
 LOCAL_FS = u'LOCAL_FS'

--- a/ocsp_pyopenssl.py
+++ b/ocsp_pyopenssl.py
@@ -25,7 +25,6 @@ from os import path
 from threading import (Lock)
 from time import gmtime, strftime, strptime
 
-import OpenSSL
 from OpenSSL.crypto import (dump_certificate, FILETYPE_PEM, FILETYPE_ASN1,
                             load_certificate, dump_publickey)
 from OpenSSL.crypto import verify as crypto_verify
@@ -590,7 +589,7 @@ def is_cert_id_in_cache(ocsp_issuer, ocsp_subject, use_cache=True):
             u'issuer name hash algorithm: %s, '
             u'issuer key hash: %s, subject serial number: %s',
             base64_name_hash, ocsp_issuer['name'], ocsp_issuer[u'is_root_ca'],
-            cert_id['hashAlgorithm'], 
+            cert_id['hashAlgorithm'],
             base64.b64encode(octet_string_to_bytearray(
                 cert_id['issuerKeyHash'])),
             cert_id['serialNumber'])
@@ -607,7 +606,7 @@ def is_cert_id_in_cache(ocsp_issuer, ocsp_subject, use_cache=True):
                         key_cert_id['issuerKeyHash'])),
                     key_cert_id['serialNumber']
                 )
-    
+
     return False, cert_id, None
 
 
@@ -642,9 +641,9 @@ def _encode_ocsp_response_cache(ocsp_response_cache,
             key_cert_id, _ = der_decoder.decode(
                 cert_id_der, asn1Spec=CertID())
             logger.debug('name: %s, serial number: %s',
-                b64encode(octet_string_to_bytearray(
-                    key_cert_id['issuerNameHash'])),
-                key_cert_id['serialNumber'])
+                         b64encode(octet_string_to_bytearray(
+                             key_cert_id['issuerNameHash'])),
+                         key_cert_id['serialNumber'])
         k = b64encode(cert_id_der).decode('ascii')
         v = b64encode(ocsp_response).decode('ascii')
         ocsp_response_cache_json[k] = (current_time, v)
@@ -724,7 +723,7 @@ def read_ocsp_response_cache_file(filename, ocsp_validation_cache):
                     filename, 'r', encoding='utf-8', errors='ignore')),
             ocsp_validation_cache)
         logger.debug("Read OCSP response cache file: %s, count=%s",
-            filename, len(OCSP_VALIDATION_CACHE))
+                     filename, len(OCSP_VALIDATION_CACHE))
     else:
         logger.info(
             "Failed to locate OCSP response cache file. "
@@ -1049,7 +1048,7 @@ class SnowflakeOCSP(object):
                 '\\', '/')
 
         self.logger.debug("ocsp_response_cache_url: %s",
-                         self._ocsp_response_cache_url)
+                          self._ocsp_response_cache_url)
         self.logger.debug(
             "OCSP_VALIDATION_CACHE size: %s", len(OCSP_VALIDATION_CACHE))
 
@@ -1131,7 +1130,7 @@ class SnowflakeOCSP(object):
                     update_ocsp_response_cache_file(
                         self._ocsp_response_cache_url)
                 OCSP_VALIDATION_CACHE_UPDATED = False
-                
+
             if len(results) != len(cert_data):
                 raise OperationalError(
                     msg=u"Failed to validate the certificate "
@@ -1161,8 +1160,8 @@ class SnowflakeOCSP(object):
             ocsp_issuer, ocsp_subject, use_cache=use_cache)
 
         self.logger.debug('must_use_cache: %s, cache_status: %s',
-            self._must_use_cache, cache_status)
-        
+                          self._must_use_cache, cache_status)
+
         # Disabled assert. If two distinct certificates are used
         # for the same URL, e.g., AWS S3 endpoint, one cannot hit
         # other in the cache.

--- a/s3_util.py
+++ b/s3_util.py
@@ -155,7 +155,7 @@ class SnowflakeS3Util(object):
             # need renew token
             return
         elif akey and meta[u'result_status'] == RESULT_STATUS_UPLOADED and \
-                not meta[u'overwrite']:
+                not meta.get(u'overwrite'):
             logger.info(
                 u'file already exists, checking digest: file=%s', s3path)
             try:

--- a/test/test_load_unload.py
+++ b/test/test_load_unload.py
@@ -144,6 +144,7 @@ file_format=(skip_header=1 null_if=('') field_optionally_enclosed_by='"')
 def test_put_local_file(conn_cnx, test_data):
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
+            cur.execute("alter session set DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE=false")
             cur.execute("use warehouse {0}".format(test_data.warehouse_name))
             cur.execute(
                 """use schema {0}.pytesting_schema""".format(
@@ -198,6 +199,7 @@ put file://{0}/ExecPlatform/Database/data/orders_10*.csv @%pytest_putget_t1
 def test_put_load_from_user_stage(conn_cnx, test_data):
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
+            cur.execute("alter session set DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE=false")
             cur.execute("""
 use warehouse {0}
 """.format(test_data.warehouse_name))

--- a/test/test_put_get.py
+++ b/test/test_put_get.py
@@ -153,6 +153,7 @@ def test_put_local_file(test_data, conn_cnx):
         with cnx.cursor() as cur:
             cur.execute(
                 """use warehouse {0}""".format(test_data.warehouse_name))
+            cur.execute("alter session set DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE=false")
             cur.execute("""use schema {0}.pytesting_schema""".format(
                 test_data.database_name))
             cur.execute("""
@@ -214,6 +215,7 @@ put file://{0}/ExecPlatform/Database/data/orders_10*.csv @%pytest_putget_t1
 def test_put_load_from_user_stage(test_data, conn_cnx):
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
+            cur.execute("alter session set DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE=false")
             cur.execute(
                 """use warehouse {0}""".format(test_data.warehouse_name))
             cur.execute("""use schema {0}.pytesting_schema""".format(

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -540,7 +540,7 @@ def _generate_huge_value_json(tmpdir, n=1, value_size=1):
     return fname
 
 
-def _huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
+def test_huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
     """
     (WIP) Huge json value data
     """

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -236,6 +236,7 @@ put file://{file} @%{name}"""):
         run(cnx, 'drop table if exists {name}')
 
 
+
 @pytest.mark.skipif(
     not CONNECTION_PARAMETERS_ADMIN,
     reason="Snowflake admin account is not accessible."
@@ -605,7 +606,7 @@ def test_put_get_large_files_s3(tmpdir, test_files, conn_cnx, db_parameters):
     [s3] Put and Get Large files
     """
     number_of_files = 3
-    number_of_lines = 200000
+    number_of_lines = 2000000
     tmp_dir = test_files(tmpdir, number_of_lines, number_of_files)
 
     files = os.path.join(tmp_dir, 'file*')

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -626,7 +626,8 @@ def test_put_get_large_files_s3(tmpdir, test_files, conn_cnx, db_parameters):
             password=db_parameters['s3_password']) as cnx:
         try:
             run(cnx, "PUT file://{files} @~/{dir}")
-            for _ in range(10):
+            # run(cnx, "PUT file://{files} @~/{dir}")  # retry
+            for _ in range(100):
                 all_recs = run(cnx, "LIST @~/{dir}")
                 if len(all_recs) == number_of_files:
                     break

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -625,7 +625,6 @@ def test_put_get_large_files_s3(tmpdir, test_files, conn_cnx, db_parameters):
             password=db_parameters['s3_password']) as cnx:
         try:
             run(cnx, "PUT file://{files} @~/{dir}")
-            # run(cnx, "PUT file://{files} @~/{dir}")
             for _ in range(10):
                 all_recs = run(cnx, "LIST @~/{dir}")
                 if len(all_recs) == number_of_files:

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -606,7 +606,7 @@ def test_put_get_large_files_s3(tmpdir, test_files, conn_cnx, db_parameters):
     [s3] Put and Get Large files
     """
     number_of_files = 3
-    number_of_lines = 2000000
+    number_of_lines = 200000
     tmp_dir = test_files(tmpdir, number_of_lines, number_of_files)
 
     files = os.path.join(tmp_dir, 'file*')

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -539,7 +539,7 @@ def _generate_huge_value_json(tmpdir, n=1, value_size=1):
     return fname
 
 
-def test_huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
+def _huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
     """
     (WIP) Huge json value data
     """

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -540,7 +540,7 @@ def _generate_huge_value_json(tmpdir, n=1, value_size=1):
     return fname
 
 
-def test_huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
+def _huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
     """
     (WIP) Huge json value data
     """

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -258,6 +258,7 @@ def test_copy_get(tmpdir, conn_cnx, db_parameters):
         return cnx.cursor().execute(sql).fetchall()
 
     with conn_cnx() as cnx:
+        run(cnx, "alter session set DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE=false")
         run(cnx, """
 create or replace table {name} (
 aa int,
@@ -277,7 +278,7 @@ format_name = 'common.public.csv'
 field_delimiter = '|'
 error_on_column_count_mismatch=false);
 """)
-
+        
         current_time = datetime.datetime.utcnow()
         current_time = current_time.replace(
             tzinfo=pytz.timezone("America/Los_Angeles"))

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -539,7 +539,7 @@ def _generate_huge_value_json(tmpdir, n=1, value_size=1):
     return fname
 
 
-def _huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
+def test_huge_value_json_upload(tmpdir, conn_cnx, db_parameters):
     """
     (WIP) Huge json value data
     """


### PR DESCRIPTION
A couple of major changes were made:
- Skip scanning all of the existing files before PUT to detect the duplicated files. Instead, check the existence of file on each PUT command to reduce overhead.
- Right after PUT a file complete, it checks if the file really accessible. 

Other than the above changes, a colleague added a new internal flag DISABLE_PUT_AND_GET_ON_EXTERNAL_STAGE for new customers to disable PUT and GET commands against the external stages. This is mainly because the external stages are not guaranteed to be secure and encrypted.