### PR TITLE
include C++ standard library headers in the places that use them

### DIFF
--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_BINARYCONVERTER_HPP
 #define PC_BINARYCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "logging.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2013-2019 Snowflake Computing
  */
-#include <memory>
-
 #include "BooleanConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013-2019 Snowflake Computing
  */
+#include <memory>
+
 #include "BooleanConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_BOOLEANCONVERTER_HPP
 #define PC_BOOLEANCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -4,6 +4,9 @@
 #ifndef PC_ARROWCHUNKITERATOR_HPP
 #define PC_ARROWCHUNKITERATOR_HPP
 
+#include <memory>
+#include <vector>
+
 #include "CArrowIterator.hpp"
 #include "IColumnConverter.hpp"
 #include "Python/Common.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
@@ -4,6 +4,9 @@
 #ifndef PC_ARROWITERATOR_HPP
 #define PC_ARROWITERATOR_HPP
 
+#include <memory>
+#include <string>
+
 #include <Python.h>
 #include <vector>
 #include <arrow/python/platform.h>

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -4,6 +4,10 @@
 #ifndef PC_ARROWTABLEITERATOR_HPP
 #define PC_ARROWTABLEITERATOR_HPP
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <arrow/table.h>
 #include "CArrowIterator.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_DATECONVERTER_HPP
 #define PC_DATECONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "Python/Common.hpp"
 #include "logging.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_DECIMALCONVERTER_HPP
 #define PC_DECIMALCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "Python/Common.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_FLOATCONVERTER_HPP
 #define PC_FLOATCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_INTCONVERTER_HPP
 #define PC_INTCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
@@ -6,6 +6,8 @@
 
 /** this two header files will be removed when we replace arrow::Status with our
  * own status data structure */
+#include <string>
+
 #include <arrow/python/platform.h>
 #include <arrow/api.h>
 #include "logging.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_STRINGCONVERTER_HPP
 #define PC_STRINGCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "logging.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_TIMECONVERTER_HPP
 #define PC_TIMECONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "Python/Common.hpp"
 #include "Python/Helpers.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
@@ -4,6 +4,8 @@
 #ifndef PC_TIMESTAMPCONVERTER_HPP
 #define PC_TIMESTAMPCONVERTER_HPP
 
+#include <memory>
+
 #include "IColumnConverter.hpp"
 #include "Python/Common.hpp"
 #include "Python/Helpers.hpp"


### PR DESCRIPTION
Similar to #387 , I'm new to this project and wanted to find some small ways to contribute

I ran [`cpplint`](https://github.com/cpplint/cpplint), an open-source linter that checks compliance with the Google Style Guide for C++, over the C++ code in this project.

```shell
pip install cpplint

cpplint \
    --filter=-build/c++11,-build/include_subdir,-build/header_guard,-whitespace/,-line_length \
    --recursive ./src/snowflake/connector/cpp
```

Some of the recommendations from this are only cosmetic and best left to maintainers, but I found at least one class of problem that I think is worth fixing.

There are several places in the code where the necessary headers from the C++ standard library aren't being directly included. For example, `Arrowiterator/BinaryConverter` uses `shared_ptr` but doesn't include `<memory>`. You're not getting any compiler warnings/errors because `<memory>` is probably included by some other header upstream of `Arrowiterator/BinaryConverter.hpp`.

This PR proposes including those headers directly.

## Why should we care about this PR?

The main benefit of this is explained in ["Why Include What You Use?"](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md#allow-refactoring)

> Suppose you refactor foo.h so it no longer uses vectors. You'd like to remove #include <vector> from foo.h, to reduce compile time -- template class files such as vector can include a lot of code. But can you? In theory yes, but in practice maybe not: some other file may be #including you and using vectors, and depending (probably unknowingly) on your #include <vector> to compile. Your refactor could break code far away from you.

> This is most compelling for a very large codebase (such as Google's). In a small codebase, it's practical to just compile everything after a refactor like this, and clean up any errors you see. When your codebase contains hundreds of thousands of source files, identifying and cleaning up the errors can be a project in itself. In practice, people are likely to just leave the #include <vector> line in there, even though it's unnecessary.

> Here, it's the actual 'include what you use' policy that saves the day. If everyone who uses vector is #including <vector> themselves, then you can remove <vector> without fear of breaking anything.

Thanks for your time and consideration.