### PR TITLE
freeze asn2crypto version as 1.0.0 is incompatible with 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
     python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
 
     install_requires=[
+        'asn1crypto<1.0.0',
         'azure-common',
         'azure-storage-blob',
         'boto3>=1.4.4,<1.10.0',

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (1, 9, 0, None)
+VERSION = (1, 9, 1, None)


### PR DESCRIPTION
Not sure if this is the best fix but 1.9.0 (and likely many versions below) are broken following the asn2crypto 1.0.0 release a few hours ago. Opening this PR here since I'm sure it will become a problem for many users who are not on 2.0.0 yet.