### PR TITLE
Fix 329 361

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -36,7 +36,8 @@ def write_pandas(conn: 'SnowflakeConnection',
                  chunk_size: Optional[int] = None,
                  compression: str = 'gzip',
                  on_error: str = 'abort_statement',
-                 parallel: int = 4
+                 parallel: int = 4,
+                 quote_identifiers: bool = False
                  ) -> Tuple[bool, int, int,
                             Sequence[Tuple[str, str, int, int, int, int, Optional[str], Optional[int],
                                            Optional[int], Optional[str]]]]:
@@ -69,6 +70,9 @@ def write_pandas(conn: 'SnowflakeConnection',
             (Default value = 'abort_statement').
         parallel: Number of threads to be used when uploading chunks, default follows documentation at:
             https://docs.snowflake.com/en/sql-reference/sql/put.html#optional-parameters (Default value = 4).
+        quote_identifiers: By default, identifiers are passed on to Snowflake without quoting. I.e. identifiers
+            will be coerced to uppercase by Snowflake. If set to True, identifiers, specifically database, schema,
+            table and column names (from df.columns) will be quoted. (Default value = False)
 
     Returns:
         Returns the COPY INTO command's results to verify ingestion in the form of a tuple of whether all chunks were
@@ -87,9 +91,14 @@ def write_pandas(conn: 'SnowflakeConnection',
             compression,
             compression_map.keys()
         ))
-    location = ((('"' + database + '".') if database else '') +
-                (('"' + schema + '".') if schema else '') +
-                ('"' + table_name + '"'))
+    if quote_identifiers:
+        location = ((('"' + database + '".') if database else '') +
+                    (('"' + schema + '".') if schema else '') +
+                    ('"' + table_name + '"'))
+    else:
+        location = ((database + '.' if database else '') +
+                    (schema + '.' if schema else '') +
+                    (table_name))
     if chunk_size is None:
         chunk_size = len(df)
     cursor = conn.cursor()
