### PR TITLE
SNOW-270639 pyjwt major bump and compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
         'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',
         'cryptography>=2.5.0,<4.0.0',
-        'pyjwt',
+        'pyjwt<3.0.0',
         'oscrypto<2.0.0',
         'asn1crypto>0.24.0,<2.0.0',
         # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
         'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',
         'cryptography>=2.5.0,<4.0.0',
-        'pyjwt<2.0.0',
+        'pyjwt',
         'oscrypto<2.0.0',
         'asn1crypto>0.24.0,<2.0.0',
         # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is

--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -74,8 +74,18 @@ class AuthByKeyPair(AuthByPlugin):
             self.EXPIRE_TIME: self._jwt_token_exp
         }
 
-        self._jwt_token = jwt.encode(payload, private_key,
-                                     algorithm=self.ALGORITHM).decode('utf-8')
+        _jwt_token = jwt.encode(
+            payload,
+            private_key,
+            algorithm=self.ALGORITHM
+        )
+
+        # jwt.encode() returns bytes in pyjwt 1.x and a string
+        # in pyjwt 2.x
+        if isinstance(_jwt_token, bytes):
+            self._jwt_token = _jwt_token.decode('utf-8')
+        else:
+            self._jwt_token = _jwt_token
 
         return self._jwt_token
 


### PR DESCRIPTION
`pyjwt` 2.0.0 was released [about a month ago](https://github.com/jpadilla/pyjwt/releases/tag/2.0.0). In that release, the behavior of `jwt.encode()` changed. It now returns a string instead of `bytes`, which is what caused the bug reported in #586 .

This PR proposes removing any version requirements on `pyjwt` in `snowflake-connector-python`. I think with the minor changes proposed in this PR, it's possible for `snowflake-connector-python` to work with both `pyjwt` 1.x and `pyjwt` 2.x.

## Changes in this PR

* makes the one use of `jwt.encode()` in this project compatible with `pyjwt` 1.x and 2.x
* removes version constraint on `pyjwt`

## How this improves `snowflake-connector-python`

This change would make `snowflake-connector-python` easier to install alongside other packages, because it relaxes a constraint placed on a popular and central package (`pyjwt`).

I think this could be a small step towards alleviating some of the dependency pain expressed in #284.

## Notes for reviewers

I looked for uses of `pyjwt` in this project with `git grep -E "jwt\."`. I think that the uses of `get_unverified_header()` and `.decode()` will work without modification, with both 1.x and 2.x.

`get_unverified_header()` was not changed between versions.

2.0.1 (https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/jwt/api_jws.py)

```python
def get_unverified_header(self, jwt):
    """Returns back the JWT header parameters as a dict()
    Note: The signature is not verified so the header parameters
    should not be fully trusted until signature verification is complete
    """
    headers = self._load(jwt)[2]
    self._validate_headers(headers)

    return headers

def _validate_headers(self, headers):
    if "kid" in headers:
        self._validate_kid(headers["kid"])

def _validate_kid(self, kid):
    if not isinstance(kid, str):
        raise InvalidTokenError("Key ID header parameter must be a string")
```

1.7.1 (https://github.com/jpadilla/pyjwt/blob/b65e1ac6dc4d11801f3642eaab34ae6a54162c18/jwt/api_jws.py)

```python
def get_unverified_header(self, jwt):
    """Returns back the JWT header parameters as a dict()
    Note: The signature is not verified so the header parameters
    should not be fully trusted until signature verification is complete
    """
    headers = self._load(jwt)[2]
    self._validate_headers(headers)

    return headers

def _validate_headers(self, headers):
    if 'kid' in headers:
        self._validate_kid(headers['kid'])

def _validate_kid(self, kid):
    if not isinstance(kid, string_types):
        raise InvalidTokenError('Key ID header parameter must be a string')

```

`.decode()` in 2.x still supports algorithm RS512

https://github.com/jpadilla/pyjwt/blob/9dca8eaa0ec43bcf54ac645872078ecdb0ca8d96/jwt/algorithms.py#L80

Thanks for your time and consideration.