### PR TITLE
SNOW-215519 fixing a type hint and Jenkins test issues

### DIFF
--- a/test/generate_test_files.py
+++ b/test/generate_test_files.py
@@ -15,7 +15,7 @@ from typing import Optional
 IS_WINDOWS = platform.system() == 'Windows'
 
 
-def generate_k_lines_of_n_files(k: int, n: int, compress: bool = False, tmp_dir: Optional[bool] = None) -> str:
+def generate_k_lines_of_n_files(k: int, n: int, compress: bool = False, tmp_dir: Optional[str] = None) -> str:
     """Creates testing files.
 
     Notes:

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -20,7 +20,7 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, db_
     """[s3] Puts and Gets Small Data via User Stage."""
     if is_public_test or 'AWS_ACCESS_KEY_ID' not in os.environ:
         pytest.skip('This test requires to change the internal parameter')
-    _put_get_user_stage(tmpdir, generate_k_lines_of_n_files, conn_cnx, db_parameters,
+    _put_get_user_stage(tmpdir, conn_cnx, db_parameters,
                         number_of_files=5, number_of_lines=10)
 
 
@@ -30,7 +30,7 @@ def test_put_get_large_data_via_user_stage(
     """[s3] Puts and Gets Large Data via User Stage."""
     if is_public_test or 'AWS_ACCESS_KEY_ID' not in os.environ:
         pytest.skip('This test requires to change the internal parameter')
-    _put_get_user_stage(tmpdir, generate_k_lines_of_n_files, conn_cnx, db_parameters,
+    _put_get_user_stage(tmpdir, conn_cnx, db_parameters,
                         number_of_files=2,
                         number_of_lines=200000)
 


### PR DESCRIPTION
When refactoring some code I imported `generate_k_lines_of_n_files` instead of using a fixture,  but never updated how the function was called. Sorry!