### PR TITLE
Test PR 362

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -178,7 +178,7 @@ def pd_writer(table: pandas.io.sql.SQLTable,
 
             sf_connector_version_df = pd.DataFrame([('snowflake-connector-python', '1.0')], columns=['NAME', 'NEWEST_VERSION'])
             sf_connector_version_df.to_sql('driver_versions', engine, index=False, method=pd_writer)
-            
+
             # to use quote_identifiers=False
             from functools import partial
             sf_connector_version_df.to_sql(

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -168,7 +168,8 @@ def write_pandas(conn: 'SnowflakeConnection',
 def pd_writer(table: pandas.io.sql.SQLTable,
               conn: Union['sqlalchemy.engine.Engine', 'sqlalchemy.engine.Connection'],
               keys: Iterable,
-              data_iter: Iterable) -> None:
+              data_iter: Iterable,
+              quote_identifiers: bool = True) -> None:
     """This is a wrapper on top of write_pandas to make it compatible with to_sql method in pandas.
 
         Example usage:
@@ -177,12 +178,19 @@ def pd_writer(table: pandas.io.sql.SQLTable,
 
             sf_connector_version_df = pd.DataFrame([('snowflake-connector-python', '1.0')], columns=['NAME', 'NEWEST_VERSION'])
             sf_connector_version_df.to_sql('driver_versions', engine, index=False, method=pd_writer)
+            
+            # to use quote_identifiers=False
+            from functools import partial
+            sf_connector_version_df.to_sql(
+                'driver_versions', engine, index=False, method=partial(pd_writer, quote_identifiers=False))
 
     Args:
         table: Pandas package's table object.
         conn: SQLAlchemy engine object to talk to Snowflake.
         keys: Column names that we are trying to insert.
         data_iter: Iterator over the rows.
+        quote_identifiers: if True (default), quote identifiers passed to Snowflake. If False, identifiers are not
+            quoted (and typically coerced to uppercase by Snowflake)
     """
     sf_connection = conn.connection.connection
     df = pandas.DataFrame(data_iter, columns=keys)
@@ -190,4 +198,5 @@ def pd_writer(table: pandas.io.sql.SQLTable,
                  df=df,
                  # Note: Our sqlalchemy connector creates tables case insensitively
                  table_name=table.name.upper(),
-                 schema=table.schema)
+                 schema=table.schema,
+                 quote_identifiers=quote_identifiers)

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -41,7 +41,7 @@ def write_pandas(conn: 'SnowflakeConnection',
                  compression: str = 'gzip',
                  on_error: str = 'abort_statement',
                  parallel: int = 4,
-                 quote_identifiers: bool = False
+                 quote_identifiers: bool = True
                  ) -> Tuple[bool, int, int,
                             Sequence[Tuple[str, str, int, int, int, int, Optional[str], Optional[int],
                                            Optional[int], Optional[str]]]]:
@@ -74,9 +74,9 @@ def write_pandas(conn: 'SnowflakeConnection',
             (Default value = 'abort_statement').
         parallel: Number of threads to be used when uploading chunks, default follows documentation at:
             https://docs.snowflake.com/en/sql-reference/sql/put.html#optional-parameters (Default value = 4).
-        quote_identifiers: By default, identifiers are passed on to Snowflake without quoting. I.e. identifiers
-            will be coerced to uppercase by Snowflake. If set to True, identifiers, specifically database, schema,
-            table and column names (from df.columns) will be quoted. (Default value = False)
+        quote_identifiers: By default, identifiers, specifically database, schema, table and column names
+            (from df.columns) will be quoted. If set to False, identifiers are passed on to Snowflake without quoting.
+            I.e. identifiers will be coerced to uppercase by Snowflake.  (Default value = True)
 
     Returns:
         Returns the COPY INTO command's results to verify ingestion in the form of a tuple of whether all chunks were

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -32,7 +32,7 @@ sf_connector_version_df = pandas.DataFrame(sf_connector_version_data, columns=['
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
 # Note: since the file will to small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],
                       compression: str,
                       parallel: int,
@@ -50,7 +50,8 @@ def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', N
                                                       table_name,
                                                       compression=compression,
                                                       parallel=parallel,
-                                                      chunk_size=chunk_size)
+                                                      chunk_size=chunk_size,
+                                                      quote_identifiers=True)
             if num_of_chunks == 1:
                 # Note: since we used one chunk order is conserved
                 assert (cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall() ==
@@ -69,7 +70,110 @@ def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', N
             cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
 
 
+@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
+@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
+# Note: since the file will to small to chunk, this is only testing the put command's syntax
+@pytest.mark.parametrize('parallel', [4, 99])
+def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+                      db_parameters: Dict[str, str],
+                      compression: str,
+                      parallel: int,
+                      chunk_size: int):
+    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
+
+    with conn_cnx(user=db_parameters['user'],
+                  account=db_parameters['account'],
+                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
+        table_name = 'driver_versions'
+        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
+        # not quote them when creating table
+        cnx.execute_string('CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name))
+        try:
+            success, nchunks, nrows, _ = write_pandas(cnx,
+                                                      sf_connector_version_df,
+                                                      table_name,
+                                                      compression=compression,
+                                                      parallel=parallel,
+                                                      chunk_size=chunk_size)
+            if num_of_chunks == 1:
+                # Note: since we used one chunk order is conserved
+                assert (cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall() ==
+                        sf_connector_version_data)
+            else:
+                # Note: since we used one chunk order is NOT conserved
+                assert (set(cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall()) ==
+                        set(sf_connector_version_data))
+            # Make sure all files were loaded and no error occurred
+            assert success
+            # Make sure overall as many rows were ingested as we tried to insert
+            assert nrows == len(sf_connector_version_data)
+            # Make sure we uploaded in as many chunk as we wanted to
+            assert nchunks == num_of_chunks
+        finally:
+            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+
+
+@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
+@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
+# Note: since the file will to small to chunk, this is only testing the put command's syntax
+@pytest.mark.parametrize('parallel', [4, 99])
+def test_write_pandas_default_cols(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+                      db_parameters: Dict[str, str],
+                      compression: str,
+                      parallel: int,
+                      chunk_size: int):
+    from snowflake.connector import DictCursor
+    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
+
+    with conn_cnx(user=db_parameters['user'],
+                  account=db_parameters['account'],
+                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
+        table_name = 'driver_versions'
+        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
+        # not quote them when creating table
+        cnx.execute_string("""CREATE OR REPLACE TABLE {} (
+                              id varchar(36) default uuid_string(),
+                              name STRING, newest_version STRING,
+                              ts timestamp_ltz default current_timestamp)""".format(table_name))
+        try:
+            success, nchunks, nrows, _ = write_pandas(cnx,
+                                                      sf_connector_version_df,
+                                                      table_name,
+                                                      compression=compression,
+                                                      parallel=parallel,
+                                                      chunk_size=chunk_size)
+            result = cnx.cursor(DictCursor).execute('SELECT * FROM {}'.format(table_name)).fetchall()
+            for row in result:
+                assert row['ID'] is not None
+                assert row['TS'] is not None
+            # Make sure all files were loaded and no error occurred
+            assert success
+            # Make sure overall as many rows were ingested as we tried to insert
+            assert nrows == len(sf_connector_version_data)
+            # Make sure we uploaded in as many chunk as we wanted to
+            assert nchunks == num_of_chunks
+        finally:
+            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+
+
 def test_location_building_db_schema(conn_cnx):
+    """This tests that write_pandas constructs location correctly with database, schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'database.schema.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
+                                                      database='database', schema='schema')
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_db_schema_quoted_identifiers(conn_cnx):
     """This tests that write_pandas constructs location correctly with database, schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -82,11 +186,28 @@ def test_location_building_db_schema(conn_cnx):
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema')
+                                                      database='database', schema='schema', quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
 def test_location_building_schema(conn_cnx):
+    """This tests that write_pandas constructs location correctly with schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'schema.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
+                                                      schema='schema')
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_schema_quoted_identifier(conn_cnx):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -99,11 +220,27 @@ def test_location_building_schema(conn_cnx):
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema')
+                                                      schema='schema', quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
 def test_location_building(conn_cnx):
+    """This tests that write_pandas constructs location correctly with schema and table name."""
+    from snowflake.connector.cursor import SnowflakeCursor
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        def mocked_execute(*args, **kwargs):
+            if len(args) >= 1 and args[0].startswith('COPY INTO'):
+                location = args[0].split(' ')[2]
+                assert location == 'teble.table'
+            cur = SnowflakeCursor(cnx)
+            cur._result = iter([])
+            return cur
+        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
+            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+
+
+def test_location_building_quoted_identifiers(conn_cnx):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
@@ -115,5 +252,5 @@ def test_location_building(conn_cnx):
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table", quote_identifiers=True)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -13,6 +13,7 @@ import pandas
 import pytest
 
 from snowflake.connector.pandas_tools import write_pandas
+from snowflake.connector.pandas_tools import pd_writer
 
 MYPY = False
 if MYPY:  # from typing import TYPE_CHECKING once 3.5 is deprecated
@@ -173,3 +174,51 @@ def test_location_building(conn_cnx, quote_identifiers: bool):
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table",
                                                       quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
+            
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_pandas_to_sql(conn_cnx, db_parameters: Dict[str, str], quote_identifiers: bool):
+    try:
+        from sqlalchemy import create_engine
+        from snowflake.sqlalchemy import URL
+    except ImportError:
+        from warnings import warn
+        warn("Not testing pandas.dataframe.to_sql because snowflake-sqlalchemy is not installed", ImportWarning)
+        # User does not have snowflake-sqlalchemy installed
+        return
+    table_name = 'driver_versions'
+    select_sql = None  # forward declaration
+    drop_sql = None  # forward declaration
+
+    engine = create_engine(URL(
+        account=db_parameters['account'],
+        user=db_parameters['user'],
+        password=db_parameters['password'],
+        database=db_parameters['database'],
+        schema=db_parameters['schema'],
+        warehouse=db_parameters['warehouse']
+    ))
+
+    connection = engine.connect()
+
+    try:
+        if quote_identifiers:
+            select_sql = 'SELECT * FROM "{}"'.format(table_name.upper())
+            drop_sql = 'DROP TABLE IF EXISTS "{}"'.format(table_name.upper())
+
+            # SQL alchemy connector creates table names case insensitively, even though write_pandas,
+            # by default, quotes everything
+            sf_connector_version_df.to_sql(name=table_name.upper(), con=engine, if_exists='replace', index=False)
+            results = [tuple(r) for r in connection.execute(select_sql).fetchall()]
+            assert (set(results) == set(sf_connector_version_data))
+        else:
+            select_sql = 'SELECT * FROM {}'.format(table_name)
+            drop_sql = 'DROP TABLE IF EXISTS {}'.format(table_name)
+
+            from functools import partial
+            sf_connector_version_df.to_sql(name=table_name, con=engine, if_exists='replace', index=False,
+                    method=partial(pd_writer, quote_identifiers=quote_identifiers))
+            results = [tuple(r) for r in connection.execute(select_sql).fetchall()]
+            assert (set(results) == set(sf_connector_version_data))
+    finally:
+        engine.execute(drop_sql)
+        engine.dispose()

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -72,7 +72,7 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
 
 @pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will to small to chunk, this is only testing the put command's syntax
+# Note: since the file will be too small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
 def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],

--- a/test/pandas/test_pandas_tools.py
+++ b/test/pandas/test_pandas_tools.py
@@ -5,6 +5,7 @@
 #
 
 import math
+from datetime import datetime
 from typing import Callable, Dict, Generator
 
 import mock
@@ -32,18 +33,48 @@ sf_connector_version_df = pandas.DataFrame(sf_connector_version_data, columns=['
 @pytest.mark.parametrize('compression', ['gzip', 'snappy'])
 # Note: since the file will to small to chunk, this is only testing the put command's syntax
 @pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+@pytest.mark.parametrize('create_default_columns', [True, False])
+def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
                       db_parameters: Dict[str, str],
                       compression: str,
                       parallel: int,
-                      chunk_size: int):
+                      chunk_size: int,
+                      quote_identifiers: bool,
+                      create_default_columns: bool):
     num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
 
     with conn_cnx(user=db_parameters['user'],
                   account=db_parameters['account'],
                   password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
         table_name = 'driver_versions'
-        cnx.execute_string('CREATE OR REPLACE TABLE "{}"("name" STRING, "newest_version" STRING)'.format(table_name))
+
+        if quote_identifiers:
+            if create_default_columns:
+                create_sql = """CREATE OR REPLACE TABLE "{}" 
+                             ("name" STRING, "newest_version" STRING,
+                             "id" varchar(36) default uuid_string(),
+                             "ts" timestamp_ltz default current_timestamp)""".format(table_name)
+                id_key = 'id'
+                ts_key = 'ts'
+            else:
+                create_sql = 'CREATE OR REPLACE TABLE "{}" ("name" STRING, "newest_version" STRING)'.format(table_name)
+            select_sql = 'SELECT * FROM "{}"'.format(table_name)
+            drop_sql = 'DROP TABLE IF EXISTS "{}"'.format(table_name)
+        else:
+            if create_default_columns:
+                create_sql = """CREATE OR REPLACE TABLE {} 
+                             (name STRING, newest_version STRING,
+                             id varchar(36) default uuid_string(),
+                             ts timestamp_ltz default current_timestamp)""".format(table_name)
+                id_key = 'ID'
+                ts_key = 'TS'
+            else:
+                create_sql = 'CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name)
+            select_sql = 'SELECT * FROM {}'.format(table_name)
+            drop_sql = 'DROP TABLE IF EXISTS {}'.format(table_name)
+
+        cnx.execute_string(create_sql)
         try:
             success, nchunks, nrows, _ = write_pandas(cnx,
                                                       sf_connector_version_df,
@@ -51,15 +82,25 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
                                                       compression=compression,
                                                       parallel=parallel,
                                                       chunk_size=chunk_size,
-                                                      quote_identifiers=True)
-            if num_of_chunks == 1:
+                                                      quote_identifiers=quote_identifiers)
+            
+            if create_default_columns:
+                from snowflake.connector import DictCursor
+                result = cnx.cursor(DictCursor).execute(select_sql).fetchall()
+                for row in result:
+                    assert row[id_key] is not None  # ID (UUID String)
+                    assert len(row[id_key]) == 36
+                    assert row[ts_key] is not None  # TS (Current Timestamp)
+                    assert isinstance(row[ts_key], datetime)
+            elif num_of_chunks == 1:
                 # Note: since we used one chunk order is conserved
-                assert (cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall() ==
+                assert (cnx.cursor().execute(select_sql).fetchall() ==
                         sf_connector_version_data)
             else:
                 # Note: since we used one chunk order is NOT conserved
-                assert (set(cnx.cursor().execute('SELECT * FROM "{}"'.format(table_name)).fetchall()) ==
+                assert (set(cnx.cursor().execute(select_sql).fetchall()) ==
                         set(sf_connector_version_data))
+                
             # Make sure all files were loaded and no error occurred
             assert success
             # Make sure overall as many rows were ingested as we tried to insert
@@ -67,190 +108,68 @@ def test_write_pandas_quoted_identifiers(conn_cnx: Callable[..., Generator['Snow
             # Make sure we uploaded in as many chunk as we wanted to
             assert nchunks == num_of_chunks
         finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
+            cnx.execute_string(drop_sql)
 
 
-@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
-@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will be too small to chunk, this is only testing the put command's syntax
-@pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
-                      db_parameters: Dict[str, str],
-                      compression: str,
-                      parallel: int,
-                      chunk_size: int):
-    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
-
-    with conn_cnx(user=db_parameters['user'],
-                  account=db_parameters['account'],
-                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
-        table_name = 'driver_versions'
-        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
-        # not quote them when creating table
-        cnx.execute_string('CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)'.format(table_name))
-        try:
-            success, nchunks, nrows, _ = write_pandas(cnx,
-                                                      sf_connector_version_df,
-                                                      table_name,
-                                                      compression=compression,
-                                                      parallel=parallel,
-                                                      chunk_size=chunk_size)
-            if num_of_chunks == 1:
-                # Note: since we used one chunk order is conserved
-                assert (cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall() ==
-                        sf_connector_version_data)
-            else:
-                # Note: since we used one chunk order is NOT conserved
-                assert (set(cnx.cursor().execute('SELECT * FROM {}'.format(table_name)).fetchall()) ==
-                        set(sf_connector_version_data))
-            # Make sure all files were loaded and no error occurred
-            assert success
-            # Make sure overall as many rows were ingested as we tried to insert
-            assert nrows == len(sf_connector_version_data)
-            # Make sure we uploaded in as many chunk as we wanted to
-            assert nchunks == num_of_chunks
-        finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
-
-
-@pytest.mark.parametrize('chunk_size', [5, 4, 3, 2, 1])
-@pytest.mark.parametrize('compression', ['gzip', 'snappy'])
-# Note: since the file will to small to chunk, this is only testing the put command's syntax
-@pytest.mark.parametrize('parallel', [4, 99])
-def test_write_pandas_default_cols(conn_cnx: Callable[..., Generator['SnowflakeConnection', None, None]],
-                      db_parameters: Dict[str, str],
-                      compression: str,
-                      parallel: int,
-                      chunk_size: int):
-    from snowflake.connector import DictCursor
-    num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
-
-    with conn_cnx(user=db_parameters['user'],
-                  account=db_parameters['account'],
-                  password=db_parameters['password']) as cnx:  # type: SnowflakeConnection
-        table_name = 'driver_versions'
-        # by default (quote_identifiers=False), the user is not interested in quoting identifiers, so do
-        # not quote them when creating table
-        cnx.execute_string("""CREATE OR REPLACE TABLE {} (
-                              id varchar(36) default uuid_string(),
-                              name STRING, newest_version STRING,
-                              ts timestamp_ltz default current_timestamp)""".format(table_name))
-        try:
-            success, nchunks, nrows, _ = write_pandas(cnx,
-                                                      sf_connector_version_df,
-                                                      table_name,
-                                                      compression=compression,
-                                                      parallel=parallel,
-                                                      chunk_size=chunk_size)
-            result = cnx.cursor(DictCursor).execute('SELECT * FROM {}'.format(table_name)).fetchall()
-            for row in result:
-                assert row['ID'] is not None
-                assert row['TS'] is not None
-            # Make sure all files were loaded and no error occurred
-            assert success
-            # Make sure overall as many rows were ingested as we tried to insert
-            assert nrows == len(sf_connector_version_data)
-            # Make sure we uploaded in as many chunk as we wanted to
-            assert nchunks == num_of_chunks
-        finally:
-            cnx.execute_string("DROP TABLE IF EXISTS {}".format(table_name))
-
-
-def test_location_building_db_schema(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building_db_schema(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with database, schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == 'database.schema.table'
+                if quote_identifiers:
+                    assert location == '"database"."schema"."table"'
+                else:
+                    assert location == 'database.schema.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema')
+                                                      database='database', schema='schema', 
+                                                      quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
-def test_location_building_db_schema_quoted_identifiers(conn_cnx):
-    """This tests that write_pandas constructs location correctly with database, schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == '"database"."schema"."table"'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      database='database', schema='schema', quote_identifiers=True)
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building_schema(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building_schema(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == 'schema.table'
+                if quote_identifiers:
+                    assert location == '"schema"."table"'
+                else:
+                    assert location == 'schema.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
             success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema')
+                                                      schema='schema', quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
 
 
-def test_location_building_schema_quoted_identifier(conn_cnx):
+@pytest.mark.parametrize('quote_identifiers', [True, False])
+def test_location_building(conn_cnx, quote_identifiers: bool):
     """This tests that write_pandas constructs location correctly with schema and table name."""
     from snowflake.connector.cursor import SnowflakeCursor
     with conn_cnx() as cnx:  # type: SnowflakeConnection
         def mocked_execute(*args, **kwargs):
             if len(args) >= 1 and args[0].startswith('COPY INTO'):
                 location = args[0].split(' ')[2]
-                assert location == '"schema"."table"'
+                if quote_identifiers:
+                    assert location == '"teble.table"'
+                else:
+                    assert location == 'teble.table'
             cur = SnowflakeCursor(cnx)
             cur._result = iter([])
             return cur
         with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "table",
-                                                      schema='schema', quote_identifiers=True)
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building(conn_cnx):
-    """This tests that write_pandas constructs location correctly with schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == 'teble.table'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table")
-            assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))
-
-
-def test_location_building_quoted_identifiers(conn_cnx):
-    """This tests that write_pandas constructs location correctly with schema and table name."""
-    from snowflake.connector.cursor import SnowflakeCursor
-    with conn_cnx() as cnx:  # type: SnowflakeConnection
-        def mocked_execute(*args, **kwargs):
-            if len(args) >= 1 and args[0].startswith('COPY INTO'):
-                location = args[0].split(' ')[2]
-                assert location == '"teble.table"'
-            cur = SnowflakeCursor(cnx)
-            cur._result = iter([])
-            return cur
-        with mock.patch('snowflake.connector.cursor.SnowflakeCursor.execute', side_effect=mocked_execute) as m_execute:
-            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table", quote_identifiers=True)
+            success, nchunks, nrows, _ = write_pandas(cnx, sf_connector_version_df, "teble.table",
+                                                      quote_identifiers=quote_identifiers)
             assert m_execute.called and any(map(lambda e: 'COPY INTO' in str(e.args), m_execute.call_args_list))


### PR DESCRIPTION
I added my own test to what was included in #362 but otherwise the same code changes are included.

So this PR fixes a couple of issues with `pandas_tools`.
- It makes it insert default/autoincrement column values.
- It allows customers to use a non-quoted syntax for column and table names.

Added integration tests to verify new code paths. It adds all of these while not causing a behavior change.