### PR TITLE
SNOW-194973 update copyright headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,20 @@ repos:
     -   id: check-ast
     -   id: flake8
         additional_dependencies: ["flake8-bugbear == 19.3.0", "flake8-docstrings"]
+-   repo: https://github.com/Lucas-C/pre-commit-hooks.git
+    rev: v1.1.9
+    hooks:
+    -   id: insert-license
+        name: insert-py-license
+        files: src/snowflake/connector/.*\.pyx?$
+        exclude: >
+            (?x)^(
+                src/snowflake/connector/version.py|
+                src/snowflake/connector/cpp|
+            )$
+        args:
+            - --license-filepath
+            - license_header.txt
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.19.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
+        exclude: license_header.txt
     -   id: check-yaml
     -   id: debug-statements
     -   id: check-ast
@@ -38,7 +39,7 @@ repos:
         exclude: version.py$
         args:
             - --comment-style
-            - '/*| *| */'
+            - //
             - --license-filepath
             - license_header.txt
 -   repo: https://github.com/asottile/pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,15 @@ repos:
         args:
             - --license-filepath
             - license_header.txt
+    -   id: insert-license
+        name: insert-cpp-license
+        files: src/snowflake/connector/cpp/.*\.(cpp|hpp)$
+        exclude: version.py$
+        args:
+            - --comment-style
+            - '/*| *| */'
+            - --license-filepath
+            - license_header.txt
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.19.0
     hooks:

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,1 @@
+Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,1 +1,3 @@
+
 Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+

--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 #
 # Python Db API v2

--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 
 #
 # Python Db API v2

--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 
 #
 # Python Db API v2

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import decimal
 import time

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import decimal
 import time
 from datetime import datetime, timedelta

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import decimal
 import time
 from datetime import datetime, timedelta

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -1,7 +1,3 @@
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 # distutils: language = c++
 # cython: language_level=3
 

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 # distutils: language = c++
 # cython: language_level=3
 

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 # distutils: language = c++
 # cython: language_level=3

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 # cython: profile=False
 # cython: language_level=3
 

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -1,7 +1,3 @@
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 # cython: profile=False
 # cython: language_level=3
 

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 # cython: profile=False
 # cython: language_level=3

--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import codecs
 import copy
 import json

--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import codecs
 import copy

--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import codecs
 import copy
 import json

--- a/src/snowflake/connector/auth_by_plugin.py
+++ b/src/snowflake/connector/auth_by_plugin.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from .errors import DatabaseError, Error
 from .sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 

--- a/src/snowflake/connector/auth_by_plugin.py
+++ b/src/snowflake/connector/auth_by_plugin.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from .errors import DatabaseError, Error
 from .sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED

--- a/src/snowflake/connector/auth_by_plugin.py
+++ b/src/snowflake/connector/auth_by_plugin.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from .errors import DatabaseError, Error
 from .sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 

--- a/src/snowflake/connector/auth_default.py
+++ b/src/snowflake/connector/auth_default.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from .auth_by_plugin import AuthByPlugin
 
 

--- a/src/snowflake/connector/auth_default.py
+++ b/src/snowflake/connector/auth_default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from .auth_by_plugin import AuthByPlugin
 

--- a/src/snowflake/connector/auth_default.py
+++ b/src/snowflake/connector/auth_default.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from .auth_by_plugin import AuthByPlugin
 
 

--- a/src/snowflake/connector/auth_idtoken.py
+++ b/src/snowflake/connector/auth_idtoken.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from .auth_by_plugin import AuthByPlugin
 from .network import ID_TOKEN_AUTHENTICATOR
 

--- a/src/snowflake/connector/auth_idtoken.py
+++ b/src/snowflake/connector/auth_idtoken.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from .auth_by_plugin import AuthByPlugin
 from .network import ID_TOKEN_AUTHENTICATOR

--- a/src/snowflake/connector/auth_idtoken.py
+++ b/src/snowflake/connector/auth_idtoken.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
-#
-
 from .auth_by_plugin import AuthByPlugin
 from .network import ID_TOKEN_AUTHENTICATOR
 

--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import base64
 import hashlib
 from datetime import datetime, timedelta

