### PR TITLE
SNOW-173756 adding coverage reporting

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -246,6 +246,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           path: artifacts
@@ -274,4 +275,6 @@ jobs:
               shutil.copy(str(src_file), str(dst_file))'
       - name: Combine coverages
         run: python -m tox -e coverage
-      # TODO add uploading to codecov.io
+      - uses: codecov/codecov-action@v1
+        with:
+          file: .tox/coverage.xml

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -231,3 +231,37 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
         shell: bash
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cov_${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
+          path: .tox/junit.*.xml
+
+  combine-coverage:
+    name: Combine coverage
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Collect all coverages to one dir
+        run: mkdir covs && cp artifacts/**/junit.*.xml
+      - name: Show collected coverages
+        run: ls -la covs
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Upgrade setuptools and pip
+        run: python -m pip install -U setuptools pip
+      - name: Install coverage
+        run: python -m pip install coverage
+      - name: Combine coverages
+        run: coverage combine covs
+      - name: Report overall coverage
+        run: coverage report -m
+      - name: Write coverage to a file
+        run: coverage xml -o python_connector_coverage.xml
+      # TODO add uploading to codecov.io

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -269,7 +269,7 @@ jobs:
           dst_dir = Path(".") / ".tox"
           dst_dir.mkdir()
           for src_file in src_dir.glob("*/.coverage"):
-              dst_file = destination_folder / ".coverage.{}".format(src_file.parent.name[9:])"
+              dst_file = dst_dir / ".coverage.{}".format(src_file.parent.name[9:])
               print("{} copy to {}".format(src_file, dst_file))
               shutil.copy(str(src_file), str(dst_file))'
       - name: Combine coverages

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -48,7 +48,7 @@ jobs:
         run: python setup.py sdist
       - name: Show sdist generated
         run: ls -lh dist
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: sdist
           path: dist/
@@ -231,7 +231,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
         shell: bash
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: cov_${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
           path: .tox/junit.*.xml

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           path: artifacts
       - name: Collect all coverages to one dir
-        run: mkdir covs && cp artifacts/**/junit.*.xml
+        run: mkdir covs && cp artifacts/**/junit.*.xml covs
       - name: Show collected coverages
         run: ls -la covs
       - name: Set up Python

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run fix_lint
-        run: tox -e fix_lint
+        run: python -m tox -e fix_lint
 
   build-sdist:
     needs: lint
@@ -226,15 +226,20 @@ jobs:
       - name: Install tox
         run: python -m pip install tox tox-external-wheels
       - name: Run tests
-        run: tox -e "py${PYTHON_VERSION/\./}{-extras,,-pandas,-sso}-ci"
+        run: python -m tox -e "py${PYTHON_VERSION/\./}{-extras,,-pandas,-sso}-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
         shell: bash
+      - name: Combine coverages
+        run: python -m tox -e coverage --skip-missing-interpreters false
+        shell: bash
       - uses: actions/upload-artifact@v2
         with:
-          name: cov_${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
-          path: .tox/junit.*.xml
+          name: coverage_${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
+          path: |
+            .tox/.coverage
+            .tox/coverage.xml
 
   combine-coverage:
     name: Combine coverage
@@ -244,10 +249,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: artifacts
-      - name: Collect all coverages to one dir
-        run: mkdir covs && cp artifacts/**/junit.*.xml covs
-      - name: Show collected coverages
-        run: ls -la covs
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -256,12 +257,21 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Upgrade setuptools and pip
         run: python -m pip install -U setuptools pip
-      - name: Install coverage
-        run: python -m pip install coverage
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Collect all coverages to one dir
+        run: |
+          python -c '
+          from pathlib import Path
+          import shutil
+
+          src_dir = Path("artifacts")
+          dst_dir = Path(".") / ".tox"
+          dst_dir.mkdir()
+          for src_file in src_dir.glob("*/.coverage"):
+              dst_file = destination_folder / ".coverage.{}".format(src_file.parent.name[9:])"
+              print("{} copy to {}".format(src_file, dst_file))
+              shutil.copy(str(src_file), str(dst_file))'
       - name: Combine coverages
-        run: coverage combine covs
-      - name: Report overall coverage
-        run: coverage report -m
-      - name: Write coverage to a file
-        run: coverage xml -o python_connector_coverage.xml
+        run: python -m tox -e coverage
       # TODO add uploading to codecov.io

--- a/tox.ini
+++ b/tox.ini
@@ -37,23 +37,9 @@ passenv =
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
 commands =
-    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
-                  --cov "snowflake.connector" \
-                  --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
-                  --ignore=test/pandas \
-                  --ignore=test/sso \
-                  {posargs} \
-                  test
-    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
-            --cov "snowflake.connector" \
-            --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
-            {posargs} \
-            test/pandas
-    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
-         --cov "snowflake.connector" \
-         --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
-         {posargs} \
-         test/sso
+    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml --ignore=test/pandas --ignore=test/sso {posargs} test
+    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/pandas
+    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/sso
     extras: python test/extras/run.py
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -37,14 +37,28 @@ passenv =
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
 commands =
-    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}.xml --ignore=test/pandas --ignore=test/sso {posargs} test
-    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}.xml {posargs} test/pandas
-    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}.xml {posargs} test/sso
+    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
+                  --cov "snowflake.connector" \
+                  --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
+                  --ignore=test/pandas \
+                  --ignore=test/sso \
+                  {posargs} \
+                  test
+    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
+            --cov "snowflake.connector" \
+            --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
+            {posargs} \
+            test/pandas
+    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} \
+         --cov "snowflake.connector" \
+         --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml \
+         {posargs} \
+         test/sso
     extras: python test/extras/run.py
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report;
-              generates a diff coverage against origin/master (can be changed by setting DIFF_AGAINST env var)
+;              generates a diff coverage against origin/master (can be changed by setting DIFF_AGAINST env var)
 deps = {[testenv]deps}
        coverage
 ;       diff_cover
@@ -53,10 +67,9 @@ passenv = DIFF_AGAINST
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
 commands = coverage combine
            coverage report -m
-           coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/python_connector_coverage.xml
-           coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov
+           coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/coverage.xml
 ;           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
-depends = py35, py36, py37, py38, pypy, pypy3
+depends = py35, py36, py37, py38
 
 [testenv:flake8]
 ; DEPRECATED

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,18 @@
+[coverage:report]
+skip_covered = False
+show_missing = True
+[coverage:run]
+branch = true
+parallel = true
+[coverage:paths]
+source = src/snowflake/connector
+         */.tox/*/lib/python*/site-packages/snowflake/connector
+         */.tox\*\Lib\site-packages\snowflake\connector
+         */src/snowflake/connector
+         *\src\snowflake\connector
+
 [tox]
+minversion = 3.7
 envlist = fix_lint,
           py{35,36,37,38}{-pandas,-sso,},
           coverage
@@ -15,11 +29,6 @@ extras =
 deps =
     pip >= 19.3.1
 install_command = python -m pip install -U {opts} {packages}
-external_wheels =
-    py35: dist/*cp35*.whl
-    py36: dist/*cp36*.whl
-    py37: dist/*cp37*.whl
-    py38: dist/*cp38*.whl
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_OPTS = -vvv --color=yes


### PR DESCRIPTION
The issue right now with our coverage creation is that not all tests run in all jobs, so they need to combined before they could be uploaded to a service like codecov.io .
This PR aims to add that.

Each test job generates multiple testing environments at the end these are merged and uploaded for later.
When all tests passed then the merged coverage report are downloaded and merged one more time to get the overall coverage, this is then uploaded to codecov.io