### PR TITLE
SNOW-274851 removing pytz pin as it doesn't follow semver anyway

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
         # While requests is vendored, we use regular requests to perform OCSP checks
         'requests<3.0.0',
         'certifi<2021.0.0',
-        'pytz<2021.0',
+        'pytz',
         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
         'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',


### PR DESCRIPTION
This PR removes the upper version pin of `pytz`, as this library doesn't follow semantic versioning I don't see a reason to maintain an upper pin. Secondly it has not broken testing yet, so I'm going to give it the benefit of the doubt and remove the upper pin until it breaks something in our testing pipeline.