### PR TITLE
Fixes #235: Removes oscrypto from dep list, which was causing crashes on MacOS Catalina

### DIFF
--- a/ocsp_asn1crypto.py
+++ b/ocsp_asn1crypto.py
@@ -17,7 +17,6 @@ from asn1crypto.core import OctetString, Integer
 from asn1crypto.ocsp import CertId, OCSPRequest, TBSRequest, Requests, \
     Request, OCSPResponse, Version
 from asn1crypto.x509 import Certificate
-from oscrypto import asymmetric
 
 from snowflake.connector.errorcode import (
     ER_INVALID_OCSP_RESPONSE,
@@ -314,7 +313,7 @@ class SnowflakeOCSPAsn1Crypto(SnowflakeOCSP):
             raise RevocationCheckError(msg=debug_msg, errno=op_er.errno)
 
     def verify_signature(self, signature_algorithm, signature, cert, data):
-        pubkey = asymmetric.load_public_key(cert.public_key).unwrap().dump()
+        pubkey = cert.public_key.unwrap().dump()
         rsakey = RSA.importKey(pubkey)
         signer = PKCS1_v1_5.new(rsakey)
         if signature_algorithm in SnowflakeOCSPAsn1Crypto.SIGNATURE_ALGORITHM_TO_DIGEST_CLASS:

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,6 @@ setup(
         'ijson',
         'pyjwt',
         'idna',
-        'oscrypto<2.0.0',
         'asn1crypto>0.24.0,<2.0.0',
         'pyasn1>=0.4.0,<0.5.0;python_version<"3.0"',
         'pyasn1-modules>=0.2.0,<0.3.0;python_version<"3.0"',


### PR DESCRIPTION
I believe that cert.public_key already produces a PublicKeyInfo() which already has an RSAPublicKey; we just need to call unwrap().dump() on that directly. No need to do a runaround into oscrypto and back.

https://github.com/wbond/asn1crypto/blob/master/asn1crypto/keys.py for documentation.
https://stackoverflow.com/questions/18806962/simple-der-cert-parsing-in-python for also sanity checks.

I am not strongly familiar with this codebase, so if someone wants to run tests and double check this, that would be great, but I was able to confirm that it unblocked my snowflake development locally.

I would also suggest doing a release to 2.0.5 for this too.