### PR TITLE
SNOW-232777 Subclass-ed HTTPAdapter to add the header to proxy headers

### DIFF
--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -175,6 +175,7 @@ class ProxySupportAdapter(HTTPAdapter):
 
     def get_connection(self, url, proxies=None):
         proxy = select_proxy(url, proxies)
+        parsed_url = urlparse(url)
 
         if proxy:
             proxy = prepend_scheme_if_needed(proxy, 'http')
@@ -183,14 +184,13 @@ class ProxySupportAdapter(HTTPAdapter):
                 raise InvalidProxyURL("Please check proxy URL. It is malformed"
                                       " and could be missing the host.")
             proxy_manager = self.proxy_manager_for(proxy)
-            parsed_url = urlparse(url)
+
             # Add Host to proxy header SNOW-232777
             proxy_manager.proxy_headers['Host'] = parsed_url.hostname
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case
-            parsed = urlparse(url)
-            url = parsed.geturl()
+            url = parsed_url.geturl()
             conn = self.poolmanager.connection_from_url(url)
 
         return conn

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -17,7 +17,6 @@ from io import BytesIO
 from threading import Lock
 
 import OpenSSL.SSL
-from urllib3.util.url import parse_url
 
 from . import ssl_wrap_socket
 from .compat import (
@@ -83,6 +82,7 @@ from .vendored.requests.auth import AuthBase
 from .vendored.requests.exceptions import ConnectionError, ConnectTimeout, InvalidProxyURL, ReadTimeout, SSLError
 from .vendored.requests.utils import prepend_scheme_if_needed, select_proxy
 from .vendored.urllib3.exceptions import ProtocolError, ReadTimeoutError
+from .vendored.urllib3.util.url import parse_url
 
 logger = logging.getLogger(__name__)
 

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -186,7 +186,7 @@ class ProxySupportAdapter(HTTPAdapter):
             proxy_manager = self.proxy_manager_for(proxy)
 
             # Add Host to proxy header SNOW-232777
-            proxy_manager.proxy_headers['Host'] = parsed_url.hostname
+            proxy_manager.proxy_headers['Host'] = "{}:{}".format(parsed_url.hostname, parsed_url.port)
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -186,7 +186,7 @@ class ProxySupportAdapter(HTTPAdapter):
             proxy_manager = self.proxy_manager_for(proxy)
 
             # Add Host to proxy header SNOW-232777
-            proxy_manager.proxy_headers['Host'] = "{}:{}".format(parsed_url.hostname, parsed_url.port)
+            proxy_manager.proxy_headers['Host'] = parsed_url.hostname
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case

--- a/tox.ini
+++ b/tox.ini
@@ -161,7 +161,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 120
 known_first_party =snowflake,parameters,generate_test_files
-known_third_party =Cryptodome,OpenSSL,asn1crypto,azure,boto3,botocore,certifi,chardet,cryptography,dateutil,idna,jwt,mock,ntlm,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools,urllib3
+known_third_party =Cryptodome,OpenSSL,asn1crypto,azure,boto3,botocore,certifi,chardet,cryptography,dateutil,idna,jwt,mock,ntlm,numpy,pendulum,pkg_resources,pytest,pytz,requests,setuptools
 
 [flake8]
 ignore=F821,W504,E501,E402,E122,E127,E126,E128,E131,E731,E125,E722x,D100,D101,D102,D103,D104,D105,D107,D401,D204


### PR DESCRIPTION
This fix addresses the customer ticket SNOW-232777. 

A lot of Snowflake customers have strict data inspection requirements which requires them to use MiTM proxies. Python connector uses the Python Requests module to manage all the connectivity which internally takes care of connecting to proxies as well. However the Requests module internally uses urllib3 which internally uses http lib for connecting to proxies (python http lib > client.py > class HTTPConnection  > _tunnel() ). This routine only support HTTP/1.0 based CONNECT messages that do not need the presence of a HOST header in the connect request. The latest HTTP protocol RFC however mandates the presence of a HOST header in all CONNECT messages. 

This PR creates a subclass of the Requests HTTPAdapter class to gain access to the ProxyManager class. The latter provides access to the proxy_header instance that can be manually updated to include the HOST header thereby forcing the underlying http lib to add that header to the initial CONNECT request. 

This fix has been manually tested with pcaps collected and verified in Wireshark. Post this fix the initial CONNECT message to the proxy contains the HOST header. However we do not have access to a setup with a proxy that explicitly looks for such a header for us to test it.