### PR TITLE
SNOW-207403 use sys.executable instead of bare python for subprocess

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Upgrade setuptools, pip and wheel
         run: python -m pip install -U setuptools pip wheel
       - name: Install tox
-        run: python -m pip install tox tox-external-wheels virtualenv==20.0.33
+        run: python -m pip install tox tox-external-wheels
       - name: Run tests
         run: python -m tox -e "py${PYTHON_VERSION/\./}{-extras,,-pandas,-sso}-ci"
         env:

--- a/test/extras/run.py
+++ b/test/extras/run.py
@@ -14,5 +14,5 @@ import sys
 for test_file in pathlib.Path(__file__).parent.glob('*.py'):
     if test_file.name != 'run.py':
         print("Running {}".format(test_file))
-        sub_process = subprocess.run([sys.executable, str(test_file)])
+        sub_process = subprocess.run([sys.executable if sys.executable else 'python', str(test_file)])
         sub_process.check_returncode()

--- a/test/extras/run.py
+++ b/test/extras/run.py
@@ -9,9 +9,10 @@
 
 import pathlib
 import subprocess
+import sys
 
 for test_file in pathlib.Path(__file__).parent.glob('*.py'):
     if test_file.name != 'run.py':
         print("Running {}".format(test_file))
-        sub_process = subprocess.run(['python', str(test_file)])
+        sub_process = subprocess.run([sys.executable, str(test_file)])
         sub_process.check_returncode()


### PR DESCRIPTION
So the original issue comes from a mixture of decisions: a behavior change introduced in Python 3.7.2's `venv` library, `virtualenv` using this new behavior in it's latest release and Windows always searching prepending the working directory to it's path.

So when `virtualenv` switched to using the new behavior of a redirector script (this is the venv behavior change). This makes it so that we don't need to copy dlls to the `venv`'s directory from the system wide Python install upon creation, saving space ultimately.

Then the redirector script execv'd to the system wide Python install and when the subprocess looked for the executable `python` it found it in the working directory, losing it's site-packages folder as the redirector script was not involved (it couldn't inject its site-packages folder before invoking the system wide python).

So this issue requires a very specific use case in a very specific environment. Our extras test checked all the boxes unfortunately. However, this is test environment issue and not customer facing.

Introducing `sys.executable` into our run script should fix the issue and I'm currently working with the Python team to better document this behavior here: https://bugs.python.org/issue42041