### PR TITLE
remove unused arguments in internal functions

### DIFF
--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -405,12 +405,12 @@ def write_temporary_credential(host, account, user, id_token, store_temporary_cr
         except keyring.errors.KeyringError as ke:
             logger.debug("Could not store id_token to keyring, %s", str(ke))
     elif IS_LINUX and store_temporary_credential:
-        write_temporary_credential_file(host, account, user, id_token)
+        write_temporary_credential_file(account, user, id_token)
     else:
         logger.debug("connection parameter client_store_temporary_credential not set or OS not support")
 
 
-def write_temporary_credential_file(host, account, user, id_token):
+def write_temporary_credential_file(account, user, id_token):
     """Writes temporary credential file when OS is Linux."""
     if not CACHE_DIR:
         # no cache is enabled

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -520,7 +520,7 @@ class SnowflakeConnection(object):
             setattr(self, m, getattr(errors, m))
 
     @staticmethod
-    def setup_ocsp_privatelink(app, hostname):
+    def setup_ocsp_privatelink(hostname):
         SnowflakeConnection.OCSP_ENV_LOCK.acquire()
         ocsp_cache_server = \
             'http://ocsp.{}/ocsp_response_cache.json'.format(

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -282,7 +282,7 @@ class SnowflakeConverter(object):
 
     _TIMESTAMP_to_python = _TIMESTAMP_LTZ_to_python
 
-    def _TIMESTAMP_NTZ_to_python(self):
+    def _TIMESTAMP_NTZ_to_python(self, ctx):
         """TIMESTAMP NTZ to datetime with no timezone info is attached."""
         scale = ctx['scale']
 

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -282,7 +282,7 @@ class SnowflakeConverter(object):
 
     _TIMESTAMP_to_python = _TIMESTAMP_LTZ_to_python
 
-    def _TIMESTAMP_NTZ_to_python(self, ctx):
+    def _TIMESTAMP_NTZ_to_python(self):
         """TIMESTAMP NTZ to datetime with no timezone info is attached."""
         scale = ctx['scale']
 

--- a/src/snowflake/connector/incident.py
+++ b/src/snowflake/connector/incident.py
@@ -49,7 +49,7 @@ class Incident(object):
         self.errorStackTrace = str(error_stack_trace)
         self.os = str(os)
         self.osVersion = str(os_version)
-        self.signature = str(self.__generate_signature(error_message, error_stack_trace))
+        self.signature = str(self.__generate_signature(error_message))
         self.driver = str(driver)
         self.driverVersion = str(driver_version)
 
@@ -81,7 +81,7 @@ class Incident(object):
         return "Incident {id}".format(id=self.uuid)
 
     @staticmethod
-    def __generate_signature(error_message: Optional[str], error_stack_trace: Optional[str]) -> Optional[str]:
+    def __generate_signature(error_message: Optional[str]) -> Optional[str]:
         """Automatically generates signature of Incident."""
         return error_message
 

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -672,7 +672,7 @@ class SnowflakeRestful(object):
                         Error.errorhandler_wrapper(conn, None, cause)
                     else:
                         self.handle_invalid_certificate_error(
-                            conn, full_url, cause)
+                            conn, cause)
                     return {}  # required for tests
             sleeping_time = retry_ctx.next_sleep()
             logger.debug(
@@ -695,7 +695,7 @@ class SnowflakeRestful(object):
             logger.debug("Ignored error", exc_info=True)
             return {}
 
-    def handle_invalid_certificate_error(self, conn, full_url, cause):
+    def handle_invalid_certificate_error(self, conn, cause):
         # all other errors raise exception
         Error.errorhandler_wrapper(
             conn, None, OperationalError,

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -219,7 +219,7 @@ class SnowflakeOCSPAsn1Crypto(SnowflakeOCSP):
 
         try:
             if cert_status == 'good':
-                self._process_good_status(single_response, cert_id, ocsp_response)
+                self._process_good_status(single_response)
         except Exception as ex:
             logger.debug("Failed to validate ocsp response %s", ex)
             return False
@@ -300,7 +300,7 @@ class SnowflakeOCSPAsn1Crypto(SnowflakeOCSP):
 
         try:
             if cert_status == 'good':
-                self._process_good_status(single_response, cert_id, ocsp_response)
+                self._process_good_status(single_response)
                 SnowflakeOCSP.OCSP_CACHE.update_cache(self, cert_id, ocsp_response)
             elif cert_status == 'revoked':
                 self._process_revoked_status(single_response, cert_id)

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1375,7 +1375,7 @@ class SnowflakeOCSP(object):
 
         return ret
 
-    def _process_good_status(self, single_response, cert_id, ocsp_response):
+    def _process_good_status(self, single_response):
         """Processes GOOD status."""
         current_time = int(time.time())
         this_update_native, next_update_native = \

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -9,14 +9,14 @@ installed_pandas = False
 installed_keyring = False
 
 
-def _warn_incompatible_dep(dep_name: str,
-                           expected_ver: 'pkg_resources.Requirement') -> None:
-    msg = (
-         "You have an incompatible version of '{}' installed, please install a version that "
-         "adheres to: '{}'"
-    )
-    msg = msg.format(dep_name, expected_ver)
-    warnings.warn(msg, stacklevel=2)
+def warn_incompatible_dep(dep_name: str,
+                          expected_ver: 'pkg_resources.Requirement') -> None:
+    warnings.warn(
+        "You have an incompatible version of '{}' installed, please install a version that "
+        "adheres to: '{}'".format(dep_name,
+                                  expected_ver),
+        stacklevel=2)
+
 
 class MissingPandas(object):
 
@@ -36,7 +36,7 @@ try:
     _expected_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]
     _installed_pyarrow = pkg_resources.working_set.by_key['pyarrow']
     if _installed_pyarrow and _installed_pyarrow.version not in _expected_version:
-        _warn_incompatible_dep('pyarrow', _expected_version)
+        warn_incompatible_dep('pyarrow', _expected_version)
 except ImportError:
     pandas = MissingPandas()
     pyarrow = MissingPandas()

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -9,16 +9,6 @@ installed_pandas = False
 installed_keyring = False
 
 
-def warn_incompatible_dep(dep_name: str,
-                          installed_ver: str,
-                          expected_ver: 'pkg_resources.Requirement') -> None:
-    warnings.warn(
-        "You have an incompatible version of '{}' installed, please install a version that "
-        "adheres to: '{}'".format(dep_name,
-                                  _expected_version),
-        stacklevel=2)
-
-
 class MissingPandas(object):
 
     def __getattr__(self, item):
@@ -37,7 +27,12 @@ try:
     _expected_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]
     _installed_pyarrow = pkg_resources.working_set.by_key['pyarrow']
     if _installed_pyarrow and _installed_pyarrow.version not in _expected_version:
-        warn_incompatible_dep('pyarrow', _installed_pyarrow.version, _expected_version)
+        msg = (
+             "You have an incompatible version of '{}' installed, please install a version that "
+             "adheres to: '{}'"
+        )
+        msg = msg.format("pyarrow", _expected_version)
+        warnings.warn(msg, stacklevel=2)
 except ImportError:
     pandas = MissingPandas()
     pyarrow = MissingPandas()

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -9,6 +9,15 @@ installed_pandas = False
 installed_keyring = False
 
 
+def _warn_incompatible_dep(dep_name: str,
+                           expected_ver: 'pkg_resources.Requirement') -> None:
+    msg = (
+         "You have an incompatible version of '{}' installed, please install a version that "
+         "adheres to: '{}'"
+    )
+    msg = msg.format(dep_name, expected_ver)
+    warnings.warn(msg, stacklevel=2)
+
 class MissingPandas(object):
 
     def __getattr__(self, item):
@@ -27,12 +36,7 @@ try:
     _expected_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]
     _installed_pyarrow = pkg_resources.working_set.by_key['pyarrow']
     if _installed_pyarrow and _installed_pyarrow.version not in _expected_version:
