### PR TITLE
update snowflake.net links to snowflake.com

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -2,7 +2,7 @@ This package includes the Snowflake Connector for Python, which conforms to the 
 https://www.python.org/dev/peps/pep-0249/
 
 Snowflake Documentation is available at:
-https://docs.snowflake.net/
+https://docs.snowflake.com/
 
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ ODBC. It can be installed using ``pip`` on Linux, Mac OSX, and Windows platforms
 (Python 3.8 is currently not supported on Windows) where Python 3.5.0 (or higher) is installed.
 
 Snowflake Documentation is available at:
-https://docs.snowflake.net/
+https://docs.snowflake.com/
 
 Feel free to file an issue or submit a PR here for general cases. For official support, contact Snowflake support at:
 https://community.snowflake.com/s/article/How-To-Submit-a-Support-Case-in-Snowflake-Lodge

--- a/ci/anaconda/meta.yaml
+++ b/ci/anaconda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
         - cffi ==1.6.0
 
 about:
-    home: https://www.snowflake.net/
+    home: https://www.snowflake.com/
     license: Apache 2.0
     license_file: /tmp/anaconda_workspace/src/LICENSE.txt
     summary: Snowflake Connector for Python

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -148,7 +148,7 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
     # is passed from the constructor of SnowflakeConnection class. Note, only FIXED, REAL
     # and TIMESTAMP_NTZ will be converted into numpy data types, all other sql types will
     # still be converted into native python types.
-    # https://docs.snowflake.net/manuals/user-guide/sqlalchemy.html#numpy-data-type-support
+    # https://docs.snowflake.com/en/user-guide/sqlalchemy.html#numpy-data-type-support
     cdef object use_numpy
 
     def __cinit__(self, object cursor, object py_inputstream, object arrow_context, object use_dict_result,


### PR DESCRIPTION
When I clicked the docs links in the README, I noticed that I was redirected from `snowflake.net` to `snowflake.com`. I confirmed this with `curl`

```shell
curl -I https://docs.snowflake.net/
```

returns this

```text
HTTP/1.1 301 Moved Permanently
Content-Length: 0
Connection: keep-alive
Date: Wed, 02 Sep 2020 23:14:06 GMT
Location: /manuals/index.html
Server: AmazonS3
X-Cache: Miss from cloudfront
Via: 1.1 5971d213ff39e16c310a05523f08e121.cloudfront.net (CloudFront)
```

This PR proposes updating the existing documentation links that point to `.net` to `.com`. I tested these new links manually and all worked without redirects.

I didn't change the links in the test files, since I'm guessing that those are still valid.

![image](https://user-images.githubusercontent.com/7608904/92047202-273ea080-ed4a-11ea-8d14-8987dd62b49b.png)

## Why this PR is important

I have been in settings where browsers block redirects. This PR will help out any of your users that are in such settings, and might otherwise not be able to click through these links.

Thanks for your time and consideration.