### PR TITLE
Allow 1.16.X series of boto3 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ setup(
         'azure-common<2.0.0',
         'azure-storage-blob<12.0.0;python_version<="3.5.1"',
         'azure-storage-blob>=12.0.0,<13.0.0;python_version>="3.5.2"',
-        'boto3>=1.4.4,<1.16',
+        'boto3>=1.4.4,<1.17',
         'requests<2.24.0',
         'urllib3>=1.20,<1.26.0',
         'certifi<2021.0.0',


### PR DESCRIPTION
We have dependency conflicts across several of our libraries due to this pin.