### PR TITLE
SNOW-257201 Explain why requests, urllib3 are still used 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,8 +195,8 @@ setup(
         'azure-common<2.0.0',
         'azure-storage-blob>=12.0.0,<13.0.0',
         'boto3>=1.4.4,<2.0.0',
+        # While requests is vendored, we use regular requests to perform OCSP checks
         'requests<3.0.0',
-        'urllib3<2.0.0',
         'certifi<2021.0.0',
         'pytz<2021.0',
         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -23,6 +23,9 @@ from threading import Lock, RLock
 from time import gmtime, strftime
 
 import jwt
+# We use regular requests and urlib3 when we reach out to do OCSP checks, basically in this very narrow
+# part of the code where we want to call out to check for revoked certificates,
+# we don't want to use our hardened version of requests.
 import requests as generic_requests
 
 from snowflake.connector.compat import OK, urlsplit
@@ -1265,6 +1268,8 @@ class SnowflakeOCSP(object):
                     self.read_cert_bundle(ca_bundle)
                 else:
                     import sys
+                    # This import that depends on these libraries is to import certificates from them,
+                    # we would like to have these as up to date as possible.
                     from requests import certs
                     if hasattr(certs, '__file__') and \
                             path.exists(certs.__file__) and \

--- a/src/snowflake/connector/ssl_wrap_socket.py
+++ b/src/snowflake/connector/ssl_wrap_socket.py
@@ -20,12 +20,12 @@ from typing import Optional
 
 import certifi
 import OpenSSL.SSL
-from urllib3.contrib.pyopenssl import PyOpenSSLContext
 
 from .constants import OCSPMode
 from .errorcode import ER_OCSP_RESPONSE_CERT_STATUS_REVOKED
 from .errors import OperationalError
 from .vendored.urllib3 import connection as connection_
+from .vendored.urllib3.contrib.pyopenssl import PyOpenSSLContext
 from .vendored.urllib3.util import ssl_ as ssl_
 
 FEATURE_OCSP_MODE = OCSPMode.FAIL_OPEN

--- a/src/snowflake/connector/vendored/urllib3/contrib/_securetransport/bindings.py
+++ b/src/snowflake/connector/vendored/urllib3/contrib/_securetransport/bindings.py
@@ -45,7 +45,7 @@ from ctypes import (
     c_bool,
 )
 from ctypes import CDLL, POINTER, CFUNCTYPE
-from urllib3.packages.six import raise_from
+from snowflake.connector.vendored.urllib3.packages.six import raise_from
 
 
 if platform.system() != "Darwin":

--- a/test/extras/no_use_pycon.py
+++ b/test/extras/no_use_pycon.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
 #
 # This test tests for SNOW-186747
-
 import requests
 
 import snowflake.connector  # NOQA

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -28,6 +28,7 @@ from snowflake.connector.errorcode import (
 from snowflake.connector.errors import Error, ForbiddenError
 from snowflake.connector.network import APPLICATION_SNOWSQL, ReauthenticationRequest
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
+from snowflake.connector.vendored import urllib3
 
 try:  # pragma: no cover
     from parameters import (CONNECTION_PARAMETERS_ADMIN)
@@ -614,7 +615,6 @@ class ExecPrivatelinkThread(threading.Thread):
 
 
 def test_another_site(db_parameters):
-    import urllib3
 
     def get(url):
         pool_manager = urllib3.PoolManager()

--- a/test/integ/test_put_get_with_gcp_account.py
+++ b/test/integ/test_put_get_with_gcp_account.py
@@ -22,8 +22,8 @@ from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent, 
 from ..generate_test_files import generate_k_lines_of_n_files
 from ..randomize import random_string
 
+# We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
 try:
-    from snowflake.connector.vendored import requests  # NOQA
     vendored_request = True
 except ImportError:  # pragma: no cover
     import requests

--- a/test/unit/test_gcs_util.py
+++ b/test/unit/test_gcs_util.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     SnowflakeGCSUtil = None
 
+# We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
 try:
     from snowflake.connector.vendored import requests  # NOQA
     vendored_request = True

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -27,6 +27,7 @@ from snowflake.connector.compat import (
 from snowflake.connector.errors import DatabaseError, InterfaceError, OtherHTTPRetryableError
 from snowflake.connector.network import STATUS_TO_EXCEPTION, RetryRequest, SnowflakeRestful
 
+# We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
 try:
     from snowflake.connector.vendored import requests  # NOQA
     from snowflake.connector.vendored import urllib3  # NOQA

--- a/tox.ini
+++ b/tox.ini
@@ -161,7 +161,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 120
 known_first_party =snowflake,parameters,generate_test_files
-known_third_party =Cryptodome,OpenSSL,asn1crypto,azure,boto3,botocore,certifi,chardet,cryptography,dateutil,idna,jwt,mock,ntlm,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools,urllib3
+known_third_party =Cryptodome,OpenSSL,asn1crypto,azure,boto3,botocore,certifi,chardet,cryptography,dateutil,idna,jwt,mock,ntlm,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools
 
 [flake8]
 ignore=F821,W504,E501,E402,E122,E127,E126,E128,E131,E731,E125,E722x,D100,D101,D102,D103,D104,D105,D107,D401,D204


### PR DESCRIPTION
This PR explains why urllib3 and requests are
still used. The PR #557 vendored in urrlib3
and request libraries but some usages of the
original libraries remained (but were not
explained)

This was not clear from the code why urllib and requests
are still used but after explanations the comments
about it have been placed in the code.

Also some inconsistencies have been removed where
the old urlib3 and requests were directly referred to,
while the vendored version should be used insted.
