### PR TITLE
SNOW-281257 pin cryptodomex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ setup(
         'requests<3.0.0',
         'certifi<2021.0.0',
         'pytz',
-        'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
+        'pycryptodomex>=3.2,!=3.5.0,<3.10.0',
         'pyOpenSSL>=16.2.0,<20.0.0',
         'cffi>=1.9,<2.0.0',
         'cryptography>=2.5.0,<4.0.0',


### PR DESCRIPTION
The newest `cryptodomex` release `3.10.1` is causing issues, making our 3.6 tests to hang indefinitely.
While we investigate the culprit pin to the last working version.