@@ -123,10 +132,22 @@ def write_pandas(conn: 'SnowflakeConnection',
             cursor.execute(upload_sql, _is_internal=True)
             # Remove chunk file
             os.remove(chunk_path)
+    if quote_identifiers:
+        columns = '"' + '","'.join(list(df.columns)) + '"'
+    else:
+        columns = ','.join(list(df.columns))
+
+    # in Snowflake, all parquet data is stored in a single column, $1, so we must select columns explicitly
+    # see (https://docs.snowflake.com/en/user-guide/script-data-load-transform-parquet.html)
+    parquet_columns = '$1:' + ',$1:'.join(df.columns)
     copy_into_sql = ('COPY INTO {location} /* Python:snowflake.connector.pandas_tools.write_pandas() */ '
-                     'FROM @"{stage_name}" FILE_FORMAT=(TYPE=PARQUET COMPRESSION={compression}) '
-                     'MATCH_BY_COLUMN_NAME=CASE_SENSITIVE  PURGE=TRUE ON_ERROR={on_error}').format(
+                     '({columns}) '
+                     'FROM (SELECT {parquet_columns} FROM @"{stage_name}") '
+                     'FILE_FORMAT=(TYPE=PARQUET COMPRESSION={compression}) '
+                     'PURGE=TRUE ON_ERROR={on_error}').format(
         location=location,
+        columns=columns,
+        parquet_columns=parquet_columns,
         stage_name=stage_name,
         compression=compression_map[compression],
         on_error=on_error

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -37,7 +37,7 @@ def write_pandas(conn: 'SnowflakeConnection',
                  compression: str = 'gzip',
                  on_error: str = 'abort_statement',
                  parallel: int = 4,
-                 quote_identifiers: bool = False
+                 quote_identifiers: bool = True
                  ) -> Tuple[bool, int, int,
                             Sequence[Tuple[str, str, int, int, int, int, Optional[str], Optional[int],
                                            Optional[int], Optional[str]]]]:
@@ -70,9 +70,9 @@ def write_pandas(conn: 'SnowflakeConnection',
             (Default value = 'abort_statement').
         parallel: Number of threads to be used when uploading chunks, default follows documentation at:
             https://docs.snowflake.com/en/sql-reference/sql/put.html#optional-parameters (Default value = 4).
-        quote_identifiers: By default, identifiers are passed on to Snowflake without quoting. I.e. identifiers
-            will be coerced to uppercase by Snowflake. If set to True, identifiers, specifically database, schema,
-            table and column names (from df.columns) will be quoted. (Default value = False)
+        quote_identifiers: By default, identifiers, specifically database, schema, table and column names
+            (from df.columns) will be quoted. If set to False, identifiers are passed on to Snowflake without quoting.
+            I.e. identifiers will be coerced to uppercase by Snowflake.  (Default value = True)
 
     Returns:
         Returns the COPY INTO command's results to verify ingestion in the form of a tuple of whether all chunks were

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -66,7 +66,7 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
 
 @pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will to small to chunk, this is only testing the put command's syntax
+# Note: since the file will be too small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
 def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -1,4 +1,5 @@
 import math
+from datetime import datetime
 from typing import Callable, Dict, Generator
 
 import mock
@@ -26,18 +27,48 @@ sf_connector_version_df = pandas.DataFrame(sf_connector_version_data, columns=['
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
 # Note: since the file will to small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+@pytest.mark.parametrize('create_default_columns', [True, False])
+def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],
                       compression: str,
                       parallel: int,
-                      chunk_size: int):
+                      chunk_size: int,
+                      quote_identifiers: bool,
+                      create_default_columns: bool):
     num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
 
     with conn_cnx(user=db_parameters['user'],
                   account=db_parameters['account'],
                   password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
         table_name = 'driver_versions'
-        cnx.execute_string('CREATE OR REPLACE TABLE "{}"("name" STRING, "newest_version" STRING)'.format(table_name))
+
+        if quote_identifiers:
+            if create_default_columns:
+                create_sql = """CREATE OR REPLACE TABLE "{}" 
+                             ("name" STRING, "newest_version" STRING,
+                             "id" varchar(36) default uuid_string(),
+                             "ts" timestamp_ltz default current_timestamp)""".format(table_name)
+                id_key = 'id'
+                ts_key = 'ts'
+            else:
+                create_sql = 'CREATE OR REPLACE TABLE "{}" ("name" STRING, "newest_version" STRING)'.format(table_name)
+            select_sql = 'SELECT * FROM "{}"'.format(table_name)
+            drop_sql = 'DROP TABLE IF EXISTS "{}"'.format(table_name)
+        else:
+            if create_default_columns:
+                create_sql = """CREATE OR REPLACE TABLE {} 
+                             (name STRING, newest_version STRING,
+                             id varchar(36) default uuid_string(),
+                             ts timestamp_ltz default current_timestamp)""".format(table_name)
+                id_key = 'ID'
+                ts_key = 'TS'
+            else:
+                create_sql = 'CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name)
+            select_sql = 'SELECT * FROM {}'.format(table_name)
+            drop_sql = 'DROP TABLE IF EXISTS {}'.format(table_name)
+
+        cnx.execute_string(create_sql)
         try:
             success, nchunks, nrows, _ = write_pandas(cnx,
                                                       sf_connector_version_df,
@@ -45,15 +76,25 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
                                                       compression=compression,
                                                       parallel=parallel,
                                                       chunk_size=chunk_size,
-                                                      quote_identifiers=True)
-            if num_of_chunks == 1:
+                                                      quote_identifiers=quote_identifiers)
+            
+            if create_default_columns:
+                from snowflake.connector import DictCursor
+                result = cnx.cursor(DictCursor).execute(select_sql).fetchall()
+                for row in result:
+                    assert row[id_key] is not None  # ID (UUID String)
+                    assert len(row[id_key]) == 36
+                    assert row[ts_key] is not None  # TS (Current Timestamp)
+                    assert isinstance(row[ts_key], datetime)
+            elif num_of_chunks == 1:
                 # Note: since we used one chunk order is conserved
-                assert (cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall() ==
+                assert (cnx.cursor().execute(select_sql).fetchall() ==
                         sf_connector_version_data)
             else:
                 # Note: since we used one chunk order is NOT conserved
-                assert (set(cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall()) ==
+                assert (set(cnx.cursor().execute(select_sql).fetchall()) ==
                         set(sf_connector_version_data))
+                
             # Make sure all files were loaded and no error occurred
             assert success
             # Make sure overall as many rows were ingested as we tried to insert
@@ -61,190 +102,68 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
             # Make sure we uploaded in as many chunk as we wanted to
             assert nchunks == num_of_chunks
         finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+            cnx.execute_string(drop_sql)
 
 
-@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
-@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will be too small to chunk, this is only testing the put command's syntax
-@pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
-                      db_parameters: Dict[str, str],
-                      compression: str,
-                      parallel: int,
-                      chunk_size: int):
-    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
-
-    with conn_cnx(user=db_parameters['user'],
-                  account=db_parameters['account'],
-                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
-        table_name = 'driver_versions'
-        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
-        # not quote them when creating table
-        cnx.execute_string('CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name))
-        try:
-            success, nchunks, nrows, _ = write_pandas(cnx,
-                                                      sf_connector_version_df,
-                                                      table_name,
-                                                      compression=compression,
-                                                      parallel=parallel,
-                                                      chunk_size=chunk_size)
-            if num_of_chunks == 1:
-                # Note: since we used one chunk order is conserved
-                assert (cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall() ==
-                        sf_connector_version_data)
-            else:
-                # Note: since we used one chunk order is NOT conserved
-                assert (set(cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall()) ==
-                        set(sf_connector_version_data))
-            # Make sure all files were loaded and no error occurred
-            assert success
-            # Make sure overall as many rows were ingested as we tried to insert
-            assert nrows == len(sf_connector_version_data)
-            # Make sure we uploaded in as many chunk as we wanted to
-            assert nchunks == num_of_chunks
-        finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
-
-
-@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
-@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will to small to chunk, this is only testing the put command's syntax
-@pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas_default_cols(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
-                      db_parameters: Dict[str, str],
-                      compression: str,
-                      parallel: int,
-                      chunk_size: int):
-    from snowflake.connector import DictCursor
-    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
-
-    with conn_cnx(user=db_parameters['user'],
-                  account=db_parameters['account'],
-                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
-        table_name = 'driver_versions'
-        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
-        # not quote them when creating table
-        cnx.execute_string("""CREATE OR REPLACE TABLE {} (
-                              id varchar(36) default uuid_string(),
-                              name STRING, newest_version STRING,
-                              ts timestamp_ltz default current_timestamp)""".format(table_name))
-        try:
-            success, nchunks, nrows, _ = write_pandas(cnx,
-                                                      sf_connector_version_df,
-                                                      table_name,
-                                                      compression=compression,
-                                                      parallel=parallel,
-                                                      chunk_size=chunk_size)
-            result = cnx.cursor(DictCursor).execute('SELECT * FROM {}'.format(table_name)).fetchall()
-            for row in result:
-                assert row['ID'] is not None
-                assert row['TS'] is not None
-            # Make sure all files were loaded and no error occurred
-            assert success
-            # Make sure overall as many rows were ingested as we tried to insert
-            assert nrows == len(sf_connector_version_data)
-            # Make sure we uploaded in as many chunk as we wanted to
-            assert nchunks == num_of_chunks
-        finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
-
-
-def test_location_building_db_schema(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building_db_schema(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with database, schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == 'database.schema.table'
+                if quote_identifiers:
+                    assert location == '"database"."schema"."table"'
+                else:
+                    assert location == 'database.schema.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema')
+                                                      database='database', schema='schema', 
+                                                      quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
-def test_location_building_db_schema_quoted_identifiers(conn_cnx):
-    """This tests that write_pandas constructs location correctly with database, schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == '"database"."schema"."table"'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema', quote_identifiers=True)
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building_schema(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building_schema(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == 'schema.table'
+                if quote_identifiers:
+                    assert location == '"schema"."table"'
+                else:
+                    assert location == 'schema.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema')
+                                                      schema='schema', quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
-def test_location_building_schema_quoted_identifier(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == '"schema"."table"'
+                if quote_identifiers:
+                    assert location == '"teble.table"'
+                else:
+                    assert location == 'teble.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema', quote_identifiers=True)
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building(conn_cnx):
-    """This tests that write_pandas constructs location correctly with schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == 'teble.table'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building_quoted_identifiers(conn_cnx):
-    """This tests that write_pandas constructs location correctly with schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == '"teble.table"'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table", quote_identifiers=True)
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table",
+                                                      quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -26,7 +26,7 @@ sf_connector_version_df = pandas.DataFrame(sf_connector_version_data, columns=['
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
 # Note: since the file will to small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],
                       compression: str,
                       parallel: int,
@@ -44,7 +44,8 @@ def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', N
                                                       table_name,
                                                       compression=compression,
                                                       parallel=parallel,
-                                                      chunk_size=chunk_size)
+                                                      chunk_size=chunk_size,
+                                                      quote_identifiers=True)
             if num_of_chunks == 1:
                 # Note: since we used one chunk order is conserved
                 assert (cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall() ==
@@ -63,7 +64,110 @@ def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', N
             cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
 
 
+@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
+@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
+# Note: since the file will to small to chunk, this is only testing the put command's syntax
+@pytest.mark.parametrize('parallel', [4, 99])
+def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+                      db_parameters: Dict[str, str],
+                      compression: str,
+                      parallel: int,
+                      chunk_size: int):
+    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
+
+    with conn_cnx(user=db_parameters['user'],
+                  account=db_parameters['account'],
+                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
+        table_name = 'driver_versions'
+        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
+        # not quote them when creating table
+        cnx.execute_string('CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name))
+        try:
+            success, nchunks, nrows, _ = write_pandas(cnx,
+                                                      sf_connector_version_df,
+                                                      table_name,
+                                                      compression=compression,
+                                                      parallel=parallel,
+                                                      chunk_size=chunk_size)
+            if num_of_chunks == 1:
+                # Note: since we used one chunk order is conserved
+                assert (cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall() ==
+                        sf_connector_version_data)
+            else:
+                # Note: since we used one chunk order is NOT conserved
+                assert (set(cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall()) ==
+                        set(sf_connector_version_data))
+            # Make sure all files were loaded and no error occurred
+            assert success
+            # Make sure overall as many rows were ingested as we tried to insert
+            assert nrows == len(sf_connector_version_data)
+            # Make sure we uploaded in as many chunk as we wanted to
+            assert nchunks == num_of_chunks
+        finally:
+            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
+@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
+# Note: since the file will to small to chunk, this is only testing the put command's syntax
+@pytest.mark.parametrize('parallel', [4, 99])
+def test_write_pandas_default_cols(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+                      db_parameters: Dict[str, str],
+                      compression: str,
+                      parallel: int,
+                      chunk_size: int):
+    from snowflake.connector import DictCursor
+    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
+
+    with conn_cnx(user=db_parameters['user'],
+                  account=db_parameters['account'],
+                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
+        table_name = 'driver_versions'
+        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
+        # not quote them when creating table
+        cnx.execute_string("""CREATE OR REPLACE TABLE {} (
+                              id varchar(36) default uuid_string(),
+                              name STRING, newest_version STRING,
+                              ts timestamp_ltz default current_timestamp)""".format(table_name))
+        try:
+            success, nchunks, nrows, _ = write_pandas(cnx,
+                                                      sf_connector_version_df,
+                                                      table_name,
+                                                      compression=compression,
+                                                      parallel=parallel,
+                                                      chunk_size=chunk_size)
+            result = cnx.cursor(DictCursor).execute('SELECT * FROM {}'.format(table_name)).fetchall()
+            for row in result:
+                assert row['ID'] is not None
+                assert row['TS'] is not None
+            # Make sure all files were loaded and no error occurred
+            assert success
+            # Make sure overall as many rows were ingested as we tried to insert
+            assert nrows == len(sf_connector_version_data)
+            # Make sure we uploaded in as many chunk as we wanted to
+            assert nchunks == num_of_chunks
+        finally:
+            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+
+
 def test_location_building_db_schema(conn_cnx):
+    """This tests that write_pandas constructs location correctly with database, schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'database.schema.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
+                                                      database='database', schema='schema')
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_db_schema_quoted_identifiers(conn_cnx):
     """This tests that write_pandas constructs location correctly with database, schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -76,11 +180,28 @@ def test_location_building_db_schema(conn_cnx):
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema')
+                                                      database='database', schema='schema', quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
 def test_location_building_schema(conn_cnx):
+    """This tests that write_pandas constructs location correctly with schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'schema.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
+                                                      schema='schema')
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_schema_quoted_identifier(conn_cnx):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -93,11 +214,27 @@ def test_location_building_schema(conn_cnx):
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema')
+                                                      schema='schema', quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
 def test_location_building(conn_cnx):
+    """This tests that write_pandas constructs location correctly with schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'teble.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_quoted_identifiers(conn_cnx):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -109,5 +246,5 @@ def test_location_building(conn_cnx):
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table", quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))


### PR DESCRIPTION
* Fixes issue where using MATCH_BY_COLUMN_NAME led to case sensitivity issues. Replaced with a `quote_identifier` parameter to `write_pandas`, which defaults to False, but if specified as True will quote all identifiers when passing to Snowflake.
* Fixes using `pd_writer` as a method to `DataFrame.to_sql` via `write_pandas` where default columns in a table pre-defined in Snowflake were not having their default values populated

