### PR TITLE
SNOW-210112 fix comments

### DIFF
--- a/.github/workflows/jira_comment.yml
+++ b/.github/workflows/jira_comment.yml
@@ -26,4 +26,4 @@ jobs:
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
         with:
           issue: "${{ steps.extract.outputs.jira }}"
-          comment: "${{ event.comment.user.login }} commented:\n\n${{ event.comment.body }}\n\n${{ event.comment.html_url }}"
+          comment: "${{ github.event.comment.user.login }} commented:\n\n${{ github.event.comment.body }}\n\n${{ github.event.comment.html_url }}"

--- a/.github/workflows/jira_comment.yml
+++ b/.github/workflows/jira_comment.yml
@@ -26,4 +26,4 @@ jobs:
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
         with:
           issue: "${{ steps.extract.outputs.jira }}"
-          comment: "${{ comment.user.login }} commented:\n\n${{ comment.body }}\n\n${{ comment.html_url }}"
+          comment: "${{ event.comment.user.login }} commented:\n\n${{ event.comment.body }}\n\n${{ event.comment.html_url }}"


### PR DESCRIPTION
Undoes what #484 did and adds `github` in front of the objects, as this seems to work on line 20:
`TITLE: "${{ github.event.issue.title }}"`