### PR TITLE
Update License header requirement from 2020 to 2021

### DIFF
--- a/license_header.txt
+++ b/license_header.txt
@@ -1,3 +1,3 @@
 
-Copyright (c) 2012-2020 Snowflake Computing Inc. All right reserved.
+Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 


### PR DESCRIPTION
We use Flake8 to enforce header requirements. This requirement needs to be updated to account for the new year. 