### PR TITLE
SNOW-200089 expicitly cast a column into integer in write_pandas

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -204,7 +204,7 @@ def write_pandas(
     return (
         all(e[1] == "LOADED" for e in copy_results),
         len(copy_results),
-        sum(e[3] for e in copy_results),
+        sum(int(e[3]) for e in copy_results),
         copy_results,
     )
 


### PR DESCRIPTION
Fixes #438
For some reason in some cases `COPY INTO <table>` returns the number of rows inserted as a string, this forces those strings to be casted into integers.

I was unable to reproduce the issue, but I don't think that adding this extra cast would detrimental for the Python connector.