--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2017 Snowflake Computing Inc. All right reserved.
-#
-
 import base64
 import hashlib
 from datetime import datetime, timedelta

--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import base64
 import hashlib

--- a/src/snowflake/connector/auth_oauth.py
+++ b/src/snowflake/connector/auth_oauth.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from .auth_by_plugin import AuthByPlugin
 from .network import OAUTH_AUTHENTICATOR
 

--- a/src/snowflake/connector/auth_oauth.py
+++ b/src/snowflake/connector/auth_oauth.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from .auth_by_plugin import AuthByPlugin
 from .network import OAUTH_AUTHENTICATOR

--- a/src/snowflake/connector/auth_oauth.py
+++ b/src/snowflake/connector/auth_oauth.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from .auth_by_plugin import AuthByPlugin
 from .network import OAUTH_AUTHENTICATOR
 

--- a/src/snowflake/connector/auth_okta.py
+++ b/src/snowflake/connector/auth_okta.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import json
 import logging

--- a/src/snowflake/connector/auth_okta.py
+++ b/src/snowflake/connector/auth_okta.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import json
 import logging
 

--- a/src/snowflake/connector/auth_okta.py
+++ b/src/snowflake/connector/auth_okta.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import json
 import logging
 

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import json
 import logging
 import socket

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import json
 import logging
 import socket

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import json
 import logging

--- a/src/snowflake/connector/azure_util.py
+++ b/src/snowflake/connector/azure_util.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from __future__ import division
 

--- a/src/snowflake/connector/azure_util.py
+++ b/src/snowflake/connector/azure_util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from __future__ import division
 
 import json

--- a/src/snowflake/connector/backport_makefile.py
+++ b/src/snowflake/connector/backport_makefile.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """Backports the Python 3 ``socket.makefile`` method for use with anything that wants to create a "fake" socket object.
 
 Copied from:

--- a/src/snowflake/connector/backport_makefile.py
+++ b/src/snowflake/connector/backport_makefile.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 """Backports the Python 3 ``socket.makefile`` method for use with anything that wants to create a "fake" socket object.
 

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import json
 import time
 from collections import namedtuple

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import json
 import time
 from collections import namedtuple

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import json
 import time

--- a/src/snowflake/connector/compat.py
+++ b/src/snowflake/connector/compat.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import collections.abc
 import decimal
 import html

--- a/src/snowflake/connector/compat.py
+++ b/src/snowflake/connector/compat.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import collections.abc
 import decimal
 import html

--- a/src/snowflake/connector/compat.py
+++ b/src/snowflake/connector/compat.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import collections.abc
 import decimal

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import os
 import re

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import os

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import logging
 import os
 import re

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from collections import defaultdict, namedtuple
 from enum import Enum
 

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from collections import defaultdict, namedtuple
 from enum import Enum

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 from collections import defaultdict, namedtuple
 from enum import Enum
 

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import binascii
 import decimal
 import time

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import binascii
 import decimal
 import time

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import binascii
 import decimal

--- a/src/snowflake/connector/converter_issue23517.py
+++ b/src/snowflake/connector/converter_issue23517.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 from datetime import datetime, time, timedelta
 from logging import getLogger
 

--- a/src/snowflake/connector/converter_issue23517.py
+++ b/src/snowflake/connector/converter_issue23517.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from datetime import datetime, time, timedelta
 from logging import getLogger
 

--- a/src/snowflake/connector/converter_issue23517.py
+++ b/src/snowflake/connector/converter_issue23517.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from datetime import datetime, time, timedelta
 from logging import getLogger

--- a/src/snowflake/connector/converter_null.py
+++ b/src/snowflake/connector/converter_null.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from .converter import SnowflakeConverter
 
 

--- a/src/snowflake/connector/converter_null.py
+++ b/src/snowflake/connector/converter_null.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from .converter import SnowflakeConverter
 

--- a/src/snowflake/connector/converter_null.py
+++ b/src/snowflake/connector/converter_null.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from .converter import SnowflakeConverter
 
 

--- a/src/snowflake/connector/converter_snowsql.py
+++ b/src/snowflake/connector/converter_snowsql.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import time
 from datetime import date, datetime, timedelta
 from logging import getLogger

