### PR TITLE
SNOW-230672 pin pyOpenSSL more

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
         'certifi<2021.0.0',
         'pytz<2021.0',
         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
-        'pyOpenSSL>=16.2.0,<21.0.0',
+        'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',
         'cryptography>=2.5.0,<4.0.0',
         'pyjwt<2.0.0',


### PR DESCRIPTION
SNOW-230672
The newest release of `pyOpenSSL` breaks our compatibility.

See issue happening here: https://jenkins.int.snowflakecomputing.com/job/RT-FIPS-PyConnector36/1252/console
Test run on this branch: https://jenkins.int.snowflakecomputing.com/job/RT-FIPS-PyConnector36/1253/console