### PR TITLE
SNOW-230857 add extra coverage publishing for debugging purposes

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -386,10 +386,16 @@ jobs:
               shutil.copy(str(src_file), str(dst_file))'
       - name: Combine coverages
         run: python -m tox -e coverage
-      - uses: actions/upload-artifact@v2
+      - name: Publish html coverage
+        uses: actions/upload-artifact@v2
         with:
           name: overall_cov_html
           path: .tox/htmlcov
+      - name: Publish xml coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: overall_cov_xml
+          path: .tox/coverage.xml
       - uses: codecov/codecov-action@v1
         with:
           file: .tox/coverage.xml


### PR DESCRIPTION
Adds an extra XML code coverage publishing, split from #557 
These XMLs will help us to debug what is going wrong with some codecov reports