--- a/src/snowflake/connector/converter_snowsql.py
+++ b/src/snowflake/connector/converter_snowsql.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import time
 from datetime import date, datetime, timedelta
 from logging import getLogger

--- a/src/snowflake/connector/converter_snowsql.py
+++ b/src/snowflake/connector/converter_snowsql.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import time
 from datetime import date, datetime, timedelta

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "BinaryConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "BinaryConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "BinaryConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_BINARYCONVERTER_HPP
 #define PC_BINARYCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_BINARYCONVERTER_HPP
 #define PC_BINARYCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BinaryConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_BINARYCONVERTER_HPP
 #define PC_BINARYCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "BooleanConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "BooleanConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "BooleanConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_BOOLEANCONVERTER_HPP
 #define PC_BOOLEANCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_BOOLEANCONVERTER_HPP
 #define PC_BOOLEANCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/BooleanConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_BOOLEANCONVERTER_HPP
 #define PC_BOOLEANCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "CArrowChunkIterator.hpp"
 #include "SnowflakeType.hpp"
 #include "IntConverter.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "CArrowChunkIterator.hpp"
 #include "SnowflakeType.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "CArrowChunkIterator.hpp"
 #include "SnowflakeType.hpp"
 #include "IntConverter.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_ARROWCHUNKITERATOR_HPP
 #define PC_ARROWCHUNKITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_ARROWCHUNKITERATOR_HPP
 #define PC_ARROWCHUNKITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_ARROWCHUNKITERATOR_HPP
 #define PC_ARROWCHUNKITERATOR_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "CArrowIterator.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "CArrowIterator.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.cpp
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
-
 #include "CArrowIterator.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_ARROWITERATOR_HPP
 #define PC_ARROWITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_ARROWITERATOR_HPP
 #define PC_ARROWITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowIterator.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_ARROWITERATOR_HPP
 #define PC_ARROWITERATOR_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include <Python.h>
 #include <arrow/python/api.h>

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include <Python.h>
 #include <arrow/python/api.h>
 #include "CArrowTableIterator.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include <Python.h>
 #include <arrow/python/api.h>
 #include "CArrowTableIterator.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_ARROWTABLEITERATOR_HPP
 #define PC_ARROWTABLEITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_ARROWTABLEITERATOR_HPP
 #define PC_ARROWTABLEITERATOR_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_ARROWTABLEITERATOR_HPP
 #define PC_ARROWTABLEITERATOR_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "DateConverter.hpp"
 #include "Python/Helpers.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "DateConverter.hpp"
 #include "Python/Helpers.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "DateConverter.hpp"
 #include "Python/Helpers.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_DATECONVERTER_HPP
 #define PC_DATECONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_DATECONVERTER_HPP
 #define PC_DATECONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DateConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_DATECONVERTER_HPP
 #define PC_DATECONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include <Python.h>
 #include <string>

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include <Python.h>
 #include <string>
 #include "DecimalConverter.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include <Python.h>
 #include <string>
 #include "DecimalConverter.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_DECIMALCONVERTER_HPP
 #define PC_DECIMALCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_DECIMALCONVERTER_HPP
 #define PC_DECIMALCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/DecimalConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_DECIMALCONVERTER_HPP
 #define PC_DECIMALCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "FloatConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "FloatConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "FloatConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_FLOATCONVERTER_HPP
 #define PC_FLOATCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_FLOATCONVERTER_HPP
 #define PC_FLOATCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/FloatConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_FLOATCONVERTER_HPP
 #define PC_FLOATCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_ICOLUMNCONVERTER_HPP
 #define PC_ICOLUMNCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_ICOLUMNCONVERTER_HPP
 #define PC_ICOLUMNCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_ICOLUMNCONVERTER_HPP
 #define PC_ICOLUMNCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "IntConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "IntConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "IntConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_INTCONVERTER_HPP
 #define PC_INTCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_INTCONVERTER_HPP
 #define PC_INTCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IntConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_INTCONVERTER_HPP
 #define PC_INTCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "Common.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "Common.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "Common.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_PYTHON_COMMON_HPP
 #define PC_PYTHON_COMMON_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_PYTHON_COMMON_HPP
 #define PC_PYTHON_COMMON_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Common.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_PYTHON_COMMON_HPP
 #define PC_PYTHON_COMMON_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include <Python.h>
 #include "Helpers.hpp"
 #include "Common.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include <Python.h>
 #include "Helpers.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include <Python.h>
 #include "Helpers.hpp"
 #include "Common.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_PYTHON_HELPERS_HPP
 #define PC_PYTHON_HELPERS_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_PYTHON_HELPERS_HPP
 #define PC_PYTHON_HELPERS_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Python/Helpers.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_PYTHON_HELPERS_HPP
 #define PC_PYTHON_HELPERS_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "SnowflakeType.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "SnowflakeType.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "SnowflakeType.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_SNOWFLAKETYPE_HPP
 #define PC_SNOWFLAKETYPE_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_SNOWFLAKETYPE_HPP
 #define PC_SNOWFLAKETYPE_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/SnowflakeType.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_SNOWFLAKETYPE_HPP
 #define PC_SNOWFLAKETYPE_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "StringConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "StringConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "StringConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_STRINGCONVERTER_HPP
 #define PC_STRINGCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_STRINGCONVERTER_HPP
 #define PC_STRINGCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/StringConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_STRINGCONVERTER_HPP
 #define PC_STRINGCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "TimeConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "TimeConverter.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "TimeConverter.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_TIMECONVERTER_HPP
 #define PC_TIMECONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_TIMECONVERTER_HPP
 #define PC_TIMECONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_TIMECONVERTER_HPP
 #define PC_TIMECONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
