### PR TITLE
register numpy.str_ in converter.py:PYTHON_TO_SNOWFLAKE_TYPE

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -40,6 +40,7 @@ PYTHON_TO_SNOWFLAKE_TYPE = {
     u'decimal': u'FIXED',
     u'float': u'REAL',
     u'str': u'TEXT',
+    u'str_': u'TEXT',
     u'unicode': u'TEXT',
     u'bytes': u'BINARY',
     u'bytearray': u'BINARY',


### PR DESCRIPTION
This simply adds a registration for `numpy.str_` in `converter.py`.

I hit an obscure error - if one by some path one ends up with a pandas column or numpy array of object type (`dtype('O')`), _containing instances of `numpy.str_`, which _is a proper subclass of `str`_, then the snowflake sqlalchemy dialect fails on trying to render those values to params for a parameterized query. The inserted line here fixes the problem.