### PR TITLE
SNOW-210112 fix variable usage in comment

### DIFF
--- a/.github/workflows/jira_comment.yml
+++ b/.github/workflows/jira_comment.yml
@@ -26,4 +26,4 @@ jobs:
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
         with:
           issue: "${{ steps.extract.outputs.jira }}"
-          comment: "{{ event.comment.user.login }} commented:\n\n{{ event.comment.body }}\n\n{{ event.comment.html_url }}"
+          comment: "${{ event.comment.user.login }} commented:\n\n${{ event.comment.body }}\n\n${{ event.comment.html_url }}"


### PR DESCRIPTION
Something changed and now our comment action is posting useless comments on Jira: https://github.com/snowflakedb/snowflake-connector-python/actions/runs/320891610
I suspect this to be a GitHub Action change.