### PR TITLE
SNOW-208979 Add option to trigger Github Action Build/Test manually

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,6 +10,14 @@ on:
         branches:
             - master
             - prep-**
+    workflow_dispatch:
+        inputs:
+          logLevel:
+            default: warning
+            description: "Log level"
+            required: true
+          tags:
+            description: "Test scenario tags"
 
 jobs:
   lint:


### PR DESCRIPTION
This will add a button for build-test workflow to run it manually . This will be useful for Releng team to run python tests on master  or any other branch as part of pre-release of server release is done to ensure it does not break python connector