### PR TITLE
SNOW-197039 add feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,3 +1,8 @@
+---
+name: Bug Report 🐞
+about: Something isn't working as expected? Here is the right place to report.
+---
+
 Please answer these questions before submitting your issue. Thanks!
 
 1. What version of Python are you using (`python --version`)?

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for the project.
+---
+
+## What is the current behavior?
+
+## What is the desired behavior?
+
+## How would this improve `snowflake-connector-python`?
+
+## References, Other Background


### PR DESCRIPTION
Thanks for this great project!

While contributing here, I've found that the issue template that shows up when you click `New Issue` has language that is specific to bug reports, such as:

> Can you set logging to DEBUG and collect the logs?

In this PR, I'd like to propose creating separate templates for bug reports and feature requests. I think this will help to provide some structure and avoid unnecessary information in feature reports.

With the setup proposed in this PR, when someone clicks `New Issue`, they'll see this choice:

![image](https://user-images.githubusercontent.com/7608904/93270353-91a60680-f776-11ea-9ca7-1927305a59fd.png)

You can read more about having multiple issue templates [in the GitHub docs](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates).

Thanks for your time and consideration!