### PR TITLE
SNOW-195220 moved flake8 setting to tox.ini

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[flake8]
-ignore=F821,W504,E501,E402,E122,E127,E126,E128,E131,E731,E125,E722x,D100,D101,D102,D103,D104,D105,D107,D401,D204
-exclude=
-    build,tool,.tox,parameters.py,parameters_jenkins.py,
-    # Disable checking virtualenv contents
-    *venv*
-max-line-length = 120
-show-source = true

--- a/tox.ini
+++ b/tox.ini
@@ -110,3 +110,12 @@ force_grid_wrap = 0
 line_length = 120
 known_first_party =snowflake,parameters,generate_test_files
 known_third_party =Cryptodome,OpenSSL,asn1crypto,boto3,botocore,certifi,cryptography,dateutil,jwt,mock,numpy,pandas,pendulum,pkg_resources,pyasn1,pyasn1_modules,pytest,pytz,requests,setuptools,urllib3
+
+[flake8]
+ignore=F821,W504,E501,E402,E122,E127,E126,E128,E131,E731,E125,E722x,D100,D101,D102,D103,D104,D105,D107,D401,D204
+exclude=
+    build,tool,.tox,parameters.py,parameters_jenkins.py,
+# Disable checking virtualenv contents
+    *venv*
+max-line-length = 120
+show-source = true


### PR DESCRIPTION
`flake8` supports reading config values straight from `tox.ini`

This could remove `setup.cfg` from our repository.