### PR TITLE
SNOW-230346 sped up arrow chunk rebuilding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
             Extension(name='snowflake.connector.arrow_result',
                       sources=[os.path.join(CONNECTOR_SRC_DIR, 'arrow_result.pyx')])
         ],
-        build_dir=os.path.join('build', 'cython'))
+    )
 
     class MyBuildExt(build_ext):
 

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -167,7 +167,6 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
         cdef CStatus ret
         input_stream.reset(new PyReadableFile(py_inputstream))
         cdef CResult[shared_ptr[CRecordBatchReader]] readerRet = CRecordBatchStreamReader.Open(input_stream.get())
-        #cdef  ret = CRecordBatchStreamReader.Open(input_stream.get(), &reader)
         if not readerRet.ok():
             Error.errorhandler_wrapper(
                 cursor.connection,

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -823,10 +823,11 @@ bool CArrowTableIterator::convertRecordBatchesToTable()
   if (!m_cTable && !m_cRecordBatches->empty())
   {
     reconstructRecordBatches();
-    arrow::Status ret = arrow::Table::FromRecordBatches(*m_cRecordBatches, &m_cTable);
+    arrow::Result<std::shared_ptr<arrow::Table>> ret = arrow::Table::FromRecordBatches(*m_cRecordBatches);
     SF_CHECK_ARROW_RC_AND_RETURN(ret, false,
       "[Snowflake Exception] arrow failed to build table from batches, errorInfo: %s",
-      ret.message().c_str());
+      ret.status().message().c_str());
+    m_cTable = ret.ValueOrDie();
 
     return true;
   }

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -137,8 +137,8 @@ void CArrowTableIterator::reconstructRecordBatches()
 
     if (needsRebuild)
     {
-     std::shared_ptr<arrow::Schema> newSchema = arrow::schema(futureFields, schema->metadata());
-     (*m_cRecordBatches)[batchIdx] = arrow::RecordBatch::Make(schema, currentBatch->num_rows(), currentBatch->columns());
+      std::shared_ptr<arrow::Schema> futureSchema = arrow::schema(futureFields, schema->metadata());
+      (*m_cRecordBatches)[batchIdx] = arrow::RecordBatch::Make(futureSchema, currentBatch->num_rows(), futureColumns);
     }
   }
 }

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -67,11 +67,14 @@ private:
   /**
    * replace column with the new column in place
    */
-  arrow::Status replaceColumn(
+  void replaceColumn(
     const unsigned int batchIdx,
     const int colIdx,
     const std::shared_ptr<arrow::Field>& newField,
-    const std::shared_ptr<arrow::Array>& newColumn);
+    const std::shared_ptr<arrow::Array>& newColumn,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild);
 
   /**
    * convert scaled fixed number column to double column
@@ -81,7 +84,10 @@ private:
     const int colIdx,
     const std::shared_ptr<arrow::Field> field,
     const std::shared_ptr<arrow::Array> columnArray,
-    const unsigned int scale);
+    const unsigned int scale,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild);
 
   /**
    * convert Snowflake Time column (Arrow int32/int64) to Arrow Time column
@@ -92,7 +98,10 @@ private:
     const int colIdx,
     const std::shared_ptr<arrow::Field> field,
     const std::shared_ptr<arrow::Array> columnArray,
-    const int scale);
+    const int scale,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild);
 
   /**
    * convert Snowflake TimestampNTZ/TimestampLTZ column to Arrow Timestamp column
@@ -103,6 +112,9 @@ private:
     const std::shared_ptr<arrow::Field> field,
     const std::shared_ptr<arrow::Array> columnArray,
     const int scale,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild,
     const std::string timezone="");
 
   /**
@@ -116,7 +128,10 @@ private:
     const std::shared_ptr<arrow::Field> field,
     const std::shared_ptr<arrow::Array> columnArray,
     const int scale,
-    const int byteLength);
+    const int byteLength,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild);
 
   /**
    * convert scaled fixed number to double

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -506,7 +506,7 @@ def validate_pandas(conn_cnx, sql, cases, col_count, method='one', data_type='fl
                             time_str_len = 8 if scale == 0 else 9 + scale
                             c_case = cases[i].strip()[:time_str_len]
                             c_new = str(c_new).strip()[:time_str_len]
-                            assert c_case == c_new, '{} row, {} column: original value is {}, ' \
+                            assert c_new == c_case, '{} row, {} column: original value is {}, ' \
                                                     'new value is {}, ' \
                                                     'values are not equal'.format(i, j, cases[i],
                                                                                   c_new)


### PR DESCRIPTION
SNOW-230346
Previously when returning NUMBERs with a non-zero scales need to be converted into doubles and switched out in the RecordBatches. Every time `AddColumn` and `DeleteColumn` were called they had to do a lot of resizing of hashmaps and copying a lot of values into new objects.
This PR removes the need to use `AddColumn` and `DeleteColumn` and instead operates on the underlying data and rebuilds RecordBatches only if necessary.

The query provided to me by support went from:
```
48.83139857795322
0.8859019490191713
```

to

```
2.7106516549829394
0.9343068830203265
```

Note that I got a lot more consistent numbers previously, I think my computer is just busier right now.
I was getting numbers close to `0.9` and `0.7` seconds.