### PR TITLE
Make pyarrow an optional dependency again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,6 @@ setup(
         'pyasn1>=0.4.0,<0.5.0;python_version<"3.0"',
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',
         'enum34;python_version<"3.4"',
-        'pyarrow>=0.14.0;python_version>"3.4"',
     ],
 
     namespace_packages=['snowflake'],
@@ -205,6 +204,10 @@ setup(
     extras_require={
         "secure-local-storage": [
             'keyring!=16.1.0'
+        ],
+        "arrow-result": [
+            'pyarrow>=0.14.0;python_version>"3.4"',
+            'pyarrow>=0.14.0;python_version<"3.0"'
         ]
     },
 


### PR DESCRIPTION
The fix in 2.0.0 for SNOW-93406 moved the dependency for pyarrow from
optional to required. This commit reverses the setup.py changes from that
and makes the dependency optional again.

Pyarrow is a difficult dependency to support on systems that aren't
manylinux1 compatible, such as alpine linux (uses musl instead of glibc).