### PR TITLE
SNOW-184712 add sdist test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,12 +23,35 @@ jobs:
           python-version: '3.x'
       - name: Display Python version
         run: python -c "import sys; import os; print(\"\n\".join(os.environ[\"PATH\"].split(os.pathsep))); print(sys.version); print(sys.executable);"
-      - name: Upgrade setuptools, pip and wheel
-        run: python -m pip install -U setuptools pip wheel
+      - name: Upgrade setuptools and pip
+        run: python -m pip install -U setuptools pip
       - name: Install tox
         run: python -m pip install tox
       - name: Run fix_lint
         run: tox -e fix_lint
+
+  build-sdist:
+    needs: lint
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Upgrade setuptools and pip
+        run: python -m pip install -U setuptools pip
+      - name: Creating source distribution
+        run: python setup.py sdist
+      - name: Show sdist generated
+        run: ls -lh dist
+      - uses: actions/upload-artifact@v1
+        with:
+          name: sdist
+          path: dist/
 
   build-manylinux:
     needs: lint
@@ -126,9 +149,33 @@ jobs:
           name: windows_py${{ matrix.python-version }}
           path: dist/
 
+  test-sdist:
+    needs: build-sdist
+    name: Test sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download sdist
+        uses: actions/download-artifact@v2
+        with:
+          name: sdist
+          path: dist
+      - name: Show sdist downloaded
+        run: ls -lh dist
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Upgrade setuptools and pip
+        run: python -m pip install -U setuptools pip
+      - name: Install sdist
+        run: pip install dist/*
+
   test:
     name: Test ${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
-    needs: [build-manylinux, build-macos, build-windows]
+    needs: ${{ matrix.os.needs }}
     runs-on: ${{ matrix.os.image_name }}
     strategy:
       fail-fast: false
@@ -136,10 +183,13 @@ jobs:
         os:
          - image_name: ubuntu-latest
            download_name: linux
+           needs: build-manylinux
          - image_name: macos-latest
            download_name: macos
+           needs: build-macos
          - image_name: windows-latest
            download_name: windows
+           needs: build-windows
         python-version: [3.5, 3.6, 3.7, 3.8]
         cloud-provider: [aws, azure, gcp]
         exclude:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -175,7 +175,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
-    needs: ${{ matrix.os.needs }}
+    needs: [build-manylinux, build-macos, build-windows]
     runs-on: ${{ matrix.os.image_name }}
     strategy:
       fail-fast: false
@@ -183,13 +183,10 @@ jobs:
         os:
          - image_name: ubuntu-latest
            download_name: linux
-           needs: build-manylinux
          - image_name: macos-latest
            download_name: macos
-           needs: build-macos
          - image_name: windows-latest
            download_name: windows
-           needs: build-windows
         python-version: [3.5, 3.6, 3.7, 3.8]
         cloud-provider: [aws, azure, gcp]
         exclude:


### PR DESCRIPTION
In light of the MANIFEST issue from last night I'm adding a test to build and install sdists.

This also makes it so not all tests wait for all build jobs to finish before starting, e.g.: linux tests will only wait for linux build jobs.