### PR TITLE
Fix multiline double quote expressions

### DIFF
--- a/test/test_unit_split_statement.py
+++ b/test/test_unit_split_statement.py
@@ -497,3 +497,16 @@ VALUES ( /*TIMEOUT*/ 10);"""
         assert next(itr) == (
             "INSERT INTO foo VALUES (\n\n10);", False
         )
+
+def test_multiline_double_dollar_experssion_with_removed_comments():
+    s = """CREATE FUNCTION mean(a FLOAT, b FLOAT)
+  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$
+  var c = a + b;
+  return(c / 2);
+  $$;"""
+    with StringIO(_to_unicode(s)) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == (
+            "CREATE FUNCTION mean(a FLOAT, b FLOAT)\n"
+            "  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$\n"
+            "  var c = a + b;\n  return(c / 2);\n  $$;", False)

--- a/util_text.py
+++ b/util_text.py
@@ -45,7 +45,7 @@ def split_statements(buf, remove_comments=False):
                         if len(statement) == 1 and statement[0][0] == '':
                             statement = []
                         break
-                    elif not in_comment and in_quote:
+                    elif not in_comment and (in_quote or in_double_dollars):
                         statement.append((line[col0:col], True))
                     elif not remove_comments:
                         statement.append((line[col0:col], False))


### PR DESCRIPTION
Previously the code would drop all contents of a multi-line double quote expression when remove comments is true, this fix means that all contents within the double quotes get propagated.

For example this SQL:
```
CREATE FUNCTION mean(a FLOAT, b FLOAT)
  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$
  var c = a + b;
  return(c / 2);
  $$;
```
would be returned as:
```
CREATE FUNCTION mean(a FLOAT, b FLOAT)
  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$
  $$;
```