### PR TITLE
SNOW-39905: SQLAlchemy doesn't work with paramstyle=qmark mode.

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -87,7 +87,7 @@ DEFAULT_CONFIGURATION = {
     u'chunk_downloader_class': SnowflakeChunkDownloader,  # snowflake internal
     u'validate_default_parameters': False,  # snowflake
     u'probe_connection': False,  # snowflake
-    u'paramstyle': u'pyformat',  # standard/snowflake
+    u'paramstyle': None,  # standard/snowflake
     u'timezone': None,  # snowflake
 }
 
@@ -524,7 +524,10 @@ class SnowflakeConnection(object):
             else:
                 setattr(self, u'_' + name, value)
 
-        if self._paramstyle not in SUPPORTED_PARAMSTYLES:
+        if self._paramstyle is None:
+            import snowflake.connector
+            self._paramstyle = snowflake.connector.paramstyle
+        elif self._paramstyle not in SUPPORTED_PARAMSTYLES:
             raise ProgrammingError(
                 msg=u'Invalid paramstyle is specified',
                 errno=ER_INVALID_VALUE

--- a/cursor.py
+++ b/cursor.py
@@ -906,7 +906,7 @@ class SnowflakeCursor(object):
                                        errorvalue)
 
     def __process_params_qmarks(self, params):
-        if params is None:
+        if not params:
             return None
         processed_params = {}
         if not isinstance(params, (list, tuple)):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -276,7 +276,7 @@ def generate_k_lines_of_n_files(tmpdir, k, n, compress=False):
 
 @contextmanager
 def db(user=None, password=None, account=None, use_numpy=False,
-       converter_class=None, paramstyle=u'pyformat', timezone=u'UTC'):
+       converter_class=None, paramstyle=None, timezone=u'UTC'):
     cnx = create_connection(
         user=user, password=password,
         account=account, use_numpy=use_numpy,


### PR DESCRIPTION
- Mitigating #55