### PR TITLE
Adjusted pyasn1 and pyasn1-modules versions for Python2

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -19,7 +19,10 @@ from .errors import (Error,
                      BadGatewayError)
 from .network import (CONTENT_TYPE_APPLICATION_JSON,
                       ACCEPT_TYPE_APPLICATION_SNOWFLAKE,
-                      PYTHON_CONNECTOR_USER_AGENT, PLATFORM, PYTHON_VERSION,
+                      PYTHON_CONNECTOR_USER_AGENT,
+                    OPERATING_SYSTEM,
+                      PLATFORM,
+                      PYTHON_VERSION,
                       IMPLEMENTATION, COMPILER)
 from .sqlstate import (SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED)
 from .version import VERSION
@@ -94,6 +97,7 @@ class Auth(object):
                 u"LOGIN_NAME": user,
                 u"CLIENT_ENVIRONMENT": {
                     u"APPLICATION": application,
+                    u"OS": OPERATING_SYSTEM,
                     u"OS_VERSION": PLATFORM,
                     u"PYTHON_VERSION": PYTHON_VERSION,
                     u"PYTHON_RUNTIME": IMPLEMENTATION,

--- a/network.py
+++ b/network.py
@@ -93,6 +93,7 @@ HEADER_SNOWFLAKE_TOKEN = u'Snowflake Token="{token}"'
 
 SNOWFLAKE_CONNECTOR_VERSION = u'.'.join(TO_UNICODE(v) for v in VERSION[0:3])
 PYTHON_VERSION = u'.'.join(TO_UNICODE(v) for v in sys.version_info[:3])
+OPERATING_SYSTEM = platform.system()
 PLATFORM = platform.platform()
 IMPLEMENTATION = platform.python_implementation()
 COMPILER = platform.python_compiler()

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
         'cryptography>=1.8.2,<2.2',
         'ijson',
         'pyjwt',
-        'pyasn1',  # added back for Python 2
-        'pyasn1-modules',  # added back Python 2
+        'pyasn1>=0.2.1,<0.5.0',  # added back for Python 2
+        'pyasn1-modules>=0.0.8,<0.3.0',  # added back for Python 2
     ],
 
     namespace_packages=['snowflake'],


### PR DESCRIPTION
In 1.5.3, pyasn1 and pyasn1-modules were pulled back for Python 2 OCSP checks.

It caused an issue if the environment doesn't specify pyasn1 and have very old pyasn1, e.g., 0.1.x.
This change is mitigate it, but note this won't fix all cases where the environment may have incompatible combination of pyasn1 and pyasn1-modules, etc.
If you don't want to hit this type of issue, pin the versions in the applications.