### PR TITLE
Fixes #124 Split out aws and azure dependencies

### DIFF
--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -9,4 +9,5 @@ pip install numpy
 pip install pytest pytest-cov pytest-rerunfailures
 pip install .
 pip install .[azure]
+pip install .[aws]
 pip list --format=columns

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -8,4 +8,5 @@ python -m pip install --upgrade pip
 pip install numpy
 pip install pytest pytest-cov pytest-rerunfailures
 pip install .
+pip install .[azure]
 pip list --format=columns

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,4 +36,5 @@ if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ $PYTHON_VERSION == "2.7"* ]]; t
     pip install mock
 fi
 pip install .
+pip install .[azure]
 pip list --format=columns

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,4 +37,5 @@ if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ $PYTHON_VERSION == "2.7"* ]]; t
 fi
 pip install .
 pip install .[azure]
+pip install .[aws]
 pip list --format=columns

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
 
     install_requires=[
-        'boto3>=1.4.4,<1.10.0',
-        'botocore>=1.5.0,<1.13.0',
         'certifi',
         'future',
         'six',
@@ -84,7 +82,11 @@ setup(
         "azure": [
             'azure-common',
             'azure-storage-blob',
-        ]
+        ],
+        "aws": [
+            'boto3>=1.4.4,<1.10.0',
+            'botocore>=1.5.0,<1.13.0',
+        ],
     },
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
 
     install_requires=[
-        'azure-common',
-        'azure-storage-blob',
         'boto3>=1.4.4,<1.10.0',
         'botocore>=1.5.0,<1.13.0',
         'certifi',
@@ -54,7 +52,12 @@ setup(
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
     ],
-
+    extras_require=dict(
+        azure=[
+            'azure-common',
+            'azure-storage-blob',
+        ]
+    ),
     namespace_packages=['snowflake'],
     packages=[
         'snowflake.connector',

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,6 @@ setup(
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
     ],
-    extras_require=dict(
-        azure=[
-            'azure-common',
-            'azure-storage-blob',
-        ]
-    ),
     namespace_packages=['snowflake'],
     packages=[
         'snowflake.connector',
@@ -87,6 +81,10 @@ setup(
         "secure-local-storage": [
             'keyring!=16.1.0'
         ],
+        "azure": [
+            'azure-common',
+            'azure-storage-blob',
+        ]
     },
 
     classifiers=[


### PR DESCRIPTION
To install the azure plugins:

```bash
pip install --upgrade snowflake-connector-python[azure]
```

To install the aws plugins:

```bash
pip install --upgrade snowflake-connector-python[aws]
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/snowflakedb/snowflake-connector-python/172)
<!-- Reviewable:end -->
