### PR TITLE
Ensure that the cython components are present in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
-include *.rst *.py
+include *.rst *.py *.pyx
+include LICENSE.txt
+recursive-include cpp *.cpp *.hpp
 prune test


### PR DESCRIPTION
Currently the cython components are not present in the source distribution of this library.

In https://github.com/conda-forge/snowflake-connector-python-feedstock/pull/19 we've attempted to build a conda-forge package for this, but failed due to missing source files.