### PR TITLE
individually resolve Snowflake type for each list element

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -795,7 +795,7 @@ class SnowflakeConnection(object):
                 if isinstance(v, list):
                     vv = [
                         self.converter.to_snowflake_bindings(
-                            snowflake_type, v0) for v0 in v]
+                            self.converter.snowflake_type(v0), v0) for v0 in v]
                 else:
                     vv = self.converter.to_snowflake_bindings(
                         snowflake_type, v)


### PR DESCRIPTION
Without resolving the Snowflake type for each element in the list comp individually, passing a list of dicts to [`bulk_insert_mappings`](http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.session.Session.bulk_insert_mappings) using `snowflake-sqlalchemy` with `snowflake.connector.paramstyle = u'qmark'` (to get around the [16384 row limit](https://github.com/snowflakedb/snowflake-connector-python/issues/37)) always results in the `snowflake_type` being set to `TEXT` [over here](https://github.com/snowflakedb/snowflake-connector-python/blob/6abc56c970cdb698a833b7f6ac9cbe7dfa667abd/connection.py#L779-L780) because `v` is always a list and [lists resolve to TEXT](https://github.com/snowflakedb/snowflake-connector-python/blob/6abc56c970cdb698a833b7f6ac9cbe7dfa667abd/converter.py#L60).

When inserting into a `TIMESTAMP_NTZ(9)` column, for example, we encounter:
```
snowflake.connector.errors.ProgrammingError: 255001: Binding datetime object with Snowflake data type TEXT is not supported.
```