### PR TITLE
Removes username restriction for OAuth.

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -556,7 +556,8 @@ class SnowflakeConnection(object):
             if u'protocol' not in kwargs:
                 setattr(self, u'_protocol', u'https')
 
-        if not self.user:
+        if not self.user and self._authenticator != OAUTH_AUTHENTICATOR:
+            # OAuth Authentication does not require a username
             Error.errorhandler_wrapper(
                 self, None, ProgrammingError,
                 {

--- a/test/README.rst
+++ b/test/README.rst
@@ -27,8 +27,7 @@ Create a virtualenv, with ``parameters.py`` in a test directory.
 
         pyvenv /tmp/test_snowflake_connector_python
         source /tmp/test_snowflake_connector_python/bin/activate
-        pip install Cython
-        pip install pytest numpy pandas
+        pip install Cython pytest numpy pandas mock
         pip install dist/snowflake_connector_python*.whl
         vim test/parameters.py
 


### PR DESCRIPTION

From @tjj5036 

Tested via the following:

```
import snowflake.connector
cnx = snowflake.connector.connect(
    account='testaccount',
    host='https://myaccount.snowflakecomputing.com',
    authenticator='OAUTH',
    token=oauth_access_token)
cnx.close()
```