-        msg = (
-             "You have an incompatible version of '{}' installed, please install a version that "
-             "adheres to: '{}'"
-        )
-        msg = msg.format("pyarrow", _expected_version)
-        warnings.warn(msg, stacklevel=2)
+        _warn_incompatible_dep('pyarrow', _expected_version)
 except ImportError:
     pandas = MissingPandas()
     pyarrow = MissingPandas()


### PR DESCRIPTION
This PR proposes fixing another class of minor issue caught by `pylint` (related to #393 ): unused arguments in functions. 

I decided to ignore many of these warnings from `pylint`, because fixing them would imply making user-facing breaking changes or removing an argument in a method that was expected by a parent class.

<details><summary>warnings I ignored (click me)</summary>

```text
src/snowflake/connector/azure_util.py:91:34: W0613: Unused argument 'use_accelerate_endpoint' (unused-argument)
src/snowflake/connector/local_util.py:17:22: W0613: Unused argument 'stage_info' (unused-argument)
src/snowflake/connector/local_util.py:17:34: W0613: Unused argument 'use_accelerate_endpoint' (unused-argument)
src/snowflake/connector/gcs_util.py:31:22: W0613: Unused argument 'use_accelerate_endpoint' (unused-argument)
src/snowflake/connector/gcs_util.py:59:58: W0613: Unused argument 'max_concurrency' (unused-argument)
src/snowflake/connector/gcs_util.py:176:56: W0613: Unused argument 'max_concurrency' (unused-argument)
src/snowflake/connector/gcs_util.py:273:30: W0613: Unused argument 'filename' (unused-argument)
src/snowflake/connector/ssl_wrap_socket.py:356:21: W0613: Unused argument 'cnx' (unused-argument)
src/snowflake/connector/ssl_wrap_socket.py:356:26: W0613: Unused argument 'x509' (unused-argument)
src/snowflake/connector/ssl_wrap_socket.py:356:40: W0613: Unused argument 'err_depth' (unused-argument)
src/snowflake/connector/ssl_wrap_socket.py:356:51: W0613: Unused argument 'return_code' (unused-argument)
src/snowflake/connector/connection.py:523:31: W0613: Unused argument 'app' (unused-argument)
src/snowflake/connector/converter_snowsql.py:107:30: W0613: Unused argument 'ctx' (unused-argument)
src/snowflake/connector/cursor.py:257:23: W0613: Unused argument 'procname' (unused-argument)
src/snowflake/connector/cursor.py:257:33: W0613: Unused argument 'args' (unused-argument)
src/snowflake/connector/cursor.py:425:16: W0613: Unused argument 'exec_async' (unused-argument)
src/snowflake/connector/cursor.py:865:21: W0613: Unused argument 'value' (unused-argument)
src/snowflake/connector/cursor.py:865:28: W0613: Unused argument 'mode' (unused-argument)
src/snowflake/connector/converter.py:297:45: W0613: Unused argument 'ctx' (unused-argument)
src/snowflake/connector/converter.py:324:33: W0613: Unused argument 'ctx' (unused-argument)
```

</details>

However, I think a few of these warnings can be safely fixed because they're only used by code internal to the library.

<details><summary>warnings I addressed</summary>

```text
src/snowflake/connector/auth.py:413:36: W0613: Unused argument 'host' (unused-argument)
src/snowflake/connector/incident.py:84:59: W0613: Unused argument 'error_stack_trace' (unused-argument)
src/snowflake/connector/network.py:698:53: W0613: Unused argument 'full_url' (unused-argument)
src/snowflake/connector/options.py:13:26: W0613: Unused argument 'installed_ver' (unused-argument)
src/snowflake/connector/options.py:14:26: W0613: Unused argument 'expected_ver' (unused-argument)
src/snowflake/connector/ocsp_snowflake.py:1378:52: W0613: Unused argument 'cert_id' (unused-argument)
src/snowflake/connector/ocsp_snowflake.py:1378:61: W0613: Unused argument 'ocsp_response' (unused-argument)
```

</details>

### How does this PR improve `snowflake-connector-python`?

By eliminating these extra arguments, I believe this PR makes this library a tiny bitter smaller, faster, and simpler, without any loss of functionality.

Thanks for your time and consideration!