### PR TITLE
SNOW-135600 added link to GH issue to Jiras created for them

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -23,7 +23,7 @@ jobs:
           AREA: "Data Platform: Ecosystem"
           ASSIGNEE: triage-data_platform_drivers_cli-dl
           SUMMARY: "{{ event.issue.title }}"
-          DESCRIPTION: "{{ event.issue.body }}\n\n_Created from GitHub Action_"
+          DESCRIPTION: "{{ event.issue.body }}\n\n_Created from GitHub Action_ for {{ event.issue.html_url }}"
       - name: update issue
         uses: ./.github/actions/gajira-issue-update
         env:


### PR DESCRIPTION
It's hard sometimes to find what issue a ticket is related to.
This change would add links to any Jiras created by GH actions.

`event.issue.html_url` seems to be the correct thing according to https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-when-someone-edits-an-issue