### PR TITLE
make change for 3.7 pep 479

### DIFF
--- a/json_result.py
+++ b/json_result.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
 #
-
+from __future__ import generator_stop
 from logging import getLogger
 from .telemetry import TelemetryField
 from .constants import FIELD_ID_TO_NAME
@@ -104,7 +104,7 @@ class JsonResult:
                     is_done = True
 
             if is_done:
-                raise StopIteration
+                return
 
             return self._row_to_python(row) if row is not None else None
 


### PR DESCRIPTION
I had to change the raise exception to make this work with 3.7 per pep [479](https://www.python.org/dev/peps/pep-0479/). Added the __from for backwards compatibility but didn't test anything. Not sure if you all are aware of this but didn't see anything in the docs.  
