### PR TITLE
SNOW-225351 added new URLs to to our setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,8 +182,12 @@ setup(
     license='Apache License, Version 2.0',
     keywords="Snowflake db database cloud analytics warehouse",
     url='https://www.snowflake.com/',
-    download_url='https://www.snowflake.com/',
     use_2to3=False,
+    project_urls={
+        "Documentation": "https://docs.snowflake.com/",
+        "Code": "https://github.com/snowflakedb/snowflake-connector-python",
+        "Issue tracker": "https://github.com/snowflakedb/snowflake-connector-python/issues",
+    },
 
     python_requires='>=3.6',
 


### PR DESCRIPTION
This adds new URLs to our PYPI site: https://pypi.org/project/snowflake-connector-python/
Documentation: https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls
An example of what this will look like: https://pypi.org/project/urllib3/