### PR TITLE
SNOW-256116 retiring flake8 tests

### DIFF
--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -36,8 +36,8 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     echo "[Info] Building for ${PYTHON_VERSION} with $PYTHON"
     # Clean up possible build artifacts
     rm -rf build generated_version.py
-    # Update PEP-517 dependencies and flake8
-    ${PYTHON} -m pip install -U pip setuptools
+    # Update PEP-517 dependencies
+    ${PYTHON} -m pip install -U pip setuptools wheel
     # Use new PEP-517 build
     ${PYTHON} -m pip wheel -w ${BUILD_DIR} --no-deps .
     # On Linux we should repair wheel(s) generated

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -19,10 +19,7 @@ if %errorlevel% neq 0 goto :error
 call %venv_dir%\scripts\activate
 if %errorlevel% neq 0 goto :error
 
-python -m pip install --upgrade pip setuptools flake8
-if %errorlevel% neq 0 goto :error
-
-flake8
+python -m pip install --upgrade pip setuptools wheel
 if %errorlevel% neq 0 goto :error
 
 (for %%v in (%python_versions%) do (


### PR DESCRIPTION
Since we switched to `precommit-hooks` to run `flake8` tests, our regular flake8 settings have been unmaintained, so when we added the newly vendored libraries this started failing our Jenkins Windows build job.

I think we can simply remove the `flake8` tests from the build jobs (we have already removed it from the Mac and Linux build jobs) as `fix_lint` will run on GitHub for sure.

Successful jobs with this change:
Build: https://jenkins.int.snowflakecomputing.com/view/ClientMasterJobs/job/BuildPyConnector-Win/151
PY36: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector36-Win/148
PY37: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector37-Win/144
PY38: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector38-Win/33/