### PR TITLE
Update mock imports in tests 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,6 @@ setup(
             'pytest-timeout',
             'coverage',
             'pexpect',
-            'mock',
             'pytz',
             'pytzdata',
             'Cython',

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -7,8 +7,8 @@
 import math
 from datetime import datetime
 from typing import Callable, Dict, Generator
+from unittest import mock
 
-import mock
 import pytest
 
 from snowflake.connector import DictCursor

--- a/test/integ/pandas/test_unit_options.py
+++ b/test/integ/pandas/test_unit_options.py
@@ -3,8 +3,8 @@
 #
 
 from copy import deepcopy
+from unittest import mock
 
-import mock
 import pytest
 from pkg_resources import working_set
 

--- a/test/integ/sso/test_unit_sso_connection.py
+++ b/test/integ/sso/test_unit_sso_connection.py
@@ -5,9 +5,9 @@
 #
 
 import os
+from unittest.mock import Mock, patch
 
 import pytest
-from mock import Mock, patch
 
 import snowflake.connector
 

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -7,9 +7,9 @@
 import os
 import queue
 import threading
+from unittest import mock
 import warnings
 
-import mock
 import pytest
 
 import snowflake.connector

--- a/test/integ/test_execute_multi_statements.py
+++ b/test/integ/test_execute_multi_statements.py
@@ -7,9 +7,9 @@
 import codecs
 import os
 from io import BytesIO, StringIO
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 from snowflake.connector import DictCursor, ProgrammingError
 

--- a/test/integ/test_incident.py
+++ b/test/integ/test_incident.py
@@ -6,10 +6,10 @@
 
 import warnings
 from traceback import format_exc
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from mock import patch
 from pytest import fail
 
 from snowflake.connector import ProgrammingError, converter

--- a/test/integ/test_large_result_set.py
+++ b/test/integ/test_large_result_set.py
@@ -3,9 +3,9 @@
 #
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
+from unittest.mock import Mock
 
 import pytest
-from mock import Mock
 
 from snowflake.connector.telemetry import TelemetryField
 

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -9,9 +9,9 @@ import pathlib
 from getpass import getuser
 from logging import getLogger
 from os import path
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 import snowflake.connector
 

--- a/test/integ/test_put_get_with_gcp_account.py
+++ b/test/integ/test_put_get_with_gcp_account.py
@@ -11,8 +11,8 @@ import sys
 import time
 from filecmp import cmp
 from logging import getLogger
+from unittest import mock
 
-import mock
 import pytest
 import requests
 

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -5,7 +5,6 @@
 #
 
 import time
-
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.auth import Auth

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -6,7 +6,7 @@
 
 import time
 
-from mock import MagicMock, Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.auth import Auth
 from snowflake.connector.auth_default import AuthByDefault

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 
-from mock import MagicMock, Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.auth_okta import AuthByOkta
 from snowflake.connector.constants import OCSPMode

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 
-from mock import MagicMock, Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.auth_webbrowser import AuthByWebBrowser
 from snowflake.connector.constants import OCSPMode

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -3,9 +3,9 @@
 #
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 import snowflake.connector
 

--- a/test/unit/test_gcs_util.py
+++ b/test/unit/test_gcs_util.py
@@ -5,8 +5,8 @@
 #
 
 import logging
+from unittest import mock
 
-import mock
 import pytest
 import requests
 from requests import Response

--- a/test/unit/test_log_secret_detector.py
+++ b/test/unit/test_log_secret_detector.py
@@ -5,8 +5,7 @@
 #
 
 import logging
-
-import mock
+from unittest import mock
 
 from snowflake.connector.secret_detector import SecretDetector
 

--- a/test/unit/test_put_get.py
+++ b/test/unit/test_put_get.py
@@ -5,9 +5,9 @@
 #
 
 from os import chmod, path
+from unittest.mock import MagicMock
 
 import pytest
-from mock import MagicMock
 
 from snowflake.connector.compat import IS_WINDOWS
 from snowflake.connector.errors import Error

--- a/test/unit/test_renew_session.py
+++ b/test/unit/test_renew_session.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 
-from mock import MagicMock, Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.network import SnowflakeRestful
 

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -11,10 +11,10 @@ import tempfile
 import time
 from logging import getLogger
 from os import path
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import OpenSSL.SSL
 import pytest
-from mock import MagicMock, Mock, PropertyMock
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
 from requests.packages.urllib3.exceptions import ProtocolError, ReadTimeoutError
 

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -9,14 +9,14 @@ import logging
 import os
 from collections import defaultdict
 from os import path
+from unittest.mock import MagicMock, Mock, PropertyMock
+import unittest.mock
 
 import botocore
 import botocore.exceptions
-import mock
 import OpenSSL
 import pytest
 from boto3.exceptions import Boto3Error, RetriesExceededError, S3UploadFailedError
-from mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.constants import SHA256_DIGEST, ResultStatus
 from snowflake.connector.remote_storage_util import DEFAULT_MAX_RETRY, SnowflakeRemoteStorageUtil

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -10,7 +10,7 @@ import os
 from collections import defaultdict
 from os import path
 from unittest.mock import MagicMock, Mock, PropertyMock
-import unittest.mock
+from unittest import mock
 
 import botocore
 import botocore.exceptions

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -9,8 +9,8 @@ import logging
 import os
 from collections import defaultdict
 from os import path
-from unittest.mock import MagicMock, Mock, PropertyMock
 from unittest import mock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import botocore
 import botocore.exceptions

--- a/test/unit/test_telemetry.py
+++ b/test/unit/test_telemetry.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 
-from mock import Mock
+from unittest.mock import Mock
 
 import snowflake.connector.telemetry
 

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 120
 known_first_party =snowflake,parameters,generate_test_files
-known_third_party =Cryptodome,OpenSSL,asn1crypto,boto3,botocore,certifi,cryptography,dateutil,jwt,mock,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools,urllib3
+known_third_party =Cryptodome,OpenSSL,asn1crypto,boto3,botocore,certifi,cryptography,dateutil,jwt,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools,urllib3
 
 [flake8]
 ignore=F821,W504,E501,E402,E122,E127,E126,E128,E131,E731,E125,E722x,D100,D101,D102,D103,D104,D105,D107,D401,D204


### PR DESCRIPTION
Python 2 support has been disabled in master branch, `unittest.mock` can be used in place of `mock` library from pypi 