### PR TITLE
SNOW-222359 Revert "SNOW-222179 Update urllib3 requirement from <1.26.0,>=1.20 to >=1.20,<1.27.0"

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox tox-external-wheels
       - name: Run tests
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-{extras,unit,integ,pandas,sso}-ci" -p auto
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-{extras,unit,integ,pandas,sso}-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(
         'azure-storage-blob>=12.0.0,<13.0.0;python_version>="3.5.2"',
         'boto3>=1.4.4,<1.16',
         'requests<2.24.0',
-        'urllib3>=1.20,<1.27.0',
+        'urllib3>=1.20,<1.26.0',
         'certifi<2021.0.0',
         'pytz<2021.0',
         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',


### PR DESCRIPTION
Reverts snowflakedb/snowflake-connector-python#529 and disables parallel `tox` runs.

So `requests` refuses to work with dependencies that are outside of its pinned range.
We have been stuck on a little older `requests` because we have OCSP to patch into the new `requests` versions still. So this pin update of `urllib3` actually places it outside of the `requests` supported range.

This didn't show up in testing because our test environment must be using the new resolver of `pip`, although I am still verifying this. Because of parallel test execution of `tox`, it has been swallowing the outputs, so I need to turn this off and this will make my RCA a little longer. I can only thank myself for this 😞 

However; if a customer was disabling the new dependency resolver on purpose then the current master wouldn't work. I'll look into disabling this in our test environment to stop masking these errors in the future.