### PR TITLE
SNOW-199427 pin pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ setup(
         ],
         "pandas": pandas_requirements,
         "development": [
-            'pytest',
+            'pytest<6.1.0',
             'pytest-cov',
             'pytest-rerunfailures',
             'pytest-timeout',


### PR DESCRIPTION
The new `pytest` 6.1.0 release breaks support for its `pytest-rerunfailures` plugin, this PR pins us to use the not newest release of `pytest`.