### PR TITLE
SNOW-236836 Remove the reference to the change that adds support for MFA token caching

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -12,7 +12,6 @@ Release Notes
 
 - v2.3.7(December 10,2020)
 
-   - Added support for MFA token caching.
    - Added support for upcoming downscoped GCS credentials.
    - Tightened the pyOpenSSL dependency pin.
    - Relaxed the boto3 dependency pin up to the next major release.


### PR DESCRIPTION
Description
Remove the reference to the change that adds support for MFA token caching.
This feature isn't available to customers yet, so it's not useful for customers to know that the
driver supports this feature.