### PR TITLE
File metas indexing fix for parallel uploads

### DIFF
--- a/file_transfer_agent.py
+++ b/file_transfer_agent.py
@@ -268,7 +268,7 @@ class SnowflakeFileTransferAgent(object):
                     result_meta[u's3client'] = s3client
                 if end_of_idx < len_file_metas:
                     for idx0 in range(idx + self._parallel, len_file_metas):
-                        file_metas[u's3client'] = s3client
+                        file_metas[idx0][u's3client'] = s3client
                 target_meta = retry_meta
 
             if end_of_idx == len_file_metas:


### PR DESCRIPTION
Hi,

I've experienced issues when uploading a large number of GZip compressed XML files.
`2018-03-19 17:36:42,324 (5910/MainThread) __main__ ERROR eventloop:762 - error with sql: 'PUT file:///../[A-Z]*.xml.gz @named_stage PARALLEL = 16;'
Traceback (most recent call last):
File "eventloop.py", line 691, in run_cli
File "snowflake/cli/sqlexecute.py", line 384, in run
File "snowflake/cli/sqlexecute.py", line 471, in execute_normal_sql
File "snowflake/connector/cursor.py", line 509, in execute
File "snowflake/connector/file_transfer_agent.py", line 189, in execute
File "snowflake/connector/file_transfer_agent.py", line 210, in upload
File "snowflake/connector/file_transfer_agent.py", line 280, in _upload_files_in_parallel
TypeError: list indices must be integers or slices, not str`

The issue is that the file_metas variable is a list of maps, and the list indexing was missing.