### PR TITLE
Bump pyasn upper bound to 0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
         'pyOpenSSL>=16.2.0,<18.0.0',
         'cffi>=1.9',
         'cryptography>=1.7.2,<2.2',
-        'pyasn1>=0.2.1,<0.4.0',
-        'pyasn1-modules>=0.0.8,<0.2.0',
+        'pyasn1>=0.2.1,<0.5.0',
+        'pyasn1-modules>=0.0.8,<0.3.0',
         'ijson',
     ],
 


### PR DESCRIPTION
The old upper bound of 0.4.0 conflicted with several google-cloud packages. But I don't see any reason why it shouldn't be compatible through 0.4.2.

I tested much of the Connector functionality with more recent versions of pyasn1, and did not run into any errors. However I didn't have access to run the tests in this repo (parameters.py was required and is encrypted). 