### PR TITLE
telemetry.py: do not send telemetry during interpreter shutdown

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -191,7 +191,7 @@ class SnowflakeConnection(object):
 
     def __del__(self):
         try:
-            self.close(retry=False)
+            self.close(retry=False, in_shutdown=True)
         except:
             pass
 
@@ -483,7 +483,7 @@ class SnowflakeConnection(object):
         self.__set_error_attributes()
         self.__open_connection()
 
-    def close(self, retry=True):
+    def close(self, retry=True, in_shutdown=False):
         u"""
         Closes the connection.
         """
@@ -499,7 +499,7 @@ class SnowflakeConnection(object):
 
             # close telemetry first, since it needs rest to send remaining data
             logger.info('closed')
-            self._telemetry.close()
+            self._telemetry.close(in_shutdown=in_shutdown)
             self.rest.delete_session(retry=retry)
             self.rest.close()
             self._rest = None

--- a/connection.py
+++ b/connection.py
@@ -191,7 +191,7 @@ class SnowflakeConnection(object):
 
     def __del__(self):
         try:
-            self.close(retry=False, in_shutdown=True)
+            self.close(retry=False)
         except:
             pass
 
@@ -483,7 +483,7 @@ class SnowflakeConnection(object):
         self.__set_error_attributes()
         self.__open_connection()
 
-    def close(self, retry=True, in_shutdown=False):
+    def close(self, retry=True):
         u"""
         Closes the connection.
         """
@@ -499,7 +499,7 @@ class SnowflakeConnection(object):
 
             # close telemetry first, since it needs rest to send remaining data
             logger.info('closed')
-            self._telemetry.close(in_shutdown=in_shutdown)
+            self._telemetry.close(send_on_close=retry)
             self.rest.delete_session(retry=retry)
             self.rest.close()
             self._rest = None

--- a/telemetry.py
+++ b/telemetry.py
@@ -108,10 +108,10 @@ class TelemetryClient(object):
     def is_closed(self):
         return self._is_closed
 
-    def close(self, in_shutdown=False):
+    def close(self, send_on_close=True):
         if not self._is_closed:
             logger.debug("Closing telemetry client.")
-            if not in_shutdown:
+            if send_on_close:
                 self.send_batch()
             self._is_closed = True
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -108,10 +108,11 @@ class TelemetryClient(object):
     def is_closed(self):
         return self._is_closed
 
-    def close(self):
+    def close(self, in_shutdown=False):
         if not self._is_closed:
             logger.debug("Closing telemetry client.")
-            self.send_batch()
+            if not in_shutdown:
+                self.send_batch()
             self._is_closed = True
 
     def disable(self):


### PR DESCRIPTION
Fixes #145
Attempting to send client telemetry during interpreter shutdown results
in a RuntimeError. Add an optional flag to SnowflakeConnection.close(),
is_shutdown, that defaults to False, but is set to True during
SnowflakeConnection.__del__, which happens during interpreter shutdown
if the connection is not close()'d before interpreter shutdown.