### PR TITLE
 SNOW-80651 Fix typo in SnowflakeConnection.get_query_status_throw_if_error

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1206,7 +1206,7 @@ class SnowflakeConnection(object):
                                         'errno': int(code),
                                         'sqlstate': sql_state,
                                         'sfqid': sf_qid})
-            return status
+        return status
 
     @staticmethod
     def is_still_running(status: QueryStatus) -> bool:

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -36,6 +36,8 @@ def test_async_exec(conn_cnx):
         with con.cursor() as cur:
             status = con.get_query_status(q_id)
             assert status == QueryStatus.SUCCESS
+            status = con.get_query_status_throw_if_error(q_id)
+            assert status == QueryStatus.SUCCESS
             cur.get_results_from_sfqid(q_id)
             assert len(cur.fetchall()) == 1
 


### PR DESCRIPTION
Hi, first off, I'm super excited about the async features that seem to be on their way! Thanks for the great work.

I've noticed a typo in `SnowflakeConnection.get_query_status_throw_if_error` (extra indentation). This PR fixes it and tests the fix.