### PR TITLE
SNOW-135960: add basic tests for lambda

### DIFF
--- a/test/lambda/test_basic_query.py
+++ b/test/lambda/test_basic_query.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+#
+
+
+def test_connection(conn_cnx):
+    """Test basic connection."""
+    with conn_cnx() as cnx:
+        cur = cnx.cursor()
+        result = cur.execute("select 1;").fetchall()
+        assert result == [(1,)]
+
+
+def test_large_resultset(conn_cnx):
+    """Test large resultset."""
+    with conn_cnx() as cnx:
+        cur = cnx.cursor()
+        result = cur.execute("select seq8(), randstr(1000, random()) from table(generator(rowcount=>10000));").fetchall()
+        assert len(result) == 10000

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ extras =
     development
     pandas: pandas
     sso: secure-local-storage
+    lambda: lambda
 deps =
     pip >= 19.3.1
 install_command = python -m pip install -U {opts} {packages}
@@ -47,9 +48,10 @@ passenv =
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
 commands =
-    !pandas-!sso-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml --ignore=test/pandas --ignore=test/sso {posargs} test
+    !pandas-!sso-!lambda-!extras: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml --ignore=test/pandas --ignore=test/sso --ignore=test/lambda {posargs} test
     pandas: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/pandas
     sso: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/sso
+    lambda: pytest {env:SNOWFLAKE_PYTEST_OPTS:} --cov "snowflake.connector" --junitxml {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:unknown}.xml {posargs} test/lambda
     extras: python test/extras/run.py
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ extras =
     development
     pandas: pandas
     sso: secure-local-storage
-    lambda: lambda
 deps =
     pip >= 19.3.1
 install_command = python -m pip install -U {opts} {packages}


### PR DESCRIPTION
SNOW-135960: Adding a few basic tests to test python-connector in AWS Lambda. 
* New tests are placed in lambda folder and plan is to run them only in a lambda function using "tox -e py{python-version}{-lambda}"