### PR TITLE
Urllib3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'pyasn1>=0.4.0,<0.5.0;python_version<"3.0"',
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
+        'urllib3>=1.21.1,<1.25;python_version="3.4"',
     ],
 
     namespace_packages=['snowflake'],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'pyasn1>=0.4.0,<0.5.0;python_version<"3.0"',
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
-        'urllib3>=1.21.1,<1.25;python_version="3.4"',
+        'urllib3>=1.21.1,<1.25',
     ],
 
     namespace_packages=['snowflake'],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'pyasn1>=0.4.0,<0.5.0;python_version<"3.0"',
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
-        'urllib3>=1.21.1,<1.25',
+        'urllib3>=1.21.1,<1.25;python_version<"3.5"',
     ],
 
     namespace_packages=['snowflake'],


### PR DESCRIPTION
I updated the urllib3 library restrictions by requiring the version to be between 1.21.1 and 1.25. I experienced errors when trying to specify that the version restrictions were only for Python 3.4, so I took out that part. Is that okay?