### PR TITLE
SNOW-155318 remove explicit build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,3 @@ requires = [
     # Must be kept in sync with the `setup_requirements` in `setup.py`
     'pyarrow>=0.17.0,<0.18.0',
 ]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I made a mistake by explicitly setting the `build-backend` to the default according to https://github.com/pypa/pip/issues/6230#issuecomment-459805348

By removing this we allow the build system to fall back to use setup.py install. This would allow us to install the connector without compiling our Arrow code, in case we wanted to do this, while defaulting to compiling it in most cases.

See the following install methods and notice the `--no-use-pep517` flag:
```
<$> pip install dist/snowflake-connector-python-2.2.10.tar.gz --no-use-pep517
Processing ./dist/snowflake-connector-python-2.2.10.tar.gz
Collecting azure-common<2.0.0
...
Installing collected packages: azure-common, urllib3, docutils, jmespath, six, python-dateutil, botocore, s3transfer, boto3, idna, chardet, certifi, requests, pytz, pycryptodomex, pycparser, cffi, cryptography, pyOpenSSL, pyjwt, asn1crypto, oscrypto, oauthlib, requests-oauthlib, isodate, msrest, azure-core, azure-storage-blob, snowflake-connector-python
    Running setup.py install for snowflake-connector-python ... done
Successfully installed asn1crypto-1.4.0 azure-common-1.1.25 azure-core-1.8.0 azure-storage-blob-12.3.2 boto3-1.14.40 botocore-1.17.40 certifi-2020.6.20 cffi-1.14.1 chardet-3.0.4 cryptography-2.9.2 docutils-0.15.2 idna-2.9 isodate-0.6.0 jmespath-0.10.0 msrest-0.6.18 oauthlib-3.1.0 oscrypto-1.2.1 pyOpenSSL-19.1.0 pycparser-2.20 pycryptodomex-3.9.8 pyjwt-1.7.1 python-dateutil-2.8.1 pytz-2020.1 requests-2.23.0 requests-oauthlib-1.3.0 s3transfer-0.3.3 six-1.15.0 snowflake-connector-python-2.2.10 urllib3-1.25.10
<$> python -c "from snowflake.connector.cursor import CAN_USE_ARROW_RESULT;print(CAN_USE_ARROW_RESULT)"
False
```
vs
```
<$> pip install dist/snowflake-connector-python-2.2.10.tar.gz                                          
Processing ./dist/snowflake-connector-python-2.2.10.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: pyjwt<2.0.0 in /tmp/snowsqlext/install_env/lib/python3.6/site-packages (from snowflake-connector-python==2.2.10) (1.7.1)
...
Building wheels for collected packages: snowflake-connector-python
  Building wheel for snowflake-connector-python (PEP 517) ... done
  Created wheel for snowflake-connector-python: filename=snowflake_connector_python-2.2.10-cp36-cp36m-linux_x86_64.whl size=12576257 sha256=f8bf62d7d05003061171473802ec5b33776fca19a41016b5130c18f681720cbe
  Stored in directory: /home/mkeller/.cache/pip/wheels/a7/8b/e2/924f343ce001a8ceed01f64fadf7839cf629846f2a85f4ce7d
Successfully built snowflake-connector-python
Installing collected packages: snowflake-connector-python
  Attempting uninstall: snowflake-connector-python
    Found existing installation: snowflake-connector-python 2.2.10
    Uninstalling snowflake-connector-python-2.2.10:
      Successfully uninstalled snowflake-connector-python-2.2.10
Successfully installed snowflake-connector-python-2.2.10
<$> python -c "from snowflake.connector.cursor import CAN_USE_ARROW_RESULT;print(CAN_USE_ARROW_RESULT)"
True
```

Giving us ultimately the best of both worlds.