-
 #include "TimeStampConverter.hpp"
 #include "Python/Helpers.hpp"
 #include "Util/time.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "TimeStampConverter.hpp"
 #include "Python/Helpers.hpp"
 #include "Util/time.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "TimeStampConverter.hpp"
 #include "Python/Helpers.hpp"

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_TIMESTAMPCONVERTER_HPP
 #define PC_TIMESTAMPCONVERTER_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_TIMESTAMPCONVERTER_HPP
 #define PC_TIMESTAMPCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/TimeStampConverter.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_TIMESTAMPCONVERTER_HPP
 #define PC_TIMESTAMPCONVERTER_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_UTIL_MACROS_HPP
 #define PC_UTIL_MACROS_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_UTIL_MACROS_HPP
 #define PC_UTIL_MACROS_HPP

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/macros.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_UTIL_MACROS_HPP
 #define PC_UTIL_MACROS_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "time.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #include "time.hpp"
 
 namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "time.hpp"
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_UTIL_TIME_HPP
 #define PC_UTIL_TIME_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_UTIL_TIME_HPP
 #define PC_UTIL_TIME_HPP
 

--- a/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/Util/time.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_UTIL_TIME_HPP
 #define PC_UTIL_TIME_HPP

--- a/src/snowflake/connector/cpp/Logging/logging.cpp
+++ b/src/snowflake/connector/cpp/Logging/logging.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #include "logging.hpp"
 #include "Python/Helpers.hpp"

--- a/src/snowflake/connector/cpp/Logging/logging.cpp
+++ b/src/snowflake/connector/cpp/Logging/logging.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #include "logging.hpp"
 #include "Python/Helpers.hpp"
 #include <cstdio>

--- a/src/snowflake/connector/cpp/Logging/logging.hpp
+++ b/src/snowflake/connector/cpp/Logging/logging.hpp
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 2013-2019 Snowflake Computing
- */
 #ifndef PC_LOGGING_HPP
 #define PC_LOGGING_HPP
 

--- a/src/snowflake/connector/cpp/Logging/logging.hpp
+++ b/src/snowflake/connector/cpp/Logging/logging.hpp
@@ -1,6 +1,6 @@
-/*
- * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
- */
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
 
 #ifndef PC_LOGGING_HPP
 #define PC_LOGGING_HPP

