### PR TITLE
Adds cursor_class as an argument to the execute_string function

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -573,7 +573,7 @@ class SnowflakeConnection(object):
     def execute_string(self, sql_text,
                        remove_comments=False,
                        return_cursors=True,
-                       cursor_class=SnowflakeCursor
+                       cursor_class=SnowflakeCursor,
                        **kwargs):
         """
         Executes a SQL text including multiple statements.

--- a/connection.py
+++ b/connection.py
@@ -573,6 +573,7 @@ class SnowflakeConnection(object):
     def execute_string(self, sql_text,
                        remove_comments=False,
                        return_cursors=True,
+                       cursor_class=SnowflakeCursor
                        **kwargs):
         """
         Executes a SQL text including multiple statements.
@@ -582,7 +583,7 @@ class SnowflakeConnection(object):
         stream = StringIO(sql_text)
         for sql, is_put_or_get in split_statements(
                 stream, remove_comments=remove_comments):
-            cur = self.cursor()
+            cur = self.cursor(cursor_class=cursor_class)
             if return_cursors:
                 ret.append(cur)
             cur.execute(sql, _is_put_get=is_put_or_get, **kwargs)


### PR DESCRIPTION
Fixes issue highlighted in this thread https://github.com/snowflakedb/snowflake-connector-python/issues/248

**Issue:** execute_string function was only returning a list of tuples, we wanted it to keep the default behaviour and add the ability to return a list of dictionaries in cursors.

**This pull request contains the following changes:**
- Adds `cursor_class` as an argument to the function `SnowflakeConnection.execute_string`
- Sets the default value for `cursor_class` to `SnowflakeCursor` to keep the existing functionality
- Write a test case to test the out of database cursors

**How is it tested:**
It is tested by creating a trial snowflake account and following the instruction to run the test cases from here https://github.com/snowflakedb/snowflake-connector-python/tree/master/test