### PR TITLE
Update Boto3 to <1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'azure-common<2',
         'azure_nspkg<3',
         'azure-storage>0.34.2,<=0.36.0',
-        'boto3>=1.4.4,<1.8.0',
+        'boto3>=1.4.4,<1.9.0',
         'botocore>=1.5.0,<1.11.0',
         'certifi',
         'future',


### PR DESCRIPTION
Hi all,

I'd like to loosen the  version requirement of Boto3 since we're using 1.8.1 in the Apache Airflow project.

Cheers, Fokko