### PR TITLE
SNOW-182731 fix aws client renewal when GCP needs renewal

### DIFF
--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -346,17 +346,17 @@ class SnowflakeFileTransferAgent(object):
                 if len(retry_meta) == 0:
                     # no new AWS token is required
                     break
-                client = self.renew_expired_client()
                 if any([result_meta['result_status'] == ResultStatus.RENEW_TOKEN
                         for result_meta in results]):
+                    client = self.renew_expired_client()
                     for result_meta in retry_meta:
                         result_meta['client'] = client
+                    if end_of_idx < len_file_metas:
+                        for idx0 in range(idx + self._parallel, len_file_metas):
+                            file_metas[idx0]['client'] = client
                 if any([result_meta['result_status'] == ResultStatus.RENEW_PRESIGNED_URL
                         for result_meta in results]):
                     self._update_file_metas_with_presigned_url()
-                if end_of_idx < len_file_metas:
-                    for idx0 in range(idx + self._parallel, len_file_metas):
-                        file_metas[idx0]['client'] = client
                 target_meta = retry_meta
 
             if end_of_idx == len_file_metas:


### PR DESCRIPTION
While investigating GCP put issues I found that my fix in #354 was incorrect, this makes it so that we don't refresh client for GCP.
I don't think this hurt anything and it doesn't fix GCP puts right now, but I want to fix this issue anyways.