--- a/src/snowflake/connector/cpp/Logging/logging.hpp
+++ b/src/snowflake/connector/cpp/Logging/logging.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+ */
+
 #ifndef PC_LOGGING_HPP
 #define PC_LOGGING_HPP
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import logging
 import re
 import signal

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import re
 import signal

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import re

--- a/src/snowflake/connector/dbapi.py
+++ b/src/snowflake/connector/dbapi.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """This module implements some constructors and singletons as required by the DB API v2.0 (PEP-249)."""
 
 import datetime

--- a/src/snowflake/connector/dbapi.py
+++ b/src/snowflake/connector/dbapi.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 """This module implements some constructors and singletons as required by the DB API v2.0 (PEP-249)."""
 

--- a/src/snowflake/connector/dbapi.py
+++ b/src/snowflake/connector/dbapi.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 """This module implements some constructors and singletons as required by the DB API v2.0 (PEP-249)."""
 
 import datetime

--- a/src/snowflake/connector/description.py
+++ b/src/snowflake/connector/description.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """Various constants."""
 
 import platform

--- a/src/snowflake/connector/description.py
+++ b/src/snowflake/connector/description.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 """Various constants."""
 

--- a/src/snowflake/connector/description.py
+++ b/src/snowflake/connector/description.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 """Various constants."""
 
 import platform

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
-
 import base64
 import json
 import os

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import base64
 import json
 import os

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import base64
 import json

--- a/src/snowflake/connector/errorcode.py
+++ b/src/snowflake/connector/errorcode.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 """This module contains Snowflake error codes."""
 
 # network

--- a/src/snowflake/connector/errorcode.py
+++ b/src/snowflake/connector/errorcode.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """This module contains Snowflake error codes."""
 
 # network

--- a/src/snowflake/connector/errorcode.py
+++ b/src/snowflake/connector/errorcode.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
+
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 
 """This module contains Snowflake error codes."""

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 from logging import getLogger

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 from logging import getLogger
 from typing import Dict

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import logging
 from logging import getLogger
 from typing import Dict

--- a/src/snowflake/connector/feature.py
+++ b/src/snowflake/connector/feature.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 # Feature flags
 
 feature_use_pyopenssl = True  # use pyopenssl API or openssl command

--- a/src/snowflake/connector/feature.py
+++ b/src/snowflake/connector/feature.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 # Feature flags
 
 feature_use_pyopenssl = True  # use pyopenssl API or openssl command

--- a/src/snowflake/connector/feature.py
+++ b/src/snowflake/connector/feature.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 # Feature flags
 

--- a/src/snowflake/connector/file_compression_type.py
+++ b/src/snowflake/connector/file_compression_type.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 class FileCompressionType():
     def __init__(self):

--- a/src/snowflake/connector/file_compression_type.py
+++ b/src/snowflake/connector/file_compression_type.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 
 
 class FileCompressionType():

--- a/src/snowflake/connector/file_compression_type.py
+++ b/src/snowflake/connector/file_compression_type.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 
 class FileCompressionType():
     def __init__(self):

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import binascii
 import glob

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import binascii
 import glob
 import mimetypes

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import binascii
 import glob
 import mimetypes

--- a/src/snowflake/connector/file_util.py
+++ b/src/snowflake/connector/file_util.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from __future__ import division
 

--- a/src/snowflake/connector/file_util.py
+++ b/src/snowflake/connector/file_util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from __future__ import division
 
 import base64

--- a/src/snowflake/connector/file_util.py
+++ b/src/snowflake/connector/file_util.py
@@ -1,4 +1,3 @@
-
 from __future__ import division
 
 import base64

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import json
 import os

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import json
 import os
 from logging import getLogger

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import json
 import os
 from logging import getLogger

--- a/src/snowflake/connector/gzip_decoder.py
+++ b/src/snowflake/connector/gzip_decoder.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import io
 import subprocess

--- a/src/snowflake/connector/gzip_decoder.py
+++ b/src/snowflake/connector/gzip_decoder.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import io
 import subprocess
 import zlib

--- a/src/snowflake/connector/gzip_decoder.py
+++ b/src/snowflake/connector/gzip_decoder.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import io
 import subprocess
 import zlib

