### PR TITLE
Catchup

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -9,9 +9,13 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 Release Notes
 -------------------------------------------------------------------------------
 
+- v1.4.15 (January 11, 2018)
+
+    - Added OCSP cache server option.
+
 - v1.4.14 (December 14, 2017)
 
-    - Improved OCSP response dump util
+    - Improved OCSP response dump util.
 
 - v1.4.13 (November 30, 2017)
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2013-2017 Snowflake Computing, Inc.
+   Copyright (c) 2013-2018 Snowflake Computing, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 #

--- a/auth.py
+++ b/auth.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import copy

--- a/auth_okta.py
+++ b/auth_okta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import json
 import logging

--- a/auth_webbrowser.py
+++ b/auth_webbrowser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import json
 import logging

--- a/chunk_downloader.py
+++ b/chunk_downloader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from collections import namedtuple

--- a/compat.py
+++ b/compat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import decimal
 import os

--- a/connection.py
+++ b/connection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 import re

--- a/constants.py
+++ b/constants.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 """
 Various constants

--- a/converter.py
+++ b/converter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import binascii
 import decimal

--- a/converter_issue23517.py
+++ b/converter_issue23517.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from datetime import timedelta
 from logging import getLogger

--- a/converter_snowsql.py
+++ b/converter_snowsql.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import time

--- a/cursor.py
+++ b/cursor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 import re

--- a/dbapi.py
+++ b/dbapi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 u"""
 This module implements some constructors and singletons as required by the

--- a/encryption_util.py
+++ b/encryption_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/errorcode.py
+++ b/errorcode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 u"""This module contains Snowflake error codes"""
 

--- a/errors.py
+++ b/errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 from logging import getLogger

--- a/feature.py
+++ b/feature.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 # Feature flags

--- a/file_compression_type.py
+++ b/file_compression_type.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import binascii
 import glob

--- a/gzip_decoder.py
+++ b/gzip_decoder.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import io

--- a/local_util.py
+++ b/local_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from __future__ import division

--- a/network.py
+++ b/network.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import collections
 import contextlib

--- a/ocsp_pyopenssl.py
+++ b/ocsp_pyopenssl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 """

--- a/proxy.py
+++ b/proxy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import botocore.endpoint

--- a/remote_storage_util.py
+++ b/remote_storage_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from __future__ import division

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from codecs import open
 from os import path

--- a/sfbinaryformat.py
+++ b/sfbinaryformat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from base64 import (b16encode, standard_b64encode, b16decode)
 

--- a/sfdatetime.py
+++ b/sfdatetime.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import time
 from datetime import datetime, timedelta

--- a/sqlstate.py
+++ b/sqlstate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED = "08001"

--- a/ssl_wrap_socket.py
+++ b/ssl_wrap_socket.py
@@ -14,7 +14,7 @@ Insecure mode flag. OCSP validation will be skipped if True
 FEATURE_INSECURE_MODE = False
 
 """
-OCSP Reponse cache file name
+OCSP Response cache file name
 """
 FEATURE_OCSP_RESPONSE_CACHE_FILE_NAME = None
 
@@ -383,7 +383,7 @@ def ssl_wrap_socket_with_ocsp(
         v = SnowflakeOCSP(
             proxies=set_proxies(PROXY_HOST, PROXY_PORT, PROXY_USER,
                                 PROXY_PASSWORD),
-            ocsp_response_cache_url=FEATURE_OCSP_RESPONSE_CACHE_FILE_NAME
+            ocsp_response_cache_url=FEATURE_OCSP_RESPONSE_CACHE_FILE_NAME,
         ).validate(server_hostname, ret.connection)
         if not v:
             raise OperationalError(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import os
 import random

--- a/test/test_autocommit.py
+++ b/test/test_autocommit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import snowflake.connector

--- a/test/test_bindings.py
+++ b/test/test_bindings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import logging

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_concurrent_create_objects.py
+++ b/test/test_concurrent_create_objects.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from logging import getLogger

--- a/test/test_concurrent_insert.py
+++ b/test/test_concurrent_insert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 """
 Concurrent test module

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -356,7 +356,9 @@ def test_invalid_proxy(db_parameters):
 
 
 @pytest.mark.timeout(15)
-def test_eu_connection():
+def test_eu_connection(tmpdir):
+    import os
+    os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED"] = "true"
     with pytest.raises(ForbiddenError):
         # must reach Snowflake
         snowflake.connector.connect(
@@ -365,4 +367,6 @@ def test_eu_connection():
             password='testpassword',
             region='eu-central-1',
             login_timeout=5,
+            ocsp_response_cache_filename=os.path.join(
+                str(tmpdir), "test_ocsp_cache.txt")
         )

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import pytest

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from datetime import timedelta, time

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import decimal
 import json

