### PR TITLE
SNOW-143458 fix win python38

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -189,10 +189,6 @@ jobs:
            download_name: windows
         python-version: [3.5, 3.6, 3.7, 3.8]
         cloud-provider: [aws, azure, gcp]
-        exclude:
-          - python-version: 3.8
-            os:
-              download_name: windows
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ using the Snowflake JDBC or ODBC drivers.
 
 The connector is a native, pure Python package that has no dependencies on JDBC or
 ODBC. It can be installed using ``pip`` on Linux, Mac OSX, and Windows platforms
-(Python 3.8 is currently not supported on Windows) where Python 3.5.0 (or higher) is installed.
+where Python 3.5.0 (or higher) is installed.
 
 Snowflake Documentation is available at:
 https://docs.snowflake.com/

--- a/src/snowflake/connector/cpp/Logging/logging.cpp
+++ b/src/snowflake/connector/cpp/Logging/logging.cpp
@@ -19,19 +19,27 @@ std::string Logger::formatString(const char *format, ...)
   return std::string(msg);
 }
 
-Logger::Logger(const char *name)
+void Logger::setupPyLogger()
 {
   py::UniqueRef pyLoggingModule;
-
   py::importPythonModule("snowflake.connector.snow_logging", pyLoggingModule);
   PyObject *logger =
-      PyObject_CallMethod(pyLoggingModule.get(), "getSnowLogger", "s", name);
+      PyObject_CallMethod(pyLoggingModule.get(), "getSnowLogger", "s", m_name);
 
   m_pyLogger.reset(logger);
 }
 
+Logger::Logger(const char *name)
+: m_name(name)
+{
+}
+
 void Logger::log(int level, const char *path_name, const char *func_name, int line_num, const char *msg)
 {
+  if (m_pyLogger.get() == nullptr)
+  {
+    setupPyLogger();
+  }
 
   PyObject *logger = m_pyLogger.get();
   py::UniqueRef keywords(PyDict_New());

--- a/src/snowflake/connector/cpp/Logging/logging.hpp
+++ b/src/snowflake/connector/cpp/Logging/logging.hpp
@@ -30,6 +30,7 @@ public:
 
 private:
   py::UniqueRef m_pyLogger;
+  const char *const m_name;
   static constexpr int CRITICAL = 50;
   static constexpr int FATAL = CRITICAL;
   static constexpr int ERROR = 40;
@@ -39,6 +40,8 @@ private:
   static constexpr int DEBUG = 10;
   static constexpr int NOTSET = 0;
   static constexpr int LINE_NUM = 0;
+
+  void setupPyLogger();
 };
 
 }  // namespace sf


### PR DESCRIPTION
Turns out that the issue with Python 3.8 was an unforeseen consequence of the new dll resolution (probably). Basically when importing anything from `snowflake.connector` the `__init__.py` imported `cursor.py`, which imported `arrow_result.py` which imported our C-extension, which then imported `snowflake.connector.snow_logging`, which imported `__init__.py` again.

So the proposed solution is to make `SnowLogger` creation lazy in our C-extensions. We only actually create our `SnowLogger`s upon the first logging message being logged.