### PR TITLE
SNOW-197039 reverting from expanding list to code block

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -11,13 +11,9 @@ Please answer these questions before submitting your issue. Thanks!
 
 3. What are the component versions in the environment (`pip freeze`)?
 
-   <details>
-   <summary>Click to expand</summary>
-
-   Insert pip freeze's output here.
-
-   </details>
-
+```
+Insert pip freeze's output here.
+```
 
 4. What did you do?
 If possible, provide a recipe for reproducing the error.


### PR DESCRIPTION
Unfortunately what I was going for doesn't work out because the lines to be considered part of the expanding list need to indented and nobody would want to indent those lines by hand, so I would like to revert back to using code blocks.

Current template: 
https://github.com/snowflakedb/snowflake-connector-python/issues/412