--- a/test/test_cursor_binding.py
+++ b/test/test_cursor_binding.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import pytest

--- a/test/test_cursor_context_manager.py
+++ b/test/test_cursor_context_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from logging import getLogger
 

--- a/test/test_daylight_savings.py
+++ b/test/test_daylight_savings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from datetime import (datetime)
 

--- a/test/test_dbapi.py
+++ b/test/test_dbapi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 """

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_execute_multi_statements.py
+++ b/test/test_execute_multi_statements.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import codecs

--- a/test/test_large_put.py
+++ b/test/test_large_put.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import os

--- a/test/test_large_result_set.py
+++ b/test/test_large_result_set.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_load_unload.py
+++ b/test/test_load_unload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import os

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from logging import getLogger
 

--- a/test/test_ocsp.py
+++ b/test/test_ocsp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 import os

--- a/test/test_put_get.py
+++ b/test/test_put_get.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import os
 from os import path

--- a/test/test_put_get_medium.py
+++ b/test/test_put_get_medium.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import datetime
 import gzip

--- a/test/test_put_get_snow_4525.py
+++ b/test/test_put_get_snow_4525.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import os

--- a/test/test_put_get_user_stage.py
+++ b/test/test_put_get_user_stage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import mimetypes
 import os

--- a/test/test_put_get_with_aws_token.py
+++ b/test/test_put_get_with_aws_token.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import glob

--- a/test/test_put_get_with_azure_token.py
+++ b/test/test_put_get_with_azure_token.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import glob

--- a/test/test_qmark.py
+++ b/test/test_qmark.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_query_cancelling.py
+++ b/test/test_query_cancelling.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 import time

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import pytest

--- a/test/test_reuse_cursor.py
+++ b/test/test_reuse_cursor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_session_parameters.py
+++ b/test/test_session_parameters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import snowflake.connector
 

--- a/test/test_snowsql_timestamp_format.py
+++ b/test/test_snowsql_timestamp_format.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from snowflake.connector.converter_snowsql import SnowflakeConverterSnowSQL
 

--- a/test/test_statement_parameter_binding.py
+++ b/test/test_statement_parameter_binding.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from datetime import datetime
 

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import pytest

--- a/test/test_unit_auth.py
+++ b/test/test_unit_auth.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import time
 

--- a/test/test_unit_auth_okta.py
+++ b/test/test_unit_auth_okta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from snowflake.connector.auth_okta import AuthByOkta

--- a/test/test_unit_auth_webbrowser.py
+++ b/test/test_unit_auth_webbrowser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from snowflake.connector.auth import EXTERNAL_BROWSER_AUTHENTICATOR

--- a/test/test_unit_binaryformat.py
+++ b/test/test_unit_binaryformat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from snowflake.connector.sfbinaryformat import (
     SnowflakeBinaryFormat, binary_to_python, binary_to_snowflake)

--- a/test/test_unit_construct_hostname.py
+++ b/test/test_unit_construct_hostname.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from snowflake.connector.util_text import construct_hostname

--- a/test/test_unit_converter.py
+++ b/test/test_unit_converter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from logging import getLogger

--- a/test/test_unit_datetime.py
+++ b/test/test_unit_datetime.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import time
 from datetime import datetime

--- a/test/test_unit_encryption_util.py
+++ b/test/test_unit_encryption_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import codecs
 import glob

--- a/test/test_unit_ocsp.py
+++ b/test/test_unit_ocsp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import codecs
 import os

--- a/test/test_unit_proxies.py
+++ b/test/test_unit_proxies.py
@@ -1,7 +1,7 @@
 # encoding=utf-8
 # !/usr/bin/env python
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 

--- a/test/test_unit_renew_session.py
+++ b/test/test_unit_renew_session.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 from snowflake.connector.compat import (

--- a/test/test_unit_retry_network.py
+++ b/test/test_unit_retry_network.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 
 import errno

--- a/test/test_unit_s3_util.py
+++ b/test/test_unit_s3_util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import errno
 import os

--- a/test/test_unit_split_statement.py
+++ b/test/test_unit_split_statement.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 from io import StringIO
 

--- a/util_text.py
+++ b/util_text.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
+# Copyright (c) 2012-2018 Snowflake Computing Inc. All right reserved.
 #
 import logging
 import re

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (1, 4, 14, None)
+VERSION = (1, 4, 15, None)


### PR DESCRIPTION
- Added OCSP response cache server option to Python Connector. SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED and SF_OCSP_RESPONSE_CACHE_SERVER_URL
- Updated copyright year with 2018
- Bumped up version to 1.4.15