### PR TITLE
Fixed pycryptodome 3.5.0 Mac issue. Bumping up the version to 1.5.3

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -9,6 +9,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 Release Notes
 -------------------------------------------------------------------------------
 
+- v1.5.3 (March 9, 2018)
+
+    - Pulled back ``pyasn1`` for OCSP check in Python 2. Python 3 continue using ``asn1crypto`` for better performance.
+
 - v1.5.2 (March 1, 2018)
 
     - Fixed failue in case HOME/USERPROFILE is not set.

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -12,6 +12,7 @@ Release Notes
 - v1.5.3 (March 9, 2018)
 
     - Pulled back ``pyasn1`` for OCSP check in Python 2. Python 3 continue using ``asn1crypto`` for better performance.
+    - Limit the upper bound of ``pycryptodome`` version to less than 3.5.0 for Issue 65.
 
 - v1.5.2 (March 1, 2018)
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'future',
         'six',
         'pytz',
-        'pycryptodome>=3.2',
+        'pycryptodome>=3.2,<3.5',
         'pyOpenSSL>=16.2.0,<18.0.0',
         'cffi>=1.9',
         'cryptography>=1.8.2,<2.2',

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (1, 5, 2, None)
+VERSION = (1, 5, 3, None)


### PR DESCRIPTION
- Limit the upper bound of `pycryptodome` for #65 
- Bumping up the version to 1.5.3