### PR TITLE
Update cryptography dependency pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
         'pyOpenSSL>=16.2.0,<21.0.0',
         'cffi>=1.9,<1.15',
-        'cryptography>=2.5.0,<3.0.0',
+        'cryptography>=2.5.0,<4.0.0',
         'pyjwt<2.0.0',
         'idna<2.11',
         'oscrypto<2.0.0',


### PR DESCRIPTION
The issue fixed in this PR  https://github.com/pyca/cryptography/pull/5507/ was released in cryptography 3.2.0.