### PR TITLE
SNOW-186696 fix mac tests with new folder structure

### DIFF
--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -24,7 +24,7 @@ cd $CONNECTOR_DIR
 for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     echo "[Info] Testing with ${PYTHON_VERSION}"
     SHORT_VERSION=$(python3 -c "print('${PYTHON_VERSION}'.replace('.', ''))")
-    CONNECTOR_WHL=$(ls ${CONNECTOR_DIR}/dist/${PYTHON_VERSION}/snowflake_connector_python*cp${SHORT_VERSION}*.whl)
+    CONNECTOR_WHL=$(ls ${CONNECTOR_DIR}/dist/snowflake_connector_python*cp${SHORT_VERSION}*.whl)
     TEST_ENVLIST=py${SHORT_VERSION}{,-pandas,-sso}-ci
     echo "[Info] Running tox for ${TEST_ENVLIST}"
 


### PR DESCRIPTION
I forgot to change the test script for our Mac tests.
This removes the e.g. `3.5` folder from dist.
This was done in #376 on the build side