--- a/src/snowflake/connector/incident.py
+++ b/src/snowflake/connector/incident.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import platform
 from datetime import datetime

--- a/src/snowflake/connector/incident.py
+++ b/src/snowflake/connector/incident.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2019 Snowflake Computing Inc. All right reserved.
-#
-
 import logging
 import platform
 from datetime import datetime

--- a/src/snowflake/connector/incident.py
+++ b/src/snowflake/connector/incident.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import platform

--- a/src/snowflake/connector/json_result.py
+++ b/src/snowflake/connector/json_result.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from logging import getLogger
 
 from .constants import FIELD_ID_TO_NAME

--- a/src/snowflake/connector/json_result.py
+++ b/src/snowflake/connector/json_result.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from logging import getLogger
 
 from .constants import FIELD_ID_TO_NAME

--- a/src/snowflake/connector/json_result.py
+++ b/src/snowflake/connector/json_result.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from logging import getLogger
 

--- a/src/snowflake/connector/local_util.py
+++ b/src/snowflake/connector/local_util.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from __future__ import division
 
 import os

--- a/src/snowflake/connector/local_util.py
+++ b/src/snowflake/connector/local_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from __future__ import division
 
 import os

--- a/src/snowflake/connector/local_util.py
+++ b/src/snowflake/connector/local_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from __future__ import division
 

--- a/src/snowflake/connector/mixin.py
+++ b/src/snowflake/connector/mixin.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 class UnicodeMixin(object):
     """Mixin class to handle defining the proper __str__/__unicode__ methods in Python 2 or 3."""
 

--- a/src/snowflake/connector/mixin.py
+++ b/src/snowflake/connector/mixin.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 class UnicodeMixin(object):
     """Mixin class to handle defining the proper __str__/__unicode__ methods in Python 2 or 3."""

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import collections
 import contextlib
 import gzip

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import collections
 import contextlib
 import gzip

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import collections
 import contextlib

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import os
 import platform

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import os
 import platform
 import sys

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import os
 import platform
 import sys

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import codecs
 import json
 import os

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import codecs
 import json
 import os

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import codecs
 import json

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import warnings
 
 import pkg_resources

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import warnings
 

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import os
 import random

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import os
 import random
 import string

--- a/src/snowflake/connector/proxy.py
+++ b/src/snowflake/connector/proxy.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 import os
 
 

--- a/src/snowflake/connector/proxy.py
+++ b/src/snowflake/connector/proxy.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import os
 
 

--- a/src/snowflake/connector/proxy.py
+++ b/src/snowflake/connector/proxy.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import os
 

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from __future__ import division
 
 import os

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from __future__ import division
 
 import os

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from __future__ import division
 

--- a/src/snowflake/connector/rfc6960.py
+++ b/src/snowflake/connector/rfc6960.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 #
 # X.509 Internet Public Key Infrastructure Online Certificate Status
 # Protocol - OCSP
 #
 # ASN.1 source from
 # https://tools.ietf.org/html/rfc6960
+
 from pyasn1.type import namedtype, namedval, tag, univ, useful
 from pyasn1_modules import rfc2459
 

--- a/src/snowflake/connector/rfc6960.py
+++ b/src/snowflake/connector/rfc6960.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 #
 # X.509 Internet Public Key Infrastructure Online Certificate Status

--- a/src/snowflake/connector/rfc6960.py
+++ b/src/snowflake/connector/rfc6960.py
@@ -5,7 +5,6 @@
 #
 # ASN.1 source from
 # https://tools.ietf.org/html/rfc6960
-#
 from pyasn1.type import namedtype, namedval, tag, univ, useful
 from pyasn1_modules import rfc2459
 

--- a/src/snowflake/connector/s3_util.py
+++ b/src/snowflake/connector/s3_util.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from __future__ import division
 

--- a/src/snowflake/connector/s3_util.py
+++ b/src/snowflake/connector/s3_util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from __future__ import division
 
 import logging

--- a/src/snowflake/connector/secret_detector.py
+++ b/src/snowflake/connector/secret_detector.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 """The secret detector detects sensitive information.
 

--- a/src/snowflake/connector/secret_detector.py
+++ b/src/snowflake/connector/secret_detector.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """The secret detector detects sensitive information.
 
 It masks secrets that might be leaked from two potential avenues

