### PR TITLE
SNOW-240336 adding Python 3.9 support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -88,7 +88,7 @@ jobs:
     needs: lint
     name: Build linux-py${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux1_x86_64
+    container: quay.io/pypa/manylinux2010_x86_64
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -108,7 +108,7 @@ jobs:
       - name: Generate wheel
         run: python${{ matrix.python-version }} -m pip wheel -v -w dist_tmp --no-deps .
       - name: Run auditwheel
-        run: auditwheel repair --plat manylinux2010_x86_64 -L connector dist_tmp/snowflake_connector_python*.whl -w dist
+        run: auditwheel repair --plat manylinux2014_x86_64 -L connector dist_tmp/snowflake_connector_python*.whl -w dist
       - name: Show wheels generated
         run: ls -lh dist
       - uses: actions/upload-artifact@v1
@@ -244,9 +244,9 @@ jobs:
       - name: Show wheels downloaded
         run: ls -lh dist
         shell: bash
-      - name: Remove manylinux1 wheel
+      - name: Remove manylinux2010 wheel
         run: |
-          rm dist/*manylinux1*.whl
+          rm dist/*manylinux2010*.whl
           ls -lh dist
         if: matrix.os.download_name == 'linux'
       - name: Upgrade setuptools, pip and wheel
@@ -335,9 +335,9 @@ jobs:
       - name: Show wheels downloaded
         run: ls -lh dist
         shell: bash
-      - name: Remove manylinux1 wheel
+      - name: Remove manylinux2010 wheel
         run: |
-          rm dist/*manylinux1*.whl
+          rm dist/*manylinux2010*.whl
           ls -lh dist
       - name: Run tests
         run: ./ci/test_fips_docker.sh

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -91,7 +91,7 @@ jobs:
     container: quay.io/pypa/manylinux1_x86_64
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v1
       - name: Updating path
@@ -100,6 +100,7 @@ jobs:
           echo "/opt/python/cp36-cp36m/bin/" >> $GITHUB_PATH
           echo "/opt/python/cp37-cp37m/bin/" >> $GITHUB_PATH
           echo "/opt/python/cp38-cp38/bin/" >> $GITHUB_PATH
+          echo "/opt/python/cp39-cp39/bin/" >> $GITHUB_PATH
       - name: Display Python version
         run: python${{ matrix.python-version }} -c "import sys; print(sys.version)"
       - name: Upgrade setuptools and pip
@@ -128,6 +129,8 @@ jobs:
             link: https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.9.pkg
           - version: 3.8
             link: https://www.python.org/ftp/python/3.8.0/python-3.8.0-macosx10.9.pkg
+          - version: 3.9
+            link: https://www.python.org/ftp/python/3.9.0/python-3.9.0-macosx10.9.pkg
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -157,7 +160,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -216,7 +219,7 @@ jobs:
            download_name: macos
          - image_name: windows-latest
            download_name: windows
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         cloud-provider: [aws, azure, gcp]
     steps:
       - uses: actions/checkout@v2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ timestamps {
           'Test Python 36': { build job: 'RT-PyConnector36-PC',parameters: params},
           'Test Python 37': { build job: 'RT-PyConnector37-PC',parameters: params},
           'Test Python 38': { build job: 'RT-PyConnector38-PC',parameters: params},
+          'Test Python 39': { build job: 'RT-PyConnector39-PC',parameters: params},
           'Test Python Lambda 37': { build job: 'RT-PyConnector37-PC-Lambda',parameters: params}
           )
         }

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -3,7 +3,7 @@
 # Build Snowflake Python Connector on Mac
 # NOTES:
 #   - To compile only a specific version(s) pass in versions like: `./build_darwin.sh "3.5 3.6"`
-PYTHON_VERSIONS="${1:-3.6 3.7 3.8}"
+PYTHON_VERSIONS="${1:-3.6 3.7 3.8 3.9}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="$CONNECTOR_DIR/dist"

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -15,7 +15,7 @@ cd $THIS_DIR/docker/connector_build
 CONTAINER_NAME=build_pyconnector
 
 echo "[Info] Building docker image"
-docker build --no-cache --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
+docker build --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
 
 echo "[Info] Building Python Connector"
 user_id=$(id -u ${USER})

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -15,7 +15,7 @@ cd $THIS_DIR/docker/connector_build
 CONTAINER_NAME=build_pyconnector
 
 echo "[Info] Building docker image"
-docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX1 -f Dockerfile .
+docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
 
 echo "[Info] Building Python Connector"
 user_id=$(id -u ${USER})

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -15,7 +15,7 @@ cd $THIS_DIR/docker/connector_build
 CONTAINER_NAME=build_pyconnector
 
 echo "[Info] Building docker image"
-docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
+docker build --no-cache --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
 
 echo "[Info] Building Python Connector"
 user_id=$(id -u ${USER})

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -7,7 +7,7 @@
 set -o pipefail
 
 U_WIDTH=16
-PYTHON_VERSIONS="${1:-3.6 3.7 3.8}"
+PYTHON_VERSIONS="${1:-3.6 3.7 3.8 3.9}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="${CONNECTOR_DIR}/dist"

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -6,7 +6,7 @@
 SET SCRIPT_DIR=%~dp0
 SET CONNECTOR_DIR=%~dp0\..\
 
-set python_versions= 3.6 3.7 3.8
+set python_versions= 3.6 3.7 3.8 3.9
 
 cd %CONNECTOR_DIR%
 

--- a/ci/docker/connector_build/Dockerfile
+++ b/ci/docker/connector_build/Dockerfile
@@ -1,5 +1,5 @@
 # We use manylinux1 base image because pyarrow_manylinux2010 has a bug and wheel failed to be audited
-ARG BASE_IMAGE=quay.io/pypa/manylinux1_x86_64
+ARG BASE_IMAGE=quay.io/pypa/manylinux2010_x86_64
 FROM $BASE_IMAGE
 
 # This is to solve permission issue, read https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
@@ -13,6 +13,6 @@ WORKDIR /home/user
 RUN chmod 777 /home/user
 RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout b943f33a92772fd52c2fa38c03d08aac974c53bd
 
-ENV PATH="${PATH}:/opt/python/cp35-cp35m/bin:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin"
+ENV PATH="${PATH}:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/docker/connector_build/Dockerfile
+++ b/ci/docker/connector_build/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 WORKDIR /home/user
 RUN chmod 777 /home/user
-RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout b943f33a92772fd52c2fa38c03d08aac974c53bd
+RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout bfc6d8b82d8c37b8ca1e386081fd800e81c6ab4a
 
 ENV PATH="${PATH}:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin"
 

--- a/ci/docker/connector_test/Dockerfile
+++ b/ci/docker/connector_test/Dockerfile
@@ -12,6 +12,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 WORKDIR /home/user
 RUN chmod 777 /home/user
-ENV PATH="${PATH}:/opt/python/cp35-cp35m/bin:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin/"
+ENV PATH="${PATH}:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin/:/opt/python/cp39-cp39/bin/"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -8,8 +8,8 @@ if [[ -n "$NEXUS_PASSWORD" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     NEXUS_USER=${USERNAME:-jenkins}
     docker login --username "$NEXUS_USER" --password "$NEXUS_PASSWORD" $INTERNAL_REPO
-    export BASE_IMAGE_MANYLINUX2010=nexus.int.snowflakecomputing.com:8086/docker/manylinux2010_x86_64:latest
-    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64:latest
+    export BASE_IMAGE_MANYLINUX2010=nexus.int.snowflakecomputing.com:8086/docker/manylinux2010_x86_64
+    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64
 else
     echo "[INFO] Pull docker images from public registry"
     export BASE_IMAGE_MANYLINUX2010=quay.io/pypa/manylinux2010_x86_64

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -8,10 +8,10 @@ if [[ -n "$NEXUS_PASSWORD" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     NEXUS_USER=${USERNAME:-jenkins}
     docker login --username "$NEXUS_USER" --password "$NEXUS_PASSWORD" $INTERNAL_REPO
-    export BASE_IMAGE_MANYLINUX1=nexus.int.snowflakecomputing.com:8086/docker/manylinux1_x86_64:latest
     export BASE_IMAGE_MANYLINUX2010=nexus.int.snowflakecomputing.com:8086/docker/manylinux2010_x86_64:latest
+    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64:latest
 else
     echo "[INFO] Pull docker images from public registry"
-    export BASE_IMAGE_MANYLINUX1=quay.io/pypa/manylinux1_x86_64
     export BASE_IMAGE_MANYLINUX2010=quay.io/pypa/manylinux2010_x86_64
+    export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux2014_x86_64
 fi

--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -5,7 +5,7 @@
 #   - Versions to be tested should be passed in as the first argument, e.g: "3.5 3.6". If omitted 3.5-3.8 will be assumed.
 #   - This script uses .. to download the newest wheel files from S3
 
-PYTHON_VERSIONS="${1:-3.6 3.7 3.8}"
+PYTHON_VERSIONS="${1:-3.6 3.7 3.8 3.9}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 PARAMETERS_DIR="${CONNECTOR_DIR}/.github/workflows/parameters/public"

--- a/ci/test_docker.sh
+++ b/ci/test_docker.sh
@@ -20,7 +20,7 @@ cd $THIS_DIR/docker/connector_test
 CONTAINER_NAME=test_pyconnector
 
 echo "[Info] Building docker image"
-docker build --no-cache --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014 -f Dockerfile .
+docker build --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014 -f Dockerfile .
 
 user_id=$(id -u ${USER})
 docker run --network=host \

--- a/ci/test_docker.sh
+++ b/ci/test_docker.sh
@@ -20,7 +20,7 @@ cd $THIS_DIR/docker/connector_test
 CONTAINER_NAME=test_pyconnector
 
 echo "[Info] Building docker image"
-docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2010 -f Dockerfile .
+docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014 -f Dockerfile .
 
 user_id=$(id -u ${USER})
 docker run --network=host \

--- a/ci/test_docker.sh
+++ b/ci/test_docker.sh
@@ -20,7 +20,7 @@ cd $THIS_DIR/docker/connector_test
 CONTAINER_NAME=test_pyconnector
 
 echo "[Info] Building docker image"
-docker build -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014 -f Dockerfile .
+docker build --no-cache --pull -t ${CONTAINER_NAME}:1.0 --build-arg BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014 -f Dockerfile .
 
 user_id=$(id -u ${USER})
 docker run --network=host \

--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -6,7 +6,7 @@
 #   - This script assumes that ../dist/repaired_wheels has the wheel(s) built for all versions to be tested
 #   - This is the script that test_docker.sh runs inside of the docker container
 
-PYTHON_VERSIONS="${1:-3.6 3.7 3.8}"
+PYTHON_VERSIONS="${1:-3.6 3.7 3.8 3.9}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ requires = [
     "wheel",
     "cython",
     # Must be kept in sync with the `setup_requirements` in `setup.py`
-    'pyarrow>=0.17.0,<0.18.0',
+    'pyarrow>=3.0.0,<3.1.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -73,13 +73,11 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
         # upgraded
         arrow_libs_to_copy = {
             'linux': ['libarrow.so.300',
-                      'libarrow_python.so.300',
-                      'libarrow_flight.so.300'],
+                      'libarrow_python.so.300'],
             'darwin': ['libarrow.300.dylib',
                        'libarrow_python.300.dylib'],
             'win32': ['arrow.dll',
-                      'arrow_python.dll',
-                      'zlib.dll']
+                      'arrow_python.dll']
         }
 
         arrow_libs_to_link = {

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ cmd_class = {}
 
 pandas_requirements = [
     # Must be kept in sync with pyproject.toml
-    'pyarrow>=0.17.0,<0.18.0',
+    'pyarrow>=3.0.0,<3.1.0',
     'pandas>=1.0.0,<1.2.0',
 ]
 
@@ -72,21 +72,21 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
         # this list should be carefully examined when pyarrow lib is
         # upgraded
         arrow_libs_to_copy = {
-            'linux': ['libarrow.so.17',
-                      'libarrow_python.so.17',
-                      'libarrow_flight.so.17'],
-            'darwin': ['libarrow.17.dylib',
-                       'libarrow_python.17.dylib'],
+            'linux': ['libarrow.so.300',
+                      'libarrow_python.so.300',
+                      'libarrow_flight.so.300'],
+            'darwin': ['libarrow.300.dylib',
+                       'libarrow_python.300.dylib'],
             'win32': ['arrow.dll',
                       'arrow_python.dll',
                       'zlib.dll']
         }
 
         arrow_libs_to_link = {
-            'linux': ['libarrow.so.17',
-                      'libarrow_python.so.17'],
-            'darwin': ['libarrow.17.dylib',
-                       'libarrow_python.17.dylib'],
+            'linux': ['libarrow.so.300',
+                      'libarrow_python.so.300'],
+            'darwin': ['libarrow.300.dylib',
+                       'libarrow_python.300.dylib'],
             'win32': ['arrow.lib',
                       'arrow_python.lib']
         }

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ setup(
         'requests<3.0.0',
         'certifi<2021.0.0',
         'pytz',
-        'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
+        'pycryptodomex>=3.2,!=3.5.0,<3.10.0',
         'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',
         'cryptography>=2.5.0,<4.0.0',

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ source = src/snowflake/connector
 [tox]
 minversion = 3.7
 envlist = fix_lint,
-          py{35,36,37,38}-{extras,unit,integ,pandas,sso},
+          py{36,37,38,39}-{extras,unit,integ,pandas,sso},
           coverage
 skip_missing_interpreters = true
 requires =
@@ -38,6 +38,7 @@ external_wheels =
     py36-ci: dist/*cp36*.whl
     py37-ci: dist/*cp37*.whl
     py38-ci: dist/*cp38*.whl
+    py39-ci: dist/*cp39*.whl
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_OPTS = -vvv
@@ -107,9 +108,9 @@ commands = coverage combine
            coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/coverage.xml
            coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov
 ;           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
-depends = py35, py36, py37, py38
+depends = py36, py37, py38, py39
 
-[testenv:py{36,37,38}-coverage]
+[testenv:py{36,37,38,39}-coverage]
 # I hate doing this, but this env is for Jenkins, please keep it up-to-date with the one env above it if necessary
 description = [run locally after tests]: combine coverage data and create report specifically with {basepython}
 deps = {[testenv:coverage]deps}


### PR DESCRIPTION
SNOW-240336
Adding support and testing for Python 3.9 for both Jenkins and GH actions.
`pyarrow` dropped releasing `manylinux1` wheels, so I did some digging and it appears as it's okay for us to do the same as well.