### PR TITLE
Use requests proxies object

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -93,10 +93,7 @@ DEFAULT_CONFIGURATION = {
     'host': ('127.0.0.1', str),  # standard
     'port': (8080, (int, str)),  # standard
     'database': (None, (type(None), str)),  # standard
-    'proxy_host': (None, (type(None), str)),  # snowflake
-    'proxy_port': (None, (type(None), str)),  # snowflake
-    'proxy_user': (None, (type(None), str)),  # snowflake
-    'proxy_password': (None, (type(None), str)),  # snowflake
+    'proxies' : (None, (type(None), dict)),  # standard
     'protocol': (u'http', str),  # snowflake
     'warehouse': (None, (type(None), str)),  # snowflake
     'region': (None, (type(None), str)),  # snowflake
@@ -170,10 +167,7 @@ class SnowflakeConnection(object):
         host: The host name the connection attempts to connect to.
         port: The port to communicate with on the host.
         region: Region name if not the default Snowflake Database deployment.
-        proxy_host: The hostname used proxy server.
-        proxy_port: Port on proxy server to communicate with.
-        proxy_user: User name to login with on the proxy sever.
-        proxy_password: Password to be used to authenticate with proxy server.
+        proxies: Proxies attribute to use in requests.
         account: Account name to be used to authenticate with Snowflake.
         database: Database to use on Snowflake.
         schema: Schema in use on Snowflake.
@@ -536,16 +530,14 @@ class SnowflakeConnection(object):
             use_numpy=self._numpy,
             support_negative_year=self._support_negative_year)
 
-        proxy.set_proxies(
-            self.proxy_host, self.proxy_port, self.proxy_user,
-            self.proxy_password)
-
         self._rest = SnowflakeRestful(
             host=self.host,
             port=self.port,
             protocol=self._protocol,
             inject_client_pause=self._inject_client_pause,
-            connection=self)
+            connection=self,
+            proxies=self._proxies
+            )
         logger.debug('REST API object was created: %s:%s',
                      self.host,
                      self.port)

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -205,7 +205,8 @@ class SnowflakeRestful(object):
     def __init__(self, host='127.0.0.1', port=8080,
                  protocol='http',
                  inject_client_pause=0,
-                 connection=None):
+                 connection=None,
+                 proxies=None):
         self._host = host
         self._port = port
         self._protocol = protocol
@@ -214,6 +215,7 @@ class SnowflakeRestful(object):
         self._lock_token = Lock()
         self._idle_sessions = collections.deque()
         self._active_sessions = set()
+        self._proxies = proxies
 
         # OCSP mode (OCSPMode.FAIL_OPEN by default)
         ssl_wrap_socket.FEATURE_OCSP_MODE = \
@@ -777,6 +779,7 @@ class SnowflakeRestful(object):
                 verify=True,
                 stream=is_raw_binary,
                 auth=SnowflakeAuth(token),
+                proxies=self._proxies
             )
             download_end_time = get_time_millis()
 


### PR DESCRIPTION
The [proxies](https://requests.readthedocs.io/en/master/user/advanced/#proxies) object from `requests` is more versatile and also allows for the use of [socks](https://requests.readthedocs.io/en/master/user/advanced/#socks) proxies. 