--- a/src/snowflake/connector/secret_detector.py
+++ b/src/snowflake/connector/secret_detector.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
-#
 """The secret detector detects sensitive information.
 
 It masks secrets that might be leaked from two potential avenues

--- a/src/snowflake/connector/sfbinaryformat.py
+++ b/src/snowflake/connector/sfbinaryformat.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from base64 import b16decode, b16encode, standard_b64encode
 
 from .errors import InternalError

--- a/src/snowflake/connector/sfbinaryformat.py
+++ b/src/snowflake/connector/sfbinaryformat.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 from base64 import b16decode, b16encode, standard_b64encode
 
 from .errors import InternalError

--- a/src/snowflake/connector/sfbinaryformat.py
+++ b/src/snowflake/connector/sfbinaryformat.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from base64 import b16decode, b16encode, standard_b64encode
 

--- a/src/snowflake/connector/sfdatetime.py
+++ b/src/snowflake/connector/sfdatetime.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import time
 from collections import namedtuple
 from datetime import date, datetime, timedelta

--- a/src/snowflake/connector/sfdatetime.py
+++ b/src/snowflake/connector/sfdatetime.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import time
 from collections import namedtuple

--- a/src/snowflake/connector/sfdatetime.py
+++ b/src/snowflake/connector/sfdatetime.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import time
 from collections import namedtuple
 from datetime import date, datetime, timedelta

--- a/src/snowflake/connector/snow_logging.py
+++ b/src/snowflake/connector/snow_logging.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import warnings

--- a/src/snowflake/connector/snow_logging.py
+++ b/src/snowflake/connector/snow_logging.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import warnings
 from typing import Optional

--- a/src/snowflake/connector/sqlstate.py
+++ b/src/snowflake/connector/sqlstate.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 
 SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED = "08001"
 SQLSTATE_CONNECTION_ALREADY_EXISTS = "08002"

--- a/src/snowflake/connector/sqlstate.py
+++ b/src/snowflake/connector/sqlstate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 
 SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED = "08001"
 SQLSTATE_CONNECTION_ALREADY_EXISTS = "08002"

--- a/src/snowflake/connector/sqlstate.py
+++ b/src/snowflake/connector/sqlstate.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED = "08001"
 SQLSTATE_CONNECTION_ALREADY_EXISTS = "08002"

--- a/src/snowflake/connector/ssd_internal_keys.py
+++ b/src/snowflake/connector/ssd_internal_keys.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from binascii import unhexlify
 
 # key version

--- a/src/snowflake/connector/ssd_internal_keys.py
+++ b/src/snowflake/connector/ssd_internal_keys.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
-
 from binascii import unhexlify
 
 # key version

--- a/src/snowflake/connector/ssd_internal_keys.py
+++ b/src/snowflake/connector/ssd_internal_keys.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from binascii import unhexlify
 

--- a/src/snowflake/connector/ssl_wrap_socket.py
+++ b/src/snowflake/connector/ssl_wrap_socket.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 #
 # SSL wrap socket for PyOpenSSL.
 # Mostly copied from
@@ -6,6 +8,7 @@
 # https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
 #
 # and added OCSP validator on the top.
+
 import logging
 import ssl
 import sys

--- a/src/snowflake/connector/ssl_wrap_socket.py
+++ b/src/snowflake/connector/ssl_wrap_socket.py
@@ -6,7 +6,6 @@
 # https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
 #
 # and added OCSP validator on the top.
-#
 import logging
 import ssl
 import sys

--- a/src/snowflake/connector/ssl_wrap_socket.py
+++ b/src/snowflake/connector/ssl_wrap_socket.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 #
 # SSL wrap socket for PyOpenSSL.

--- a/src/snowflake/connector/ssl_wrap_util.py
+++ b/src/snowflake/connector/ssl_wrap_util.py
@@ -1,4 +1,6 @@
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 """SSL wrap util for PyOpenSSL.
 

--- a/src/snowflake/connector/ssl_wrap_util.py
+++ b/src/snowflake/connector/ssl_wrap_util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 """SSL wrap util for PyOpenSSL.
 
 Copied from: https://github.com/shazow/urllib3/tree/master/urllib3/util to support ssl_wrap_socket.

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 from threading import Lock

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2018-2019 Snowflake Computing Inc. All right reserved.
-#
 import logging
 from threading import Lock
 

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 from threading import Lock
 

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import datetime
 import json

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import datetime
 import json
 import logging

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2018-2019 Snowflake Computing Inc. All right reserved.
-#
 import datetime
 import json
 import logging

--- a/src/snowflake/connector/test_util.py
+++ b/src/snowflake/connector/test_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import os

--- a/src/snowflake/connector/test_util.py
+++ b/src/snowflake/connector/test_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import os
 

--- a/src/snowflake/connector/test_util.py
+++ b/src/snowflake/connector/test_util.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
-#
 import logging
 import os
 

--- a/src/snowflake/connector/time_util.py
+++ b/src/snowflake/connector/time_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import random
 import time

--- a/src/snowflake/connector/time_util.py
+++ b/src/snowflake/connector/time_util.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import random
 import time
 from logging import getLogger

--- a/src/snowflake/connector/time_util.py
+++ b/src/snowflake/connector/time_util.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2018-2019 Snowflake Computing Inc. All right reserved.
-#
 import random
 import time
 from logging import getLogger

--- a/src/snowflake/connector/tool/__init__.py
+++ b/src/snowflake/connector/tool/__init__.py
@@ -1,5 +1,3 @@
 #
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
-
-# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.

--- a/src/snowflake/connector/tool/__init__.py
+++ b/src/snowflake/connector/tool/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.

--- a/src/snowflake/connector/tool/__init__.py
+++ b/src/snowflake/connector/tool/__init__.py
@@ -1,1 +1,5 @@
+#
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
+
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.

--- a/src/snowflake/connector/tool/dump_certs.py
+++ b/src/snowflake/connector/tool/dump_certs.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import os
 import sys
 from os import path

--- a/src/snowflake/connector/tool/dump_certs.py
+++ b/src/snowflake/connector/tool/dump_certs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import os
 import sys

--- a/src/snowflake/connector/tool/dump_certs.py
+++ b/src/snowflake/connector/tool/dump_certs.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import os
 import sys
 from os import path

--- a/src/snowflake/connector/tool/dump_ocsp_response.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import time
 from os import path
 from time import gmtime, strftime

--- a/src/snowflake/connector/tool/dump_ocsp_response.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import time
 from os import path
 from time import gmtime, strftime

--- a/src/snowflake/connector/tool/dump_ocsp_response.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import time
 from os import path

--- a/src/snowflake/connector/tool/dump_ocsp_response_cache.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response_cache.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import json
 import sys

--- a/src/snowflake/connector/tool/dump_ocsp_response_cache.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response_cache.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import json
 import sys
 from datetime import datetime

--- a/src/snowflake/connector/tool/dump_ocsp_response_cache.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response_cache.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import json
 import sys
 from datetime import datetime

--- a/src/snowflake/connector/tool/probe_connection.py
+++ b/src/snowflake/connector/tool/probe_connection.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 from socket import gaierror, gethostbyname_ex
 

--- a/src/snowflake/connector/tool/probe_connection.py
+++ b/src/snowflake/connector/tool/probe_connection.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 from socket import gaierror, gethostbyname_ex
 
 from asn1crypto import ocsp

--- a/src/snowflake/connector/tool/probe_connection.py
+++ b/src/snowflake/connector/tool/probe_connection.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-#
-
 from socket import gaierror, gethostbyname_ex
 
 from asn1crypto import ocsp

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
-#
 import logging
 import re
 from typing import Optional

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+
 import logging
 import re
 from typing import Optional

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
 
 import logging
 import re


### PR DESCRIPTION
This PR introduces precommit hooks to require copyright notices in each cpp, hpp, py and pyx files.

This will also help us update them easily in the future, procedure description: https://github.com/Lucas-C/pre-commit-hooks#removing-old-license-and-replacing-it-with-a-new-one