### PR TITLE
SNOW-216517 improve cursor coverage

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -279,6 +279,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
+          PYTEST_ADDOPTS: --color=yes
         shell: bash
 
   test-fips:

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -29,7 +29,7 @@ cdef class ArrowResult:
     cdef:
         object _cursor
         object _connection
-        int total_row_index;
+        readonly int total_row_index;
         int _chunk_index
         int _chunk_count
         int _current_chunk_row_count

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -365,7 +365,7 @@ class SnowflakeCursor(object):
         try:
             if not original_sigint == exit_handler:
                 signal.signal(signal.SIGINT, interrupt_handler)
-        except ValueError:
+        except ValueError:  # pragma: no cover
             logger.debug(
                 'Failed to set SIGINT handler. '
                 'Not in main thread. Ignored...')
@@ -384,7 +384,7 @@ class SnowflakeCursor(object):
             try:
                 if original_sigint:
                     signal.signal(signal.SIGINT, original_sigint)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError):  # pragma: no cover
                 logger.debug(
                     'Failed to reset SIGINT handler. Not in main '
                     'thread. Ignored...')
@@ -823,8 +823,7 @@ class SnowflakeCursor(object):
         if size < 0:
             errorvalue = {
                 'msg': ("The number of rows is not zero or "
-                         "positive number: {0}").format(
-                    size),
+                         "positive number: {}").format(size),
                 'errno': ER_NOT_POSITIVE_SIZE}
             Error.errorhandler_wrapper(
                 self.connection, self, ProgrammingError, errorvalue)

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -18,7 +18,6 @@ import pytz
 import snowflake.connector
 from snowflake.connector import InterfaceError, NotSupportedError, ProgrammingError, constants, errorcode, errors
 from snowflake.connector.compat import BASE_EXCEPTION_CLASS, IS_WINDOWS
-from snowflake.connector.constants import PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT
 from snowflake.connector.errorcode import (
     ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
     ER_INVALID_VALUE,
@@ -30,6 +29,11 @@ from snowflake.connector.errorcode import (
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 
 from ..randomize import random_string
+
+try:
+    from snowflake.connector.constants import PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT
+except ImportError:
+    PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = None
 
 
 def _drop_warehouse(conn, db_parameters):
@@ -887,6 +891,7 @@ def test_desc_rewrite(conn, caplog):
                 cur.execute('drop table {}'.format(table_name))
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize('result_format', [False, None, 'json'])
 def test_execute_helper_cannot_use_arrow(conn_cnx, caplog, result_format):
     """Tests whether cannot use arrow is handled correctly inside of _execute_helper."""
@@ -906,6 +911,7 @@ def test_execute_helper_cannot_use_arrow(conn_cnx, caplog, result_format):
                 assert cur.fetchone() == (1,)
 
 
+@pytest.mark.skipolddriver
 def test_execute_helper_cannot_use_arrow_exception(conn_cnx, caplog):
     """Like test_execute_helper_cannot_use_arrow but when we are trying to force arrow an Exception should be raised."""
     with conn_cnx() as cnx:
@@ -964,6 +970,7 @@ def test_check_cannot_use_pandas(conn_cnx):
                     assert pe.errno == ER_NO_PYARROW
 
 
+@pytest.mark.skipolddriver
 def test_not_supported_pandas(conn_cnx):
     """Check that fetch_pandas functions return expected error when arrow results are not available."""
     result_format = {

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -991,7 +991,6 @@ def test_not_supported_pandas(conn_cnx):
                     list(cur.fetch_pandas_batches())
 
 
-@pytest.mark.timeout(30)
 def test_query_cancellation(conn_cnx):
     """Tests whether query_cancellation works."""
     with conn_cnx() as cnx:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -819,6 +819,16 @@ def test_empty_execution(conn):
                 cur.fetchall()
 
 
+def test_rownumber(conn):
+    """Checks whether rownumber is returned as expected."""
+    with conn() as cnx:
+        with cnx.cursor() as cur:
+            assert cur.execute('select * from values (1), (2)').fetchone() == (1,)
+            assert cur.rownumber == 0
+            assert cur.fetchone() == (2,)
+            assert cur.rownumber == 1
+
+
 def test_values_set(conn):
     """Checks whether a bunch of properties start as Nones, but get set to something else when a query was executed."""
     properties = [

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -18,22 +18,23 @@ import pytz
 import snowflake.connector
 from snowflake.connector import InterfaceError, NotSupportedError, ProgrammingError, constants, errorcode, errors
 from snowflake.connector.compat import BASE_EXCEPTION_CLASS, IS_WINDOWS
-from snowflake.connector.errorcode import (
-    ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
-    ER_INVALID_VALUE,
-    ER_NO_ARROW_RESULT,
-    ER_NO_PYARROW,
-    ER_NO_PYARROW_SNOWSQL,
-    ER_NOT_POSITIVE_SIZE,
-)
+from snowflake.connector.errorcode import ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT, ER_INVALID_VALUE, ER_NOT_POSITIVE_SIZE
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 
 from ..randomize import random_string
 
 try:
     from snowflake.connector.constants import PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT
+    from snowflake.connector.errorcode import (
+        ER_NO_ARROW_RESULT,
+        ER_NO_PYARROW,
+        ER_NO_PYARROW_SNOWSQL,
+    )
 except ImportError:
     PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = None
+    ER_NO_ARROW_RESULT = None
+    ER_NO_PYARROW = None
+    ER_NO_PYARROW_SNOWSQL = None
 
 
 def _drop_warehouse(conn, db_parameters):
@@ -933,6 +934,7 @@ def test_check_can_use_arrow_resultset(conn_cnx, caplog):
     assert 'Arrow' not in caplog.text
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize('snowsql', [True, False])
 def test_check_cannot_use_arrow_resultset(conn_cnx, caplog, snowsql):
     """Tests check_can_use_arrow_resultset expected outcomes."""
@@ -950,6 +952,7 @@ def test_check_cannot_use_arrow_resultset(conn_cnx, caplog, snowsql):
                     assert pe.errno == (ER_NO_PYARROW_SNOWSQL if snowsql else ER_NO_ARROW_RESULT)
 
 
+@pytest.mark.skipolddriver
 def test_check_can_use_pandas(conn_cnx):
     """Tests check_can_use_arrow_resultset has no effect when we can import pandas."""
     with conn_cnx() as cnx:
@@ -958,6 +961,7 @@ def test_check_can_use_pandas(conn_cnx):
                 cur.check_can_use_pandas()
 
 
+@pytest.mark.skipolddriver
 def test_check_cannot_use_pandas(conn_cnx):
     """Tests check_can_use_arrow_resultset has expected outcomes."""
     with conn_cnx() as cnx:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -925,6 +925,7 @@ def test_execute_helper_cannot_use_arrow_exception(conn_cnx, caplog):
                     })
 
 
+@pytest.mark.skipolddriver
 def test_check_can_use_arrow_resultset(conn_cnx, caplog):
     """Tests check_can_use_arrow_resultset has no effect when we can use arrow."""
     with conn_cnx() as cnx:

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ passenv =
     ; see https://github.com/tox-dev/tox/issues/1455
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
+    PYTEST_ADDOPTS
 commands =
     # Test environments
     # Note: make sure to have a default env and all the other special ones


### PR DESCRIPTION
Raises `cursor.py` coverage to ~100%. Covering the leftover part would only be questionably useful.