### PR TITLE
Added proxies to SnowflakeRestfuls requests session instead of env vars

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -536,7 +536,7 @@ class SnowflakeConnection(object):
             use_numpy=self._numpy,
             support_negative_year=self._support_negative_year)
 
-        proxy.set_proxies(
+        proxies = proxy.format_proxies(
             self.proxy_host, self.proxy_port, self.proxy_user,
             self.proxy_password)
 
@@ -545,7 +545,9 @@ class SnowflakeConnection(object):
             port=self.port,
             protocol=self._protocol,
             inject_client_pause=self._inject_client_pause,
-            connection=self)
+            connection=self,
+            proxies=proxies
+        )
         logger.debug('REST API object was created: %s:%s',
                      self.host,
                      self.port)

--- a/network.py
+++ b/network.py
@@ -205,7 +205,8 @@ class SnowflakeRestful(object):
     def __init__(self, host='127.0.0.1', port=8080,
                  protocol='http',
                  inject_client_pause=0,
-                 connection=None):
+                 connection=None,
+                 proxies=None):
         self._host = host
         self._port = port
         self._protocol = protocol
@@ -214,6 +215,9 @@ class SnowflakeRestful(object):
         self._lock_token = Lock()
         self._idle_sessions = collections.deque()
         self._active_sessions = set()
+        if proxies is None:
+            proxies = {}
+        self._proxies = proxies
 
         # OCSP mode (OCSPMode.FAIL_OPEN by default)
         ssl_wrap_socket.FEATURE_OCSP_MODE = \
@@ -888,6 +892,7 @@ class SnowflakeRestful(object):
         s.mount('http://', HTTPAdapter(max_retries=REQUESTS_RETRY))
         s.mount('https://', HTTPAdapter(max_retries=REQUESTS_RETRY))
         s._reuse_count = itertools.count()
+        s.proxies = self._proxies
         return s
 
     @contextlib.contextmanager

--- a/proxy.py
+++ b/proxy.py
@@ -7,7 +7,7 @@
 import os
 
 
-def set_proxies(proxy_host, proxy_port, proxy_user=None, proxy_password=None):
+def format_proxies(proxy_host, proxy_port, proxy_user=None, proxy_password=None):
     """Sets proxy dict for requests."""
     PREFIX_HTTP = 'http://'
     PREFIX_HTTPS = 'https://'
@@ -37,6 +37,4 @@ def set_proxies(proxy_host, proxy_port, proxy_user=None, proxy_password=None):
                 proxy_auth=proxy_auth,
             ),
         }
-        os.environ['HTTP_PROXY'] = proxies['http']
-        os.environ['HTTPS_PROXY'] = proxies['https']
     return proxies


### PR DESCRIPTION
Added proxies to SnowflakeRestfuls requests session.

What this PR did:

1. Changed `set_proxies` method to not set the proxies as system wide environment variables, and renamed it `format_proxies`
2. Added a `proxies` param to `SnowflakeRestful`, and passed the formatted proxy dict from 'SnowflakeConnection.__open_connection()`.
3. Added the proxy dict to the reqests Session created in `SnowflakeRestful.make_requests_session()`