### PR TITLE
SNOW-80651 renamed SnowflakeConnection.safe_to_destroy to something less confusi…

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -437,7 +437,7 @@ class SnowflakeConnection(object):
             # close telemetry first, since it needs rest to send remaining data
             logger.info('closed')
             self._telemetry.close(send_on_close=retry)
-            if self._all_aync_queries_finished():
+            if self._all_async_queries_finished():
                 logger.info('No async queries seem to be running, deleting session')
                 self.rest.delete_session(retry=retry)
             else:
@@ -1231,7 +1231,7 @@ class SnowflakeConnection(object):
             QueryStatus.BLOCKED,
         )
 
-    def _all_aync_queries_finished(self) -> bool:
+    def _all_async_queries_finished(self) -> bool:
         """Checks whether all async queries started by this Connection have finished executing."""
         queries = copy.copy(self._async_sfqids)  # get_query_status might update _async_sfqids, let's copy the list
         finished_async_queries = (not self.is_still_running(self.get_query_status(q)) for q in queries)

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -134,7 +134,7 @@ def test_done_caching(conn_cnx):
             assert con.get_query_status(qid2) == QueryStatus.SUCCESS
             assert len(con._async_sfqids) == 0
             assert len(con._done_async_sfqids) == 2
-            assert con.safe_to_close()
+            assert con._all_aync_queries_finished()
 
 
 def test_invalid_uuid_get_status(conn_cnx):

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -134,7 +134,7 @@ def test_done_caching(conn_cnx):
             assert con.get_query_status(qid2) == QueryStatus.SUCCESS
             assert len(con._async_sfqids) == 0
             assert len(con._done_async_sfqids) == 2
-            assert con._all_aync_queries_finished()
+            assert con._all_async_queries_finished()
 
 
 def test_invalid_uuid_get_status(conn_cnx):


### PR DESCRIPTION
SNOW-80651
I'm renaming `safe_to_close` to `_all_aync_queries_finished`.

While working with the Docs team we found this name confusing, so I'm making it private and I gave it a more fitting name and better doc string.