### PR TITLE
SNOW-228474: Support converting VARIANT to python object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'FloatConverter.cpp'),
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'IntConverter.cpp'),
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'StringConverter.cpp'),
+                                os.path.join(ARROW_ITERATOR_SRC_DIR, 'VariantConverter.cpp'),
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'TimeConverter.cpp'),
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'TimeStampConverter.cpp'),
                                 os.path.join(ARROW_ITERATOR_SRC_DIR, 'Python', 'Common.cpp'),

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -5,6 +5,7 @@
 #
 
 import decimal
+import json
 import time
 from datetime import datetime, timedelta
 from logging import getLogger
@@ -31,10 +32,11 @@ logger = getLogger(__name__)
 
 
 class ArrowConverterContext(object):
-    def __init__(self, session_parameters=None):
+    def __init__(self, session_parameters=None, convert_variant_to_object=False):
         if session_parameters is None:
             session_parameters = {}
         self._timezone = None if PARAMETER_TIMEZONE not in session_parameters else session_parameters[PARAMETER_TIMEZONE]
+        self._convert_variant_to_object = convert_variant_to_object
 
     @property
     def timezone(self):
@@ -116,3 +118,9 @@ class ArrowConverterContext(object):
     def TIMESTAMP_NTZ_TWO_FIELD_to_numpy_datetime64(self, epoch, fraction):
         nanoseconds = int(decimal.Decimal(epoch).scaleb(9) + decimal.Decimal(fraction))
         return numpy.datetime64(nanoseconds, 'ns')
+
+    def VARIANT_to_python(self, value):
+        if not self._convert_variant_to_object:
+            return value
+
+        return json.loads(value)

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -66,7 +66,8 @@ cdef class ArrowResult:
 
         if rowset_b64:
             arrow_bytes = b64decode(rowset_b64)
-            self._arrow_context = ArrowConverterContext(self._connection._session_parameters)
+            self._arrow_context = ArrowConverterContext(self._connection._session_parameters,
+                                                        self._connection.convert_arrow_variant_to_object)
             self._current_chunk_row = PyArrowIterator(self._cursor, io.BytesIO(arrow_bytes),
                                                       self._arrow_context, self._use_dict_result,
                                                       self._use_numpy)

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -303,7 +303,8 @@ class ArrowBinaryHandler(RawBinaryDataHandler):
 
     def __init__(self, cursor, connection):
         self._cursor = cursor
-        self._arrow_context = ArrowConverterContext(connection._session_parameters)
+        self._arrow_context = ArrowConverterContext(connection._session_parameters,
+                                                    connection.convert_arrow_variant_to_object)
 
     """
     Handler to consume data as arrow stream

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -130,6 +130,7 @@ DEFAULT_CONFIGURATION = {
     'numpy': (False, bool),  # snowflake
     'ocsp_response_cache_filename': (None, (type(None), str)),  # snowflake internal
     'converter_class': (DefaultConverterClass(), SnowflakeConverter),
+    'convert_arrow_variant_to_object': (False, bool),
     'chunk_downloader_class': (SnowflakeChunkDownloader, object),  # snowflake internal
     'validate_default_parameters': (False, bool),  # snowflake
     'probe_connection': (False, bool),  # snowflake
@@ -195,6 +196,7 @@ class SnowflakeConnection(object):
         is_pyformat: Whether the current argument binding is pyformat or format.
         consent_cache_id_token: Consented cache ID token.
         use_openssl_only: Use OpenSSL instead of pure Python libraries for signature verification and encryption.
+        convert_arrow_variant_to_object: Convert array, object and variant columns to python objects instead of to strings.
     """
 
     OCSP_ENV_LOCK = Lock()
@@ -363,6 +365,10 @@ class SnowflakeConnection(object):
     @property
     def converter_class(self):
         return self._converter_class
+
+    @property
+    def convert_arrow_variant_to_object(self):
+        return self._convert_arrow_variant_to_object
 
     @property
     def validate_default_parameters(self):

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -6,6 +6,7 @@
 #include "SnowflakeType.hpp"
 #include "IntConverter.hpp"
 #include "StringConverter.hpp"
+#include "VariantConverter.hpp"
 #include "FloatConverter.hpp"
 #include "DecimalConverter.hpp"
 #include "BinaryConverter.hpp"
@@ -191,13 +192,19 @@ void CArrowChunkIterator::initColumnConverters()
 
       case SnowflakeType::Type::ANY:
       case SnowflakeType::Type::CHAR:
-      case SnowflakeType::Type::OBJECT:
-      case SnowflakeType::Type::VARIANT:
       case SnowflakeType::Type::TEXT:
-      case SnowflakeType::Type::ARRAY:
       {
         m_currentBatchConverters.push_back(
             std::make_shared<sf::StringConverter>(columnArray));
+        break;
+      }
+
+      case SnowflakeType::Type::OBJECT:
+      case SnowflakeType::Type::VARIANT:
+      case SnowflakeType::Type::ARRAY:
+      {
+        m_currentBatchConverters.push_back(
+            std::make_shared<sf::VariantConverter>(columnArray, m_context));
         break;
       }
 

--- a/src/snowflake/connector/cpp/ArrowIterator/VariantConverter.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/VariantConverter.cpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
+
+#include "VariantConverter.hpp"
+
+namespace sf
+{
+
+VariantConverter::VariantConverter(std::shared_ptr<arrow::Array> array, PyObject* context)
+: m_array(std::dynamic_pointer_cast<arrow::StringArray>(array)), m_context(context)
+{
+}
+
+PyObject* VariantConverter::toPyObject(int64_t rowIndex) const
+{
+  if (m_array->IsValid(rowIndex))
+  {
+    arrow::util::string_view sv = m_array->GetView(rowIndex);
+    PyObject* string = PyUnicode_FromStringAndSize(sv.data(), sv.size());
+
+    return PyObject_CallMethod(m_context, "VARIANT_to_python",
+                               "O", string);
+  }
+  else
+  {
+    Py_RETURN_NONE;
+  }
+}
+
+}  // namespace sf

--- a/src/snowflake/connector/cpp/ArrowIterator/VariantConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/VariantConverter.hpp
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+//
+
+#ifndef PC_VARIANTCONVERTER_HPP
+#define PC_VARIANTCONVERTER_HPP
+
+#include "IColumnConverter.hpp"
+
+namespace sf
+{
+
+class VariantConverter : public IColumnConverter
+{
+public:
+  explicit VariantConverter(std::shared_ptr<arrow::Array> array, PyObject* m_context);
+
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+private:
+  std::shared_ptr<arrow::StringArray> m_array;
+
+  PyObject* m_context;
+};
+
+}  // namespace sf
+
+#endif  // PC_VARIANTCONVERTER_HPP


### PR DESCRIPTION
What this pr does:

Adds the convert_arrow_variant_to_object parameter to SnowflakeConnection. 
If this parameter value is `True` columns of the types VARIANT, ARRAY and OBJECT are retuned as python object and not string. 

To support this feature I added
- The `convert_arrow_variant_to_object` parameter and property. The default value of this parameter is False to preserve the old behavior.
- The method `VARIANT_to_python` in `ArrowConverterContext` that uses `json.loads` if the flag is True.
- A cpp `VariantConverter` class that call the method `VARIANT_to_python`.
- Some test to tests the new functionality.

Why this change is necessary: 
I wrote about it in #544 :
> When querying a variant (or array and object) column the results are returned as dumped json string.
> In the past before the Arrow format support one could've used the converter_class parameter to pass its own subclass of `SnowflakeConverter` that calls `json.loads` on the returned string.
> But when using the Arrow format this parameter has no affect.

I hope my changes make sense in the project and I would be happy to fix any comments you have.
