### PR TITLE
SNOW-195747 add more object files, core dumps to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ __pycache__/
 *$py.class
 
 # C extensions
+*.a
+*.dll
+*.exe
+*.o
 *.so
 
 # Distribution / packaging
@@ -103,3 +107,6 @@ snowflake_connector_python.egg-info/
 wss*.config
 wss-unified-agent.jar
 whitesource/
+
+# core dumps
+core.*


### PR DESCRIPTION
While exploring #397 today, I found that when I made mistakes working with Arrow, a core dump file was generated.

These are not ignored in this project's `.gitignore` today. This PR proposes that they should be ignored.

![image](https://user-images.githubusercontent.com/7608904/92770226-57e09480-f35f-11ea-992d-7e5754d4a6a7.png)

While touching `.gitignore`, I also noticed that some other common C object file extensions aren't currently ignored. This PR also proposes ignoring those.

Thanks for your time and consideration.
