### PR TITLE
It is possible for the client_prefetch_threads to not be an int when …

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -1121,9 +1121,9 @@ class SnowflakeConnection(object):
         return self.client_session_keep_alive_heartbeat_frequency
 
     def _validate_client_prefetch_threads(self):
-        if self.client_prefetch_threads <= 0:
+        if int(self.client_prefetch_threads) <= 0:
             self._client_prefetch_threads = 1
-        elif self.client_prefetch_threads > MAX_CLIENT_PREFETCH_THREADS:
+        elif int(self.client_prefetch_threads) > MAX_CLIENT_PREFETCH_THREADS:
             self._client_prefetch_threads = MAX_CLIENT_PREFETCH_THREADS
         self._client_prefetch_threads = int(
             self.client_prefetch_threads)


### PR DESCRIPTION
…compared. Prevent TypeError: '<=' not supported between instances of 'str' and 'int' errors

This PR prevents an error which occured when using sqlalchemy with the snowflake connector and setting the `client_prefetch_threads` config value.  That was being passed as a `str` hence failed the checks against `0` and `MAX_CLIENT_PREFETCH_THREADS` value.  

It gets cast to an int later anyway. 