### PR TITLE
SNOW-197585 aws glue options

### DIFF
--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -35,16 +35,11 @@ from .network import (
     PYTHON_CONNECTOR_USER_AGENT,
     ReauthenticationRequest,
 )
+from .options import installed_keyring, keyring
 from .sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 from .version import VERSION
 
 logger = logging.getLogger(__name__)
-
-try:
-    import keyring
-except ImportError as ie:
-    keyring = None
-    logger.debug('Failed to import keyring module. err=[%s]', ie)
 
 # Cache directory
 CACHE_ROOT_DIR = getenv('SF_TEMPORARY_CREDENTIAL_CACHE_DIR') or \
@@ -370,7 +365,7 @@ class Auth(object):
         if session_parameters.get(PARAMETER_CLIENT_STORE_TEMPORARY_CREDENTIAL, False):
             id_token = None
             if IS_MACOS or IS_WINDOWS:
-                if not keyring:
+                if not installed_keyring:
                     # we will leave the exception for write_temporary_credential function to raise
                     return
                 new_target = convert_target(host, user)
@@ -393,7 +388,7 @@ def write_temporary_credential(host, account, user, id_token, store_temporary_cr
         logger.debug("no ID token is given when try to store temporary credential")
         return
     if IS_MACOS or IS_WINDOWS:
-        if not keyring:
+        if not installed_keyring:
             logger.debug("Dependency 'keyring' is not installed, cannot cache id token. You might experience "
                          "multiple authentication pop ups while using ExternalBrowser Authenticator. To avoid "
                          "this please install keyring module using the following command : pip install "
@@ -496,7 +491,7 @@ def unlock_temporary_credential_file():
 
 
 def delete_temporary_credential(host, user, store_temporary_credential=False):
-    if (IS_MACOS or IS_WINDOWS) and keyring:
+    if (IS_MACOS or IS_WINDOWS) and installed_keyring:
         new_target = convert_target(host, user)
         try:
             keyring.delete_password(new_target, user.upper())

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -67,7 +67,6 @@ def _import_or_missing_pandas_option() -> Tuple[ModuleLikeObject, ModuleLikeObje
         pandas = importlib.import_module('pandas')  # NOQA
         # since we enable relative imports without dots this import gives us an issues when ran from test directory
         from pandas import DataFrame  # NOQA
-        import pyarrow  # NOQA
         pyarrow = importlib.import_module('pyarrow')  # NOQA
         # Check whether we have the currently supported pyarrow installed
         installed_packages = pkg_resources.working_set.by_key

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -71,7 +71,6 @@ def _import_or_missing_pandas_option() -> Tuple[ModuleLikeObject, ModuleLikeObje
         pyarrow = importlib.import_module('pyarrow')  # NOQA
         # Check whether we have the currently supported pyarrow installed
         installed_packages = pkg_resources.working_set.by_key
-        print(installed_packages)
         if all(k in installed_packages for k in ("snowflake-connector-python", "pyarrow")):
             _pandas_extras = installed_packages['snowflake-connector-python']._dep_map['pandas']  # NOQA
             _expected_pyarrow_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -2,60 +2,103 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 
+import importlib
 import warnings
 from logging import getLogger
+from types import ModuleType
+from typing import Tuple, Union
 
 import pkg_resources
 
 from .errors import MissingDependencyError
 
-# Flags to see whether optional dependencies were installed
-installed_pandas = False
-installed_keyring = False
-
 logger = getLogger(__name__)
+
+"""This module helps to manage optional dependencies.
+
+It implements MissingOptionalDependency as a base class. If a module is unavailable an instance of this will be
+returned. These derived classes can be seen in this file pre-defined. The point of these classes is that if someone
+tries to use pyarrow code then by importing pyarrow from this module if they did pyarrow.xxx then that would raise
+a MissingDependencyError.
+"""
+
+
+class MissingOptionalDependency(object):
+    """A class to replace missing dependencies.
+
+    The only thing this class is supposed to do is raise a MissingDependencyError when __getattr__ is called.
+    This will be triggered whenever module.member is going to be called.
+    """
+
+    _dep_name = "not set"
+
+    def __getattr__(self, item):
+        raise MissingDependencyError(self._dep_name)
+
+
+class MissingPandas(MissingOptionalDependency):
+    """The class is specifically for pandas optional dependency."""
+    _dep_name = "pandas"
+
+
+class MissingKeyring(MissingOptionalDependency):
+    """The class is specifically for sso optional dependency."""
+    _dep_name = "keyring"
+
+
+ModuleLikeObject = Union[ModuleType, MissingOptionalDependency]
 
 
 def warn_incompatible_dep(dep_name: str,
                           installed_ver: str,
                           expected_ver: 'pkg_resources.Requirement') -> None:
-    warnings.warn(
-        "You have an incompatible version of '{}' installed, please install a version that "
-        "adheres to: '{}'".format(dep_name, expected_ver),
-        stacklevel=2)
+    warnings.warn("You have an incompatible version of '{}' installed ({}), please install a version that "
+                  "adheres to: '{}'".format(dep_name, installed_ver, expected_ver),
+                  stacklevel=2)
 
 
-class MissingPandas(object):
+def _import_or_missing_pandas_option() -> Tuple[ModuleLikeObject, ModuleLikeObject, bool]:
+    """This function tries importing the following packages: pandas, pyarrow.
 
-    def __getattr__(self, item):
-        raise MissingDependencyError('pandas')
+    If available it returns pandas and pyarrow packages with a flag of whether they were imported.
+    It also warns users if they have an unsupported pyarrow version installed if possible.
+    """
+    try:
+        pandas = importlib.import_module('pandas')  # NOQA
+        # since we enable relative imports without dots this import gives us an issues when ran from test directory
+        from pandas import DataFrame  # NOQA
+        import pyarrow  # NOQA
+        pyarrow = importlib.import_module('pyarrow')  # NOQA
+        # Check whether we have the currently supported pyarrow installed
+        installed_packages = pkg_resources.working_set.by_key
+        print(installed_packages)
+        if all(k in installed_packages for k in ("snowflake-connector-python", "pyarrow")):
+            _pandas_extras = installed_packages['snowflake-connector-python']._dep_map['pandas']  # NOQA
+            _expected_pyarrow_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]
+            _installed_pyarrow_version = installed_packages['pyarrow']
+            if _installed_pyarrow_version and _installed_pyarrow_version.version not in _expected_pyarrow_version:
+                warn_incompatible_dep('pyarrow', _installed_pyarrow_version.version, _expected_pyarrow_version)
+
+        else:
+            logger.info("Cannot determine if compatible pyarrow is installed because of missing package(s) from "
+                        "{}".format(installed_packages.keys()))
+        return pandas, pyarrow, True
+    except ImportError:
+        return MissingPandas(), MissingPandas(), False
 
 
-try:
-    import pandas  # NOQA
-    # since we enable relative imports without dots this import gives us an issues when ran from test directory
-    from pandas import DataFrame  # NOQA
-    import pyarrow  # NOQA
+def _import_or_missing_keyring_option() -> Tuple[ModuleLikeObject, bool]:
+    """This function tries importing the following packages: keyring.
 
-    installed_pandas = True
-    # Make sure we have the right pyarrow installed
-    installed_packages = pkg_resources.working_set.by_key
-    if all(k in installed_packages for k in ("snowflake-connector-python", "pyarrow")):
-        _pandas_extras = installed_packages['snowflake-connector-python']._dep_map['pandas']
-        _expected_pyarrow_version = [dep for dep in _pandas_extras if dep.name == 'pyarrow'][0]
-        _installed_pyarrow_version = installed_packages['pyarrow']
-        if _installed_pyarrow_version and _installed_pyarrow_version.version not in _expected_pyarrow_version:
-            warn_incompatible_dep('pyarrow', _installed_pyarrow_version.version, _expected_pyarrow_version)
-    else:
-        logger.info("Cannot determine if compatible pyarrow is installed because of missing package(s) from "
-                    "{}".format(installed_packages.keys()))
-except ImportError:
-    pandas = MissingPandas()
-    pyarrow = MissingPandas()
+    If available it returns keyring package with a flag of whether it was imported.
+    """
+    try:
+        keyring = importlib.import_module('keyring')  # NOQA
+        return keyring, True
+    except ImportError:
+        return MissingKeyring(), False
 
-try:
-    import keyring  # NOQA
 
-    installed_keyring = True
-except ImportError:
-    keyring = None
+# Create actual constants to be imported from this file
+pandas, pyarrow, installed_pandas = _import_or_missing_pandas_option()
+keyring, installed_keyring = _import_or_missing_keyring_option()

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -21,7 +21,7 @@ def warn_incompatible_dep(dep_name: str,
                           expected_ver: 'pkg_resources.Requirement') -> None:
     warnings.warn(
         "You have an incompatible version of '{}' installed, please install a version that "
-        "adheres to: '{}'".format(dep_name, _expected_pyarrow_version),
+        "adheres to: '{}'".format(dep_name, expected_ver),
         stacklevel=2)
 
 

--- a/test/pandas/test_unit_options.py
+++ b/test/pandas/test_unit_options.py
@@ -16,5 +16,5 @@ def test_pandas_option_reporting(caplog):
         from snowflake.connector.options import pandas, pyarrow, MissingPandas
         assert not isinstance(pandas, MissingPandas)
         assert not isinstance(pyarrow, MissingPandas)
-        assert any(r.startswith("Cannot determine if compatible pyarrow is installed because of missing package(s) "
-                                 "from dict_keys([") for r in caplog.messages)
+        assert any([r.startswith("Cannot determine if compatible pyarrow is installed because of missing package(s) "
+                                 "from dict_keys([") for r in caplog.messages])

--- a/test/pandas/test_unit_options.py
+++ b/test/pandas/test_unit_options.py
@@ -1,0 +1,20 @@
+from copy import deepcopy
+
+import mock
+from pkg_resources import working_set
+
+
+def test_pandas_option_reporting(caplog):
+    """Tests for the weird case where someone can import pyarrow, but setuptools doesn't know about it.
+
+    This issue was brought to attention in: https://github.com/snowflakedb/snowflake-connector-python/issues/412
+    """
+    modified_by_key = deepcopy(working_set.by_key)
+    modified_by_key.pop('snowflake-connector-python')
+    modified_by_key.pop('pyarrow')
+    with mock.patch.object(working_set, 'by_key', modified_by_key):
+        from snowflake.connector.options import pandas, pyarrow, MissingPandas
+        assert not isinstance(pandas, MissingPandas)
+        assert not isinstance(pyarrow, MissingPandas)
+        assert any(r.startswith("Cannot determine if compatible pyarrow is installed because of missing package(s) "
+                                 "from dict_keys([") for r in caplog.messages)

--- a/test/pandas/test_unit_options.py
+++ b/test/pandas/test_unit_options.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 import mock
 from pkg_resources import working_set
 
+from snowflake.connector.options import MissingPandas, _import_or_missing_pandas_option  # NOQA
+
 
 def test_pandas_option_reporting(caplog):
     """Tests for the weird case where someone can import pyarrow, but setuptools doesn't know about it.
@@ -13,8 +15,9 @@ def test_pandas_option_reporting(caplog):
     modified_by_key.pop('snowflake-connector-python')
     modified_by_key.pop('pyarrow')
     with mock.patch.object(working_set, 'by_key', modified_by_key):
-        from snowflake.connector.options import pandas, pyarrow, MissingPandas
+        pandas, pyarrow, installed_pandas = _import_or_missing_pandas_option()
+        assert installed_pandas
         assert not isinstance(pandas, MissingPandas)
         assert not isinstance(pyarrow, MissingPandas)
-        assert any([r.startswith("Cannot determine if compatible pyarrow is installed because of missing package(s) "
-                                 "from dict_keys([") for r in caplog.messages])
+        assert ("Cannot determine if compatible pyarrow is installed because of missing package(s) "
+                "from dict_keys([") in caplog.text

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,9 @@ passenv =
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
 commands =
-    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml --ignore=test/pandas --ignore=test/sso {posargs} test
-    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/pandas
-    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/sso
+    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml --ignore=test/pandas --ignore=test/sso {posargs:test}
+    pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs:test/pandas}
+    sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs:test/sso}
     extras: python test/extras/run.py
 
 [testenv:coverage]


### PR DESCRIPTION
SNOW-197585 and #412 
Fixes an issue where on AWS Glue `setuptools` doesn't know what packages are installed.