### PR TITLE
SNOW-237424 Declare dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,6 +206,10 @@ setup(
         'pyjwt<2.0.0',
         'oscrypto<2.0.0',
         'asn1crypto>0.24.0,<2.0.0',
+        # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is
+        # required. Python 3.6 was released at the end of 2016. setuptools 34.0.0 was released
+        # in early 2017, so we pick this version as a reasonably modern base.
+        'setuptools>34.0.0',
     ],
 
     namespace_packages=['snowflake'],


### PR DESCRIPTION
The code makes use of modules that are not bundled with the Python standard library.

Ensure that "setuptools" is part of `install_requires`