### PR TITLE
SNOW-136583 adding multipart PUT threshold support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
         'chardet>=3.0.2,<4',
         'idna>=2.5,<3',
         'certifi>=2017.4.17',
+        'dataclasses<1.0;python_version=="3.6"',
     ],
 
     namespace_packages=['snowflake'],

--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -39,7 +39,7 @@ from .errors import (
     NotSupportedError,
     OperationalError,
     ProgrammingError,
-    Warning,
+    _Warning,
 )
 from .version import VERSION
 
@@ -57,7 +57,7 @@ __version__ = SNOWFLAKE_CONNECTOR_VERSION
 
 __all__ = [
     # Error handling
-    'Error', 'Warning',
+    'Error', '_Warning',
     'InterfaceError', 'DatabaseError',
     'NotSupportedError', 'DataError', 'IntegrityError', 'ProgrammingError',
     'OperationalError', 'InternalError',

--- a/src/snowflake/connector/azure_util.py
+++ b/src/snowflake/connector/azure_util.py
@@ -188,7 +188,7 @@ class SnowflakeAzureUtil(object):
         upload_src = None
         upload_size = None
 
-        if 'src_stream' not in meta:
+        if meta.src_stream is None:
             upload_size = os.path.getsize(data_file)
             upload_src = open(data_file, 'rb')
         else:
@@ -237,7 +237,7 @@ class SnowflakeAzureUtil(object):
                 meta.result_status = ResultStatus.NEED_RETRY
             return
         finally:
-            if 'src_stream' not in meta:
+            if meta.src_stream is None:
                 upload_src.close()
 
         logger.debug('DONE putting a file')

--- a/src/snowflake/connector/azure_util.py
+++ b/src/snowflake/connector/azure_util.py
@@ -8,13 +8,16 @@ import json
 import os
 from collections import namedtuple
 from logging import getLogger
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient, ContentSettings, ExponentialRetry
 
-from .constants import HTTP_HEADER_VALUE_OCTET_STREAM, SHA256_DIGEST, FileHeader, ResultStatus
+from .constants import HTTP_HEADER_VALUE_OCTET_STREAM, FileHeader, ResultStatus
 from .encryption_util import EncryptionMetadata
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .file_transfer_agent import SnowflakeFileMeta
 
 logger = getLogger(__name__)
 
@@ -33,7 +36,8 @@ class SnowflakeAzureUtil(object):
     """Azure Utility class."""
 
     @staticmethod
-    def create_client(stage_info, use_accelerate_endpoint: bool = False):
+    def create_client(stage_info: Dict[str, Any],
+                      use_accelerate_endpoint: bool = False) -> BlobServiceClient:
         """Creates a client object with a stage credential.
 
         Args:
@@ -51,10 +55,7 @@ class SnowflakeAzureUtil(object):
         if end_point.startswith('blob.'):
             end_point = end_point[len('blob.'):]
         client = BlobServiceClient(
-            account_url="https://{}.blob.{}".format(
-                stage_info['storageAccount'],
-                end_point
-            ),
+            account_url=f"https://{stage_info['storageAccount']}.blob.{end_point}",
             credential=sas_token)
         client._config.retry_policy = ExponentialRetry(
             initial_backoff=1,
@@ -83,39 +84,34 @@ class SnowflakeAzureUtil(object):
             path=path)
 
     @staticmethod
-    def get_file_header(meta, filename):
+    def get_file_header(meta: 'SnowflakeFileMeta', filename):
         """Gets Azure file properties."""
-        client = meta['client']
-        azure_location = SnowflakeAzureUtil.extract_container_name_and_path(
-            meta['stage_info']['location'])
+        client: BlobServiceClient = meta.client
+        azure_location = SnowflakeAzureUtil.extract_container_name_and_path(meta.stage_info['location'])
         try:
             # HTTP HEAD request
             blob = client.get_blob_client(azure_location.container_name,
                                           azure_location.path + filename)
             blob_details = blob.get_blob_properties()
         except ResourceNotFoundError:
-            meta['result_status'] = ResultStatus.NOT_FOUND_FILE
+            meta.result_status = ResultStatus.NOT_FOUND_FILE
             return FileHeader(
                 digest=None,
                 content_length=None,
                 encryption_metadata=None
             )
         except HttpResponseError as err:
-            logger.debug("Caught exception's status code: {status_code} and message: {ex_representation}".format(
-                status_code=err.status_code,
-                ex_representation=str(err)
-            ))
+            logger.debug(f"Caught exception's status code: {err.status_code} and message: {str(err)}")
             if err.status_code == 403 and SnowflakeAzureUtil._detect_azure_token_expire_error(err):
                 logger.debug("AZURE Token expired. Renew and retry")
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
             else:
-                logger.debug('Unexpected Azure error: %s'
-                             'container: %s, path: %s',
-                             err, azure_location.container_name,
-                             azure_location.path)
-                meta['result_status'] = ResultStatus.ERROR
+                logger.debug(f'Unexpected Azure error: {err} '
+                             f'container: {azure_location.container_name}, path: {azure_location.path}')
+                meta.result_status = ResultStatus.ERROR
+
             return
-        meta['result_status'] = ResultStatus.UPLOADED
+        meta.result_status = ResultStatus.UPLOADED
         encryptiondata = json.loads(blob_details.metadata.get('encryptiondata', 'null'))
         encryption_metadata = EncryptionMetadata(
             key=encryptiondata['WrappedContentKey']['EncryptedKey'],
@@ -139,7 +135,7 @@ class SnowflakeAzureUtil(object):
 
     @staticmethod
     def upload_file(data_file: str,
-                    meta: Dict[str, Any],
+                    meta: 'SnowflakeFileMeta',
                     encryption_metadata: 'EncryptionMetadata',
                     max_concurrency: int,
                     multipart_threshold: int,
@@ -161,7 +157,7 @@ class SnowflakeAzureUtil(object):
             None.
         """
         azure_metadata = {
-            'sfcdigest': meta[SHA256_DIGEST],
+            'sfcdigest': meta.sha256_digest,
         }
         if encryption_metadata:
             azure_metadata.update({
@@ -184,10 +180,10 @@ class SnowflakeAzureUtil(object):
                 'matdesc': encryption_metadata.matdesc
             })
         azure_location = SnowflakeAzureUtil.extract_container_name_and_path(
-            meta['stage_info']['location'])
-        path = azure_location.path + meta['dst_file_name'].lstrip('/')
+            meta.stage_info['location'])
+        path = azure_location.path + meta.dst_file_name.lstrip('/')
 
-        client = meta['client']
+        client: BlobServiceClient = meta.client
         callback = None
         upload_src = None
         upload_size = None
@@ -196,16 +192,16 @@ class SnowflakeAzureUtil(object):
             upload_size = os.path.getsize(data_file)
             upload_src = open(data_file, 'rb')
         else:
-            upload_src = meta.get('real_src_stream', meta['src_stream'])
+            upload_src = meta.real_src_stream or meta.src_stream
             upload_size = upload_src.seek(0, os.SEEK_END)
             upload_src.seek(0)
 
-        if meta['put_azure_callback']:
-            callback = meta['put_azure_callback'](
+        if meta.put_azure_callback:
+            callback = meta.put_azure_callback(
                 data_file,
                 upload_size,
-                output_stream=meta['put_callback_output_stream'],
-                show_progress_bar=meta['show_progress_bar'])
+                output_stream=meta.put_callback_output_stream,
+                show_progress_bar=meta.show_progress_bar)
 
         def azure_callback(response):
             current = response.context['upload_stream_current']
@@ -213,8 +209,7 @@ class SnowflakeAzureUtil(object):
             if current is not None:
                 callback(current)
                 logger.debug("data transfer progress from sdk callback. "
-                             "current: %s, total: %s",
-                             current, total)
+                             f"current: {current}, total: {total}")
 
         try:
             blob = client.get_blob_client(
@@ -226,58 +221,51 @@ class SnowflakeAzureUtil(object):
                 metadata=azure_metadata,
                 overwrite=True,
                 max_concurrency=max_concurrency,
-                raw_response_hook=azure_callback if meta['put_azure_callback'] else None,
+                raw_response_hook=azure_callback if meta.put_azure_callback else None,
                 content_settings=ContentSettings(
                     content_type=HTTP_HEADER_VALUE_OCTET_STREAM,
                     content_encoding='utf-8',
                 )
             )
         except HttpResponseError as err:
-            logger.debug("Caught exception's status code: {status_code} and message: {ex_representation}".format(
-                status_code=err.status_code,
-                ex_representation=str(err)
-            ))
+            logger.debug(f"Caught exception's status code: {err.status_code} and message: {err}")
             if err.status_code == 403 and SnowflakeAzureUtil._detect_azure_token_expire_error(err):
                 logger.debug("AZURE Token expired. Renew and retry")
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
             else:
-                meta['last_error'] = err
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.last_error = err
+                meta.result_status = ResultStatus.NEED_RETRY
             return
         finally:
             if 'src_stream' not in meta:
                 upload_src.close()
 
         logger.debug('DONE putting a file')
-        meta['dst_file_size'] = meta['upload_size']
-        meta['result_status'] = ResultStatus.UPLOADED
+        meta.dst_file_size = meta.upload_size
+        meta.result_status = ResultStatus.UPLOADED
         # Comparing with s3, azure haven't experienced OpenSSL.SSL.SysCallError,
         # so we will add logic to catch it only when it happens
 
     @staticmethod
-    def _native_download_file(meta, full_dst_file_name, max_concurrency):
-        azure_location = SnowflakeAzureUtil.extract_container_name_and_path(
-            meta['stage_info']['location'])
-        path = azure_location.path + meta['src_file_name'].lstrip('/')
-        client = meta['client']
+    def _native_download_file(meta: 'SnowflakeFileMeta', full_dst_file_name, max_concurrency):
+        azure_location = SnowflakeAzureUtil.extract_container_name_and_path(meta.stage_info['location'])
+        path = azure_location.path + meta.src_file_name.lstrip('/')
+        client: BlobServiceClient = meta.client
 
         callback = None
-        if meta['get_azure_callback']:
-            callback = meta['get_azure_callback'](
-                meta['src_file_name'],
-                meta['src_file_size'],
-                output_stream=meta['get_callback_output_stream'],
-                show_progress_bar=meta['show_progress_bar'])
+        if meta.get_azure_callback:
+            callback = meta.get_azure_callback(
+                meta.src_file_name,
+                meta.src_file_size,
+                output_stream=meta.get_callback_output_stream,
+                show_progress_bar=meta.show_progress_bar)
 
         def azure_callback(response):
             current = response.context['download_stream_current']
             total = response.context['data_stream_total']
             if current is not None:
                 callback(current)
-                logger.debug("data transfer progress from sdk callback. "
-                             "current: %s, total: %s",
-                             current, total)
-
+                logger.debug(f"data transfer progress from sdk callback. current: {current}, total: {total}")
         try:
             blob = client.get_blob_client(
                 azure_location.container_name,
@@ -286,20 +274,17 @@ class SnowflakeAzureUtil(object):
             with open(full_dst_file_name, 'wb') as download_f:
                 download = blob.download_blob(
                     max_concurrency=max_concurrency,
-                    raw_response_hook=azure_callback if meta['put_azure_callback'] else None,
+                    raw_response_hook=azure_callback if meta.put_azure_callback else None,
                 )
                 download.readinto(download_f)
 
         except HttpResponseError as err:
-            logger.debug("Caught exception's status code: {status_code} and message: {ex_representation}".format(
-                status_code=err.status_code,
-                ex_representation=str(err)
-            ))
+            logger.debug(f"Caught exception's status code: {err.status_code} and message: {str(err)}")
             if err.status_code == 403 and SnowflakeAzureUtil._detect_azure_token_expire_error(err):
                 logger.debug("AZURE Token expired. Renew and retry")
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
             else:
-                meta['last_error'] = err
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.last_error = err
+                meta.result_status = ResultStatus.NEED_RETRY
             return
-        meta['result_status'] = ResultStatus.DOWNLOADED
+        meta.result_status = ResultStatus.DOWNLOADED

--- a/src/snowflake/connector/compat.py
+++ b/src/snowflake/connector/compat.py
@@ -90,9 +90,7 @@ try:
     # builtin dataclass
     from dataclass import dataclass  # NOQA
     from dataclass import field  # NOQA
-    from dataclass import asdict  # NOQA
 except ImportError:
     # backported dataclass for Python 3.6
     from dataclasses import dataclass  # NOQA
     from dataclasses import field  # NOQA
-    from dataclasses import asdict  # NOQA

--- a/src/snowflake/connector/compat.py
+++ b/src/snowflake/connector/compat.py
@@ -84,3 +84,15 @@ def PRINT(msg):
 
 def INPUT(prompt):
     return input(prompt)
+
+
+try:
+    # builtin dataclass
+    from dataclass import dataclass  # NOQA
+    from dataclass import field  # NOQA
+    from dataclass import asdict  # NOQA
+except ImportError:
+    # backported dataclass for Python 3.6
+    from dataclasses import dataclass  # NOQA
+    from dataclasses import field  # NOQA
+    from dataclasses import asdict  # NOQA

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -225,6 +225,7 @@ class SnowflakeConnection(object):
         self.heartbeat_thread = None
 
         self.converter = None
+        self.__set_error_attributes()
         self.connect(**kwargs)
         self._telemetry = TelemetryClient(self._rest)
         self.incident = IncidentAPI(self._rest)
@@ -419,7 +420,6 @@ class SnowflakeConnection(object):
             self.__config(**kwargs)
             TelemetryService.get_instance().update_context(kwargs)
 
-        self.__set_error_attributes()
         self.__open_connection()
 
     def close(self, retry=True):
@@ -533,7 +533,9 @@ class SnowflakeConnection(object):
     def __set_error_attributes(self):
         for m in [method for method in dir(errors) if
                   callable(getattr(errors, method))]:
-            setattr(self, m, getattr(errors, m))
+            # If name starts with _ then ignore that
+            name = m if not m.startswith('_') else m[1:]
+            setattr(self, name, getattr(errors, m))
 
     @staticmethod
     def setup_ocsp_privatelink(app, hostname):

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -566,7 +566,6 @@ class SnowflakeCursor(object):
             logger.debug('SUCCESS')
             data = ret['data']
 
-            # logger.debug(ret)
             logger.debug("PUT OR GET: %s", self.is_file_transfer)
             if self.is_file_transfer:
                 sf_file_transfer_agent = SnowflakeFileTransferAgent(
@@ -580,7 +579,9 @@ class SnowflakeCursor(object):
                     show_progress_bar=_show_progress_bar,
                     raise_put_get_error=_raise_put_get_error,
                     force_put_overwrite=_force_put_overwrite or data.get('overwrite', False),
-                    source_from_stream=file_stream)
+                    source_from_stream=file_stream,
+                    multipart_threshold=data.get('threshold'),
+                )
                 sf_file_transfer_agent.execute()
                 data = sf_file_transfer_agent.result()
                 self._total_rowcount = len(data['rowset']) if \

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -10,8 +10,6 @@ import traceback
 from logging import getLogger
 from typing import TYPE_CHECKING, Dict, Optional, Type, Union
 
-from snowflake.connector.constants import UTF8
-
 from .compat import BASE_EXCEPTION_CLASS
 from .description import CLIENT_NAME, SNOWFLAKE_CONNECTOR_VERSION
 from .secret_detector import SecretDetector
@@ -67,11 +65,8 @@ class Error(BASE_EXCEPTION_CLASS):
     def __repr__(self):
         return self.__str__()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.msg
-
-    def __bytes__(self):
-        return self.__unicode__().encode(UTF8)
 
     @staticmethod
     def generate_telemetry_stacktrace() -> str:

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -253,9 +253,6 @@ class Error(BASE_EXCEPTION_CLASS):
             raise error_class(error_value)
 
 
-Error.__str__ = lambda self: self.__unicode__()
-
-
 class _Warning(BASE_EXCEPTION_CLASS):
     """Exception for important warnings."""
     pass

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -8,7 +8,7 @@ import logging
 import os
 import traceback
 from logging import getLogger
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, Type, Union
 
 from snowflake.connector.constants import UTF8
 
@@ -30,9 +30,14 @@ connector_base_path = os.path.join("snowflake", "connector")
 class Error(BASE_EXCEPTION_CLASS):
     """Base Snowflake exception class."""
 
-    def __init__(self, msg: Optional[str] = None, errno: Optional[int] = None, sqlstate: Optional[str] = None,
-                 sfqid: Optional[str] = None, done_format_msg: Optional[bool] = None,
-                 connection: Optional['SnowflakeConnection'] = None, cursor: Optional['SnowflakeCursor'] = None):
+    def __init__(self,
+                 msg: Optional[str] = None,
+                 errno: Optional[int] = None,
+                 sqlstate: Optional[str] = None,
+                 sfqid: Optional[str] = None,
+                 done_format_msg: Optional[bool] = None,
+                 connection: Optional['SnowflakeConnection'] = None,
+                 cursor: Optional['SnowflakeCursor'] = None):
         self.msg = msg
         self.raw_msg = msg
         self.errno = errno or -1
@@ -44,26 +49,16 @@ class Error(BASE_EXCEPTION_CLASS):
 
         if self.errno != -1 and not done_format_msg:
             if self.sqlstate != "n/a":
-                if logger.getEffectiveLevel() in (logging.INFO,
-                                                  logging.DEBUG):
-                    self.msg = '{errno:06d} ({sqlstate}): {sfqid}: {msg}'.format(
-                        errno=self.errno, msg=self.msg,
-                        sqlstate=self.sqlstate,
-                        sfqid=self.sfqid)
+                if logger.getEffectiveLevel() in (logging.INFO, logging.DEBUG):
+                    self.msg = f'{self.errno:06d} ({self.sqlstate}): {self.sfqid}: {self.msg}'
                 else:
-                    self.msg = '{errno:06d} ({sqlstate}): {msg}'.format(
-                        errno=self.errno,
-                        sqlstate=self.sqlstate,
-                        msg=self.msg)
+                    self.msg = f'{self.errno:06d} ({self.sqlstate}): {self.msg}'
             else:
                 if logger.getEffectiveLevel() in (logging.INFO,
                                                   logging.DEBUG):
-                    self.msg = '{errno:06d}: {sfqid}: {msg}'.format(
-                        errno=self.errno, msg=self.msg,
-                        sfqid=self.sfqid)
+                    self.msg = f'{self.errno:06d}: {self.errno}: {self.msg}'
                 else:
-                    self.msg = '{errno:06d}: {msg}'.format(errno=self.errno,
-                                                            msg=self.msg)
+                    self.msg = f'{self.errno:06d}: {self.msg}'
 
         # We want to skip the last frame/line in the traceback since it is the current frame
         self.telemetry_traceback = self.generate_telemetry_stacktrace()
@@ -78,7 +73,8 @@ class Error(BASE_EXCEPTION_CLASS):
     def __bytes__(self):
         return self.__unicode__().encode(UTF8)
 
-    def generate_telemetry_stacktrace(self) -> str:
+    @staticmethod
+    def generate_telemetry_stacktrace() -> str:
         # Get the current stack minus this function and the Error init function
         stack_frames = traceback.extract_stack()[:-2]
         filtered_frames = list()
@@ -88,7 +84,7 @@ class Error(BASE_EXCEPTION_CLASS):
                 # Get the index to truncate the file path to hide any user path
                 safe_path_index = frame.filename.find(connector_base_path)
                 # Create a new frame with the truncated file name and without the line argument since that can
-                # output senitive data
+                # output sensitive data
                 filtered_frames.append(
                     traceback.FrameSummary(frame.filename[safe_path_index:], frame.lineno, frame.name, line='')
                 )
@@ -97,9 +93,9 @@ class Error(BASE_EXCEPTION_CLASS):
 
     def telemetry_msg(self) -> Optional[str]:
         if self.sqlstate != "n/a":
-            return '{errno:06d} ({sqlstate})'.format(errno=self.errno, sqlstate=self.sqlstate)
+            return f'{self.errno:06d} ({self.sqlstate})'
         elif self.errno != -1:
-            return '{errno:06d}'.format(errno=self.errno)
+            return f'{self.errno:06d}'
         else:
             return None
 
@@ -135,9 +131,8 @@ class Error(BASE_EXCEPTION_CLASS):
             try:
                 connection._log_telemetry(TelemetryData(telemetry_data, ts))
             except AttributeError:
-                logger.debug(
-                    "Cursor failed to log to telemetry.",
-                    exc_info=True)
+                logger.debug("Cursor failed to log to telemetry.",
+                             exc_info=True)
         elif connection is None:
             # Send with out-of-band telemetry
             telemetry_oob = TelemetryService.get_instance()
@@ -156,14 +151,14 @@ class Error(BASE_EXCEPTION_CLASS):
                 self.send_exception_telemetry(connection, telemetry_data)
             else:
                 self.send_exception_telemetry(None, telemetry_data)
-        except Exception:
+        except Exception:  # NOQA
             # Do nothing but log if sending telemetry fails
             logger.debug("Sending exception telemetry failed")
 
     @staticmethod
     def default_errorhandler(connection: 'SnowflakeConnection',
                              cursor: 'SnowflakeCursor',
-                             error_class: Exception,
+                             error_class: Type['Error'],
                              error_value: Dict[str, str]) -> None:
         """Default error handler that raises an error.
 
@@ -183,13 +178,46 @@ class Error(BASE_EXCEPTION_CLASS):
             sfqid=error_value.get('sfqid'),
             done_format_msg=error_value.get('done_format_msg'),
             connection=connection,
-            cursor=cursor)
+            cursor=cursor
+        )
+
+    @staticmethod
+    def errorhandler_wrapper_from_cause(connection: 'SnowflakeConnection',
+                                        cursor: Optional['SnowflakeCursor'],
+                                        cause: Union['Error', Exception]) -> None:
+        """Wrapper for errorhandler_wrapper, it is called with a cause instead of a dictionary.
+
+        The dictionary is first extracted form the cause and then it's given to errorhandler_wrapper
+
+        Args:
+            connection: Connections in which the error happened.
+            cursor: Cursor in which the error happened.
+            cause: Error instance that we want to handle.
+
+        Returns:
+            None if no exceptions are raised by the connection's and cursor's error handlers.
+
+        Raises:
+            A Snowflake error if connection and cursor are None.
+        """
+        return Error.errorhandler_wrapper(
+            connection,
+            cursor,
+            type(cause),
+            {
+                'msg': cause.msg,
+                'errno': cause.errno,
+                'sqlstate': cause.sqlstate,
+                'done_format_msg': True
+            }
+
+        )
 
     @staticmethod
     def errorhandler_wrapper(connection: 'SnowflakeConnection',
-                             cursor: 'SnowflakeCursor',
-                             error_class: Exception,
-                             error_value: Optional[Dict[str, str]] = None):
+                             cursor: Optional['SnowflakeCursor'],
+                             error_class: Union[Type['Error'], Type[Exception]],
+                             error_value: Dict[str, Union[str, bool]]) -> None:
         """Error handler wrapper that calls the errorhandler method.
 
         Args:
@@ -204,18 +232,7 @@ class Error(BASE_EXCEPTION_CLASS):
         Raises:
             A Snowflake error if connection and cursor are None.
         """
-        if error_value is None:
-            # no value indicates errorclass is error_object
-            error_object = error_class
-            error_class = type(error_object)
-            error_value = {
-                'msg': error_object.msg,
-                'errno': error_object.errno,
-                'sqlstate': error_object.sqlstate,
-                'done_format_msg': True
-            }
-        else:
-            error_value['done_format_msg'] = False
+        error_value.setdefault('done_format_msg', False)
 
         if connection is not None:
             connection.messages.append((error_class, error_value))
@@ -239,7 +256,7 @@ class Error(BASE_EXCEPTION_CLASS):
 Error.__str__ = lambda self: self.__unicode__()
 
 
-class Warning(BASE_EXCEPTION_CLASS):
+class _Warning(BASE_EXCEPTION_CLASS):
     """Exception for important warnings."""
     pass
 
@@ -345,44 +362,44 @@ class RequestTimeoutError(Error):
     """Exception for 408 HTTP error for retry."""
 
     def __init__(self, **kwargs):
-        Error.__init__(
-            self, msg=kwargs.get('msg') or 'HTTP 408: Request Timeout',
-            errno=kwargs.get('errno'),
-            sqlstate=kwargs.get('sqlstate'),
-            sfqid=kwargs.get('sfqid'))
+        Error.__init__(self,
+                       msg=kwargs.get('msg') or 'HTTP 408: Request Timeout',
+                       errno=kwargs.get('errno'),
+                       sqlstate=kwargs.get('sqlstate'),
+                       sfqid=kwargs.get('sfqid'))
 
 
 class BadRequest(Error):
     """Exception for 400 HTTP error for retry."""
 
     def __init__(self, **kwargs):
-        Error.__init__(
-            self, msg=kwargs.get('msg') or 'HTTP 400: Bad Request',
-            errno=kwargs.get('errno'),
-            sqlstate=kwargs.get('sqlstate'),
-            sfqid=kwargs.get('sfqid'))
+        Error.__init__(self,
+                       msg=kwargs.get('msg') or 'HTTP 400: Bad Request',
+                       errno=kwargs.get('errno'),
+                       sqlstate=kwargs.get('sqlstate'),
+                       sfqid=kwargs.get('sfqid'))
 
 
 class BadGatewayError(Error):
     """Exception for 502 HTTP error for retry."""
 
     def __init__(self, **kwargs):
-        Error.__init__(
-            self, msg=kwargs.get('msg') or 'HTTP 502: Bad Gateway',
-            errno=kwargs.get('errno'),
-            sqlstate=kwargs.get('sqlstate'),
-            sfqid=kwargs.get('sfqid'))
+        Error.__init__(self,
+                       msg=kwargs.get('msg') or 'HTTP 502: Bad Gateway',
+                       errno=kwargs.get('errno'),
+                       sqlstate=kwargs.get('sqlstate'),
+                       sfqid=kwargs.get('sfqid'))
 
 
 class MethodNotAllowed(Error):
     """Exception for 405 HTTP error for retry."""
 
     def __init__(self, **kwargs):
-        Error.__init__(
-            self, msg=kwargs.get('msg') or 'HTTP 405: Method not allowed',
-            errno=kwargs.get('errno'),
-            sqlstate=kwargs.get('sqlstate'),
-            sfqid=kwargs.get('sfqid'))
+        Error.__init__(self,
+                       msg=kwargs.get('msg') or 'HTTP 405: Method not allowed',
+                       errno=kwargs.get('errno'),
+                       sqlstate=kwargs.get('sqlstate'),
+                       sfqid=kwargs.get('sfqid'))
 
 
 class OtherHTTPRetryableError(Error):
@@ -390,15 +407,15 @@ class OtherHTTPRetryableError(Error):
 
     def __init__(self, **kwargs):
         code = kwargs.get('code', 'n/a')
-        Error.__init__(
-            self, msg=kwargs.get('msg') or 'HTTP {}'.format(code),
-            errno=kwargs.get('errno'),
-            sqlstate=kwargs.get('sqlstate'),
-            sfqid=kwargs.get('sfqid'))
+        Error.__init__(self,
+                       msg=kwargs.get('msg') or f'HTTP {code}',
+                       errno=kwargs.get('errno'),
+                       sqlstate=kwargs.get('sqlstate'),
+                       sfqid=kwargs.get('sfqid'))
 
 
 class MissingDependencyError(Error):
     """Exception for missing extras dependencies."""
 
     def __init__(self, dependency: str):
-        super(MissingDependencyError, self).__init__(msg="Missing optional dependency: {}".format(dependency))
+        super(MissingDependencyError, self).__init__(msg=f"Missing optional dependency: {dependency}")

--- a/src/snowflake/connector/file_compression_type.py
+++ b/src/snowflake/connector/file_compression_type.py
@@ -3,122 +3,121 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 #
+from typing import Dict, List
 
-class FileCompressionType():
-    def __init__(self):
-        pass
-
-    Types = {
-        'GZIP': {
-            'name': 'GZIP',
-            'file_extension': '.gz',
-            'mime_type': 'application',
-            'mime_subtypes': ['gzip', 'x-gzip'],
-            'is_supported': True,
-        },
-        'DEFLATE': {
-            'name': 'DEFLATE',
-            'file_extension': '.deflate',
-            'mime_type': 'application',
-            'mime_subtypes': ['zlib', 'deflate'],
-            'is_supported': True,
-        },
-        'RAW_DEFLATE': {
-            'name': 'RAW_DEFLATE',
-            'file_extension': '.raw_deflate',
-            'mime_type': 'application',
-            'mime_subtypes': ['raw_deflate'],
-            'is_supported': True,
-        },
-        'BZIP2': {
-            'name': 'BZIP2',
-            'file_extension': '.bz2',
-            'mime_type': 'application',
-            'mime_subtypes': ['bzip2', 'x-bzip2', 'x-bz2', 'x-bzip', 'bz2'],
-            'is_supported': True,
-        },
-        'LZIP': {
-            'name': 'LZIP',
-            'file_extension': '.lz',
-            'mime_type': 'application',
-            'mime_subtypes': ['lzip', 'x-lzip'],
-            'is_supported': False,
-        },
-        'LZMA': {
-            'name': 'LZMA',
-            'file_extension': '.lzma',
-            'mime_type': 'application',
-            'mime_subtypes': ['lzma', 'x-lzma'],
-            'is_supported': False,
-        },
-        'LZO': {
-            'name': 'LZO',
-            'file_extension': '.lzo',
-            'mime_type': 'application',
-            'mime_subtypes': ['lzo', 'x-lzo'],
-            'is_supported': False,
-        },
-        'XZ': {
-            'name': 'XZ',
-            'file_extension': '.xz',
-            'mime_type': 'application',
-            'mime_subtypes': ['xz', 'x-xz'],
-            'is_supported': False,
-        },
-        'COMPRESS': {
-            'name': 'COMPRESS',
-            'file_extension': '.Z',
-            'mime_type': 'application',
-            'mime_subtypes': ['compress', 'x-compress'],
-            'is_supported': False,
-        },
-        'PARQUET': {
-                'name': 'PARQUET',
-                'file_extension': '.parquet',
-                'mime_type': 'snowflake',
-                'mime_subtypes': ['parquet'],
-                'is_supported': True,
-        },
-        'ZSTD': {
-            'name': 'ZSTD',
-            'file_extension': '.zst',
-            'mime_type': 'application',
-            'mime_subtypes': ['zstd', 'x-zstd'],
-            'is_supported': True,
-        },
-        'BROTLI': {
-            'name': 'BROTLI',
-            'file_extension': '.br',
-            'mime_type': 'application',
-            'mime_subtypes': ['br', 'x-br'],
-            'is_supported': True,
-        },
-        'ORC': {
-            'name': 'ORC',
-            'file_extension': '.orc',
-            'mime_type': 'snowflake',
-            'mime_subtypes': ['orc'],
-            'is_supported': True,
-        },
-    }
-
-    subtype_to_meta = {}
-
-    # TODO: Snappy avro doesn't need to be compressed again
-
-    @classmethod
-    def init(cls):
-        for meta in cls.Types.values():
-            for ms in meta['mime_subtypes']:
-                cls.subtype_to_meta[ms] = meta
-
-    @classmethod
-    def lookupByMimeSubType(cls, mime_subtype):
-        if mime_subtype.lower() in cls.subtype_to_meta:
-            return cls.subtype_to_meta[mime_subtype]
-        else:
-            return None
+from .compat import dataclass
 
 
-# do init once
-FileCompressionType.init()
+@dataclass
+class CompressionType:
+    name: str
+    file_extension: str
+    mime_type: str
+    mime_subtypes: List[str]
+    is_supported: bool
+
+
+CompressionTypes = {
+    'GZIP': CompressionType(
+        name='GZIP',
+        file_extension='.gz',
+        mime_type='application',
+        mime_subtypes=['gzip', 'x-gzip'],
+        is_supported=True,
+    ),
+    'DEFLATE': CompressionType(
+        name='DEFLATE',
+        file_extension='.deflate',
+        mime_type='application',
+        mime_subtypes=['zlib', 'deflate'],
+        is_supported=True,
+    ),
+    'RAW_DEFLATE': CompressionType(
+        name='RAW_DEFLATE',
+        file_extension='.raw_deflate',
+        mime_type='application',
+        mime_subtypes=['raw_deflate'],
+        is_supported=True,
+    ),
+    'BZIP2': CompressionType(
+        name='BZIP2',
+        file_extension='.bz2',
+        mime_type='application',
+        mime_subtypes=['bzip2', 'x-bzip2', 'x-bz2', 'x-bzip', 'bz2'],
+        is_supported=True,
+    ),
+    'LZIP': CompressionType(
+        name='LZIP',
+        file_extension='.lz',
+        mime_type='application',
+        mime_subtypes=['lzip', 'x-lzip'],
+        is_supported=False,
+    ),
+    'LZMA': CompressionType(
+        name='LZMA',
+        file_extension='.lzma',
+        mime_type='application',
+        mime_subtypes=['lzma', 'x-lzma'],
+        is_supported=False,
+    ),
+    'LZO': CompressionType(
+        name='LZO',
+        file_extension='.lzo',
+        mime_type='application',
+        mime_subtypes=['lzo', 'x-lzo'],
+        is_supported=False,
+    ),
+    'XZ': CompressionType(
+        name='XZ',
+        file_extension='.xz',
+        mime_type='application',
+        mime_subtypes=['xz', 'x-xz'],
+        is_supported=False,
+    ),
+    'COMPRESS': CompressionType(
+        name='COMPRESS',
+        file_extension='.Z',
+        mime_type='application',
+        mime_subtypes=['compress', 'x-compress'],
+        is_supported=False,
+    ),
+    'PARQUET': CompressionType(
+        name='PARQUET',
+        file_extension='.parquet',
+        mime_type='snowflake',
+        mime_subtypes=['parquet'],
+        is_supported=True,
+    ),
+    'ZSTD': CompressionType(
+        name='ZSTD',
+        file_extension='.zst',
+        mime_type='application',
+        mime_subtypes=['zstd', 'x-zstd'],
+        is_supported=True,
+    ),
+    'BROTLI': CompressionType(
+        name='BROTLI',
+        file_extension='.br',
+        mime_type='application',
+        mime_subtypes=['br', 'x-br'],
+        is_supported=True,
+    ),
+    'ORC': CompressionType(
+        name='ORC',
+        file_extension='.orc',
+        mime_type='snowflake',
+        mime_subtypes=['orc'],
+        is_supported=True,
+    ),
+}
+
+subtype_to_meta: Dict[str, CompressionType] = {
+    ms: meta for meta in CompressionTypes.values() for ms in meta.mime_subtypes
+}
+
+# TODO: Snappy avro doesn't need to be compressed again
+
+
+def lookup_by_mime_sub_type(mime_subtype: str) -> CompressionType:
+    """Look up a CompressionType for a specific mime subtype."""
+    return subtype_to_meta.get(mime_subtype.lower())

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -125,6 +125,8 @@ class SnowflakeFileMeta:
     require_compress: bool = False
     dst_file_name: Optional[str] = None
     dst_file_size: int = -1
+    src_stream: Optional[IO[bytes]] = None
+    real_src_stream: Optional[IO[bytes]] = None
     # Specific to Downloads only
     local_location: Optional[str] = None
 
@@ -501,7 +503,7 @@ class SnowflakeFileTransferAgent(object):
                             meta.src_stream)
 
             logger.debug(f'getting digest file={meta.real_src_file_name}')
-            if 'src_stream' not in meta:
+            if meta.src_stream is None:
                 meta.sha256_digest, meta.upload_size = \
                     SnowflakeFileUtil.get_digest_and_size_for_file(meta.real_src_file_name)
             else:
@@ -523,9 +525,9 @@ class SnowflakeFileTransferAgent(object):
         finally:
             logger.debug(f'cleaning up tmp dir: {tmp_dir}')
             shutil.rmtree(tmp_dir)
-            if 'src_stream' in meta:
+            if meta.src_stream is not None:
                 meta.src_stream.seek(0)
-            if 'real_src_stream' in meta:
+            if meta.real_src_stream is not None:
                 meta.real_src_stream.close()
         return meta
 

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -15,12 +15,13 @@ import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import getLogger
 from time import sleep, time
-from typing import IO, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 import botocore.exceptions
+from boto3.session import Session
 
-from .compat import GET_CWD, IS_WINDOWS
-from .constants import SHA256_DIGEST, ResultStatus
+from .compat import GET_CWD, IS_WINDOWS, dataclass, field
+from .constants import ResultStatus
 from .converter_snowsql import SnowflakeConverterSnowSQL
 from .errorcode import (
     ER_COMPRESSION_NOT_SUPPORTED,
@@ -33,7 +34,7 @@ from .errorcode import (
     ER_LOCAL_PATH_NOT_DIRECTORY,
 )
 from .errors import DatabaseError, Error, InternalError, OperationalError, ProgrammingError
-from .file_compression_type import FileCompressionType
+from .file_compression_type import CompressionTypes, lookup_by_mime_sub_type
 from .file_util import SnowflakeFileUtil
 from .gcs_util import SnowflakeGCSUtil
 from .local_util import SnowflakeLocalUtil
@@ -42,6 +43,8 @@ from .s3_util import SnowflakeS3Util
 
 if TYPE_CHECKING:  # pragma: no cover
     from snowflake.connector.cursor import SnowflakeCursor
+    from azure.storage.blob import BlobServiceClient
+    from .file_compression_type import CompressionType
 
 S3_FS = 'S3'
 AZURE_FS = 'AZURE'
@@ -51,16 +54,6 @@ CMD_TYPE_UPLOAD = 'UPLOAD'
 CMD_TYPE_DOWNLOAD = 'DOWNLOAD'
 FILE_PROTOCOL = 'file://'
 
-RESULT_TEXT_COLUMN_DESC = lambda name: {
-    'name': name, 'type': 'text',
-    'length': 16777216, 'precision': None,
-    'scale': None, 'nullable': False}
-RESULT_FIXED_COLUMN_DESC = lambda name: {
-    'name': name, 'type': 'fixed',
-    'length': 5, 'precision': 0,
-    'scale': 0,
-    'nullable': False}
-
 MB = 1024.0 * 1024.0
 
 INJECT_WAIT_IN_PUT = 0
@@ -68,10 +61,78 @@ INJECT_WAIT_IN_PUT = 0
 logger = getLogger(__name__)
 
 
+def result_text_column_desc(name):
+    return {
+        'name': name,
+        'type': 'text',
+        'length': 16777216,
+        'precision': None,
+        'scale': None,
+        'nullable': False,
+    }
+
+
+def result_fixed_column_desc(name):
+    return {
+        'name': name,
+        'type': 'fixed',
+        'length': 5,
+        'precision': 0,
+        'scale': 0,
+        'nullable': False
+    }
+
+
+@dataclass
+class SnowflakeFileMeta:
+    """Class to keep track of information necessary for file operations."""
+    name: str
+    src_file_name: str
+    stage_location_type: str
+    result_status: Optional['ResultStatus'] = None
+
+    client: Optional[Union['Session.resource', 'BlobServiceClient', Optional[str]]] = None
+    self: Optional['SnowflakeFileTransferAgent'] = None
+    put_callback: Optional[Type['SnowflakeProgressPercentage']] = None
+    put_azure_callback: Optional[Type['SnowflakeProgressPercentage']] = None
+    put_callback_output_stream: Optional[IO[str]] = None
+    get_callback: Optional[Type['SnowflakeProgressPercentage']] = None
+    get_azure_callback: Optional[Type['SnowflakeProgressPercentage']] = None
+    get_callback_output_stream: Optional[IO[str]] = None
+    show_progress_bar: bool = False
+    multipart_threshold: int = -1
+    parallel: int = 1
+    presigned_url: Optional[str] = None
+    overwrite: bool = False
+    tmp_dir: Optional[str] = None
+    sha256_digest: Optional[str] = None
+    upload_size: Optional[int] = None
+    real_src_file_name: Optional[str] = None
+    error_details: Optional[str] = None
+    last_max_concurrency: int = -1
+    last_error: Optional[Exception] = None
+    no_sleeping_time: bool = False
+    gcs_file_header_digest: Optional[str] = None
+    gcs_file_header_content_length: Optional[int] = None
+    gcs_file_header_encryption_metadata: Optional[Dict[str, Any]] = None
+
+    stage_info: Dict[str, Any] = field(default_factory=dict)  # TODO could be strongly defined if need be
+    encryption_material: Optional['SnowflakeFileEncryptionMaterial'] = None
+    # Specific to Uploads only
+    src_file_size: int = 0
+    src_compression_type: Optional['CompressionType'] = None
+    dst_compression_type: 'CompressionType' = None
+    require_compress: bool = False
+    dst_file_name: Optional[str] = None
+    dst_file_size: int = -1
+    # Specific to Downloads only
+    local_location: Optional[str] = None
+
+
 def _update_progress(
         file_name: str, start_time: float, total_size: float, progress: Union[float, int],
         output_stream: Optional[IO] = sys.stdout, show_progress_bar: Optional[bool] = True) -> float:
-    barLength = 10  # Modify this to change the length of the progress bar
+    bar_length = 10  # Modify this to change the length of the progress bar
     total_size /= MB
     status = ""
     elapsed_time = time() - start_time
@@ -94,22 +155,21 @@ def _update_progress(
             elapsed_time=elapsed_time,
             throughput=throughput)
     if status:
-        block = int(round(barLength * progress))
+        block = int(round(bar_length * progress))
         text = "\r{file_name}({size:.2f}MB): [{bar}] {percentage:.2f}% {status}".format(
             file_name=file_name,
             size=total_size,
-            bar="#" * block + "-" * (barLength - block),
+            bar="#" * block + "-" * (bar_length - block),
             percentage=progress * 100.0,
             status=status)
         output_stream.write(text)
         output_stream.flush()
-    logger.debug('filename: %s, start_time: %s, total_size: %s, progress: %s, '
-                 'show_progress_bar: %s',
-                 file_name, start_time, total_size, progress, show_progress_bar)
+    logger.debug(f'filename: {file_name}, start_time: {start_time}, total_size: {total_size}, progress: {progress}, '
+                 f'show_progress_bar: {show_progress_bar}')
     return progress == 1.0
 
 
-class SnowflakeProgressPercentage():
+class SnowflakeProgressPercentage:
     """Built-in Progress bar for PUT commands."""
 
     def __init__(
@@ -143,7 +203,6 @@ class SnowflakeS3ProgressPercentage(SnowflakeProgressPercentage):
             show_progress_bar=show_progress_bar)
 
     def __call__(self, bytes_amount: int):
-        # logger.debug("Bytes returned from callback %s", bytes_amount)
         with self._lock:
             if self._output_stream:
                 self._seen_so_far += bytes_amount
@@ -157,9 +216,13 @@ class SnowflakeS3ProgressPercentage(SnowflakeProgressPercentage):
 
 
 class SnowflakeAzureProgressPercentage(SnowflakeProgressPercentage):
-    def __init__(self, filename: str, filesize: Union[int, float],
+    def __init__(
+            self,
+            filename: str,
+            filesize: Union[int, float],
             output_stream: Optional[IO] = sys.stdout,
-            show_progress_bar: Optional[bool] = True):
+            show_progress_bar: Optional[bool] = True,
+    ):
         super(SnowflakeAzureProgressPercentage, self).__init__(
             filename, filesize,
             output_stream=output_stream,
@@ -185,11 +248,11 @@ class SnowflakeFileTransferAgent(object):
                  cursor: 'SnowflakeCursor',
                  command: str,
                  ret: Dict[str, Any],
-                 put_callback: Optional['SnowflakeProgressPercentage'] = None,
-                 put_azure_callback: Optional['SnowflakeProgressPercentage'] = None,
+                 put_callback: Optional[Type['SnowflakeProgressPercentage']] = None,
+                 put_azure_callback: Optional[Type['SnowflakeProgressPercentage']] = None,
                  put_callback_output_stream: IO[str] = sys.stdout,
-                 get_callback: Optional['SnowflakeProgressPercentage'] = None,
-                 get_azure_callback: Optional['SnowflakeProgressPercentage'] = None,
+                 get_callback: Optional[Type['SnowflakeProgressPercentage']] = None,
+                 get_azure_callback: Optional[Type['SnowflakeProgressPercentage']] = None,
                  get_callback_output_stream: IO[str] = sys.stdout,
                  show_progress_bar: bool = True,
                  raise_put_get_error: bool = True,
@@ -213,6 +276,10 @@ class SnowflakeFileTransferAgent(object):
         self._show_progress_bar = show_progress_bar
         self._force_put_overwrite = force_put_overwrite
         self._source_from_stream = source_from_stream
+        # The list of self-sufficient file metas that are sent to
+        # remote storage clients to get operated on.
+        self._file_metadata: List['SnowflakeFileMeta'] = []
+        self._results: List['SnowflakeFileMeta'] = []
         if multipart_threshold is not None:
             self._multipart_threshold = multipart_threshold
         else:
@@ -241,35 +308,32 @@ class SnowflakeFileTransferAgent(object):
 
         small_file_metas = []
         large_file_metas = []
-        for meta in self._file_metadata:
-            meta['overwrite'] = self._overwrite
-            meta['self'] = self
+        for m in self._file_metadata:
+            m.overwrite = self._overwrite
+            m.self = self
             if self._stage_location_type != LOCAL_FS:
-                meta['put_callback'] = self._put_callback
-                meta['put_azure_callback'] = self._put_azure_callback
-                meta['put_callback_output_stream'] = \
-                    self._put_callback_output_stream
-                meta['get_callback'] = self._get_callback
-                meta['get_azure_callback'] = self._get_azure_callback
-                meta['get_callback_output_stream'] = \
-                    self._get_callback_output_stream
-                meta['show_progress_bar'] = self._show_progress_bar
+                m.put_callback = self._put_callback
+                m.put_azure_callback = self._put_azure_callback
+                m.put_callback_output_stream = self._put_callback_output_stream
+                m.get_callback = self._get_callback
+                m.get_azure_callback = self._get_azure_callback
+                m.get_callback_output_stream = self._get_callback_output_stream
+                m.show_progress_bar = self._show_progress_bar
 
                 # multichunk uploader threshold
                 size_threshold = self._multipart_threshold
-                meta['multipart_threshold'] = size_threshold
-                if meta.get('src_file_size', 1) > size_threshold:
-                    meta['parallel'] = self._parallel
-                    large_file_metas.append(meta)
+                m.multipart_threshold = size_threshold
+                if m.src_file_size > size_threshold:
+                    m.parallel = self._parallel
+                    large_file_metas.append(m)
                 else:
-                    meta['parallel'] = 1
-                    small_file_metas.append(meta)
+                    m.parallel = 1
+                    small_file_metas.append(m)
             else:
-                meta['parallel'] = 1
-                small_file_metas.append(meta)
+                m.parallel = 1
+                small_file_metas.append(m)
 
-        logger.debug('parallel=[%s]', self._parallel)
-        self._results = []
+        logger.debug(f'parallel=[{self._parallel}]')
         if self._command_type == CMD_TYPE_UPLOAD:
             self.upload(large_file_metas, small_file_metas)
         else:
@@ -277,9 +341,9 @@ class SnowflakeFileTransferAgent(object):
 
         # turn enum to string, in order to have backward compatible interface
         for result in self._results:
-            result['result_status'] = result['result_status'].value
+            result.result_status = result.result_status.value
 
-    def upload(self, large_file_metas, small_file_metas):
+    def upload(self, large_file_metas: List['SnowflakeFileMeta'], small_file_metas: List[SnowflakeFileMeta]):
         storage_client = SnowflakeFileTransferAgent.get_storage_client(
             self._stage_location_type)
         client = storage_client.create_client(
@@ -287,9 +351,9 @@ class SnowflakeFileTransferAgent(object):
             use_accelerate_endpoint=self._use_accelerate_endpoint
         )
         for meta in small_file_metas:
-            meta['client'] = client
+            meta.client = client
         for meta in large_file_metas:
-            meta['client'] = client
+            meta.client = client
 
         if len(small_file_metas) > 0:
             self._upload_files_in_parallel(small_file_metas)
@@ -322,7 +386,7 @@ class SnowflakeFileTransferAgent(object):
                 'use_accelerate_endpoint: %s',
                 self._use_accelerate_endpoint)
 
-    def _upload_files_in_parallel(self, file_metas):
+    def _upload_files_in_parallel(self, file_metas: List['SnowflakeFileMeta']) -> None:
         """Uploads files in parallel.
 
         Args:
@@ -335,21 +399,20 @@ class SnowflakeFileTransferAgent(object):
                 idx + self._parallel <= len_file_metas else \
                 len_file_metas
 
-            logger.debug(
-                'uploading files idx: {}/{}'.format(idx + 1, end_of_idx))
+            logger.debug(f'uploading files idx: {idx + 1}/{end_of_idx}')
 
             target_meta = file_metas[idx:end_of_idx]
             while True:
                 pool = ThreadPoolExecutor(len(target_meta))
-                results = list(pool.map(
+                results: List['SnowflakeFileMeta'] = list(pool.map(
                     SnowflakeFileTransferAgent.upload_one_file,
                     target_meta))
                 pool.shutdown()
 
                 # need renew AWS token?
-                retry_meta = []
+                retry_meta: List['SnowflakeFileMeta'] = []
                 for result_meta in results:
-                    if result_meta['result_status'] in [
+                    if result_meta.result_status in [
                         ResultStatus.RENEW_TOKEN,
                         ResultStatus.RENEW_PRESIGNED_URL
                     ]:
@@ -360,15 +423,15 @@ class SnowflakeFileTransferAgent(object):
                 if len(retry_meta) == 0:
                     # no new AWS token is required
                     break
-                if any([result_meta['result_status'] == ResultStatus.RENEW_TOKEN
+                if any([result_meta.result_status == ResultStatus.RENEW_TOKEN
                         for result_meta in results]):
                     client = self.renew_expired_client()
                     for result_meta in retry_meta:
-                        result_meta['client'] = client
+                        result_meta.client = client
                     if end_of_idx < len_file_metas:
                         for idx0 in range(idx + self._parallel, len_file_metas):
-                            file_metas[idx0]['client'] = client
-                if any([result_meta['result_status'] == ResultStatus.RENEW_PRESIGNED_URL
+                            file_metas[idx0].client = client
+                if any([result_meta.result_status == ResultStatus.RENEW_PRESIGNED_URL
                         for result_meta in results]):
                     self._update_file_metas_with_presigned_url()
                 target_meta = retry_meta
@@ -377,7 +440,7 @@ class SnowflakeFileTransferAgent(object):
                 break
             idx += self._parallel
 
-    def _upload_files_in_sequential(self, file_metas):
+    def _upload_files_in_sequential(self, file_metas: List['SnowflakeFileMeta']):
         """Uploads files in sequential. Retry if the access token expires.
 
         Args:
@@ -386,36 +449,33 @@ class SnowflakeFileTransferAgent(object):
         idx = 0
         len_file_metas = len(file_metas)
         while idx < len_file_metas:
-            logger.debug(
-                'uploading files idx: {}/{}'.format(idx + 1, len_file_metas))
-            result = SnowflakeFileTransferAgent.upload_one_file(
-                file_metas[idx])
-            if result['result_status'] == ResultStatus.RENEW_TOKEN:
+            logger.debug(f'uploading files idx: {idx+1}/{len_file_metas}')
+            result = SnowflakeFileTransferAgent.upload_one_file(file_metas[idx])
+            if result.result_status == ResultStatus.RENEW_TOKEN:
                 client = self.renew_expired_client()
                 for idx0 in range(idx, len_file_metas):
-                    file_metas[idx0]['client'] = client
+                    file_metas[idx0].client = client
                 continue
-            elif result['result_status'] == ResultStatus.RENEW_PRESIGNED_URL:
+            elif result.result_status == ResultStatus.RENEW_PRESIGNED_URL:
                 self._update_file_metas_with_presigned_url()
                 continue
             self._results.append(result)
             idx += 1
             if INJECT_WAIT_IN_PUT > 0:
-                logger.debug('LONGEVITY TEST: waiting for %s',
-                             INJECT_WAIT_IN_PUT)
+                logger.debug(f'LONGEVITY TEST: waiting for {INJECT_WAIT_IN_PUT}')
                 sleep(INJECT_WAIT_IN_PUT)
 
     @staticmethod
     def get_storage_client(stage_location_type):
-        if (stage_location_type == LOCAL_FS):
+        if stage_location_type == LOCAL_FS:
             return SnowflakeLocalUtil
-        elif (stage_location_type in [S3_FS, AZURE_FS, GCS_FS]):
+        elif stage_location_type in [S3_FS, AZURE_FS, GCS_FS]:
             return SnowflakeRemoteStorageUtil
         else:
             return None
 
     @staticmethod
-    def upload_one_file(meta):
+    def upload_one_file(meta: 'SnowflakeFileMeta') -> 'SnowflakeFileMeta':
         """Uploads one file.
 
         Args:
@@ -424,63 +484,52 @@ class SnowflakeFileTransferAgent(object):
         Returns:
             Metadata of uploaded file.
         """
-        logger = getLogger(__name__)
-
-        logger.debug("uploading file=%s", meta['src_file_name'])
-        meta['real_src_file_name'] = meta['src_file_name']
+        logger.debug(f"uploading file={meta.src_file_name}")
+        meta.real_src_file_name = meta.src_file_name
         tmp_dir = tempfile.mkdtemp()
-        meta['tmp_dir'] = tmp_dir
+        meta.tmp_dir = tmp_dir
         try:
-            if meta['require_compress']:
-                logger.debug('compressing file=%s', meta['src_file_name'])
-                if 'src_stream' not in meta:
-                    meta['real_src_file_name'], upload_size = \
+            if meta.require_compress:
+                logger.debug(f'compressing file={meta.src_file_name}')
+                if meta.src_stream is None:
+                    meta.real_src_file_name, upload_size = \
                         SnowflakeFileUtil.compress_file_with_gzip(
-                            meta['src_file_name'], tmp_dir)
+                            meta.src_file_name, tmp_dir)
                 else:
-                    meta['real_src_stream'], upload_size = \
+                    meta.real_src_stream, upload_size = \
                         SnowflakeFileUtil.compress_with_gzip_from_stream(
-                            meta['src_stream'])
+                            meta.src_stream)
 
-            logger.debug(
-                'getting digest file=%s', meta['real_src_file_name'])
+            logger.debug(f'getting digest file={meta.real_src_file_name}')
             if 'src_stream' not in meta:
-                meta[SHA256_DIGEST], meta['upload_size'] = \
-                    SnowflakeFileUtil.get_digest_and_size_for_file(meta['real_src_file_name'])
+                meta.sha256_digest, meta.upload_size = \
+                    SnowflakeFileUtil.get_digest_and_size_for_file(meta.real_src_file_name)
             else:
-                meta[SHA256_DIGEST], meta['upload_size'] = \
-                    SnowflakeFileUtil.get_digest_and_size_for_stream(meta.get('real_src_stream', meta['src_stream']))
+                meta.sha256_digest, meta.upload_size = \
+                    SnowflakeFileUtil.get_digest_and_size_for_stream(meta.real_src_stream or meta.src_stream)
             logger.debug('really uploading data')
-            storage_client = SnowflakeFileTransferAgent.get_storage_client(
-                meta['stage_location_type'])
+            storage_client = SnowflakeFileTransferAgent.get_storage_client(meta.stage_location_type)
             storage_client.upload_one_file_with_retry(meta)
             logger.debug(
-                'done: status=%s, file=%s, real file=%s',
-                meta['result_status'],
-                meta['src_file_name'],
-                meta['real_src_file_name'])
+                f'done: status={meta.result_status}, file={meta.src_file_name}, real file={meta.real_src_file_name}'
+            )
         except Exception as e:
-            logger.exception(
-                'Failed to upload a file: file=%s, real file=%s',
-                meta['src_file_name'],
-                meta['real_src_file_name'])
-            meta['dst_file_size'] = 0
-            if 'result_status' not in meta:
-                meta['result_status'] = ResultStatus.ERROR
-            meta['error_details'] = str(e)
-            meta['error_details'] += \
-                ", file={}, real file={}".format(
-                    meta.get('src_file_name'), meta.get('real_src_file_name'))
+            logger.exception(f'Failed to upload a file: file={meta.src_file_name}, real file={meta.real_src_file_name}')
+            meta.dst_file_size = 0
+            if meta.result_status is None:
+                meta.result_status = ResultStatus.ERROR
+            meta.error_details = str(e)
+            meta.error_details += f", file={meta.src_file_name}, real file={meta.real_src_file_name}"
         finally:
-            logger.debug('cleaning up tmp dir: %s', tmp_dir)
+            logger.debug(f'cleaning up tmp dir: {tmp_dir}')
             shutil.rmtree(tmp_dir)
             if 'src_stream' in meta:
-                meta['src_stream'].seek(0)
+                meta.src_stream.seek(0)
             if 'real_src_stream' in meta:
-                meta['real_src_stream'].close()
+                meta.real_src_stream.close()
         return meta
 
-    def download(self, large_file_metas, small_file_metas):
+    def download(self, large_file_metas: List['SnowflakeFileMeta'], small_file_metas: List['SnowflakeFileMeta']):
         storage_client = SnowflakeFileTransferAgent.get_storage_client(
             self._stage_location_type)
         client = storage_client.create_client(
@@ -488,16 +537,16 @@ class SnowflakeFileTransferAgent(object):
             use_accelerate_endpoint=self._use_accelerate_endpoint
         )
         for meta in small_file_metas:
-            meta['client'] = client
+            meta.client = client
         for meta in large_file_metas:
-            meta['client'] = client
+            meta.client = client
 
         if len(small_file_metas) > 0:
             self._download_files_in_parallel(small_file_metas)
         if len(large_file_metas) > 0:
             self._download_files_in_sequential(large_file_metas)
 
-    def _download_files_in_parallel(self, file_metas):
+    def _download_files_in_parallel(self, file_metas: List['SnowflakeFileMeta']):
         """Downloads files in parallel.
 
         Args:
@@ -506,9 +555,7 @@ class SnowflakeFileTransferAgent(object):
         idx = 0
         len_file_metas = len(file_metas)
         while idx < len_file_metas:
-            end_of_idx = idx + self._parallel if \
-                idx + self._parallel <= len_file_metas else \
-                len_file_metas
+            end_of_idx = idx + self._parallel if idx + self._parallel <= len_file_metas else len_file_metas
 
             logger.debug(
                 'downloading files idx: {} to {}'.format(idx, end_of_idx))
@@ -516,16 +563,15 @@ class SnowflakeFileTransferAgent(object):
             target_meta = file_metas[idx:end_of_idx]
             while True:
                 pool = ThreadPoolExecutor(len(target_meta))
-                results = list(pool.map(
+                results: List['SnowflakeFileMeta'] = list(pool.map(
                     SnowflakeFileTransferAgent.download_one_file,
                     target_meta))
                 pool.shutdown()
 
                 # need renew AWS token?
-                retry_meta = []
+                retry_meta: List['SnowflakeFileMeta'] = []
                 for result_meta in results:
-                    if result_meta[
-                        'result_status'] in [
+                    if result_meta.result_status in [
                         ResultStatus.RENEW_TOKEN,
                         ResultStatus.RENEW_PRESIGNED_URL
                     ]:
@@ -536,24 +582,24 @@ class SnowflakeFileTransferAgent(object):
                 if len(retry_meta) == 0:
                     # no new AWS token is required
                     break
-                if any([result_meta['result_status'] == ResultStatus.RENEW_TOKEN
+                if any([result_meta.result_status == ResultStatus.RENEW_TOKEN
                         for result_meta in results]):
                     client = self.renew_expired_client()
                     for result_meta in retry_meta:
-                        result_meta['client'] = client
-                if any([result_meta['result_status'] == ResultStatus.RENEW_PRESIGNED_URL
+                        result_meta.client = client
+                if any([result_meta.result_status == ResultStatus.RENEW_PRESIGNED_URL
                         for result_meta in results]):
                     self._update_file_metas_with_presigned_url()
                 if end_of_idx < len_file_metas:
                     for idx0 in range(idx + self._parallel, len_file_metas):
-                        file_metas[idx0]['client'] = client
+                        file_metas[idx0].client = client
                 target_meta = retry_meta
 
             if end_of_idx == len_file_metas:
                 break
             idx += self._parallel
 
-    def _download_files_in_sequential(self, file_metas):
+    def _download_files_in_sequential(self, file_metas: List['SnowflakeFileMeta']):
         """Downloads files in sequential. Retry if the access token expires.
 
         Args:
@@ -567,20 +613,19 @@ class SnowflakeFileTransferAgent(object):
             if result['result_status'] == ResultStatus.RENEW_TOKEN:
                 client = self.renew_expired_client()
                 for idx0 in range(idx, len_file_metas):
-                    file_metas[idx0]['client'] = client
+                    file_metas[idx0].client = client
                 continue
-            elif result['result_status'] == ResultStatus.RENEW_PRESIGNED_URL:
+            elif result.result_status == ResultStatus.RENEW_PRESIGNED_URL:
                 self._update_file_metas_with_presigned_url()
                 continue
             self._results.append(result)
             idx += 1
             if INJECT_WAIT_IN_PUT > 0:
-                logger.debug('LONGEVITY TEST: waiting for %s',
-                             INJECT_WAIT_IN_PUT)
+                logger.debug(f'LONGEVITY TEST: waiting for {INJECT_WAIT_IN_PUT}')
                 sleep(INJECT_WAIT_IN_PUT)
 
     @staticmethod
-    def download_one_file(meta):
+    def download_one_file(meta: 'SnowflakeFileMeta'):
         """Download a one file.
 
         Args:
@@ -589,34 +634,27 @@ class SnowflakeFileTransferAgent(object):
         Returns:
             Metadata of downloaded file.
         """
-        logger = getLogger(__name__)
-
         tmp_dir = tempfile.mkdtemp()
-        meta['tmp_dir'] = tmp_dir
+        meta.tmp_dir = tmp_dir
         try:
             storage_client = SnowflakeFileTransferAgent.get_storage_client(
-                meta['stage_location_type'])
+                meta.stage_location_type)
             storage_client.download_one_file(meta)
             logger.debug(
-                'done: status=%s, file=%s',
-                meta.get('result_status'),
-                meta.get('dst_file_name'))
+                f'done: status={meta.result_status}, file={meta.dst_file_name}')
         except Exception as e:
-            logger.exception('Failed to download a file: %s',
-                             meta['dst_file_name'])
-            meta['dst_file_size'] = -1
-            if 'result_status' not in meta:
-                meta['result_status'] = ResultStatus.ERROR
-            meta['error_details'] = str(e)
-            meta['error_details'] += \
-                ', file={}'.format(meta.get('dst_file_name'))
+            logger.exception(f'Failed to download a file: {meta.dst_file_name}')
+            meta.dst_file_size = -1
+            if meta.result_status is not None:
+                meta.result_status = ResultStatus.ERROR
+            meta.error_details = str(e)
+            meta.error_details += f', file={meta.dst_file_name}'
         finally:
-            logger.debug('cleaning up tmp dir: %s', tmp_dir)
+            logger.debug(f'cleaning up tmp dir: {tmp_dir}')
             shutil.rmtree(tmp_dir)
         return meta
 
     def renew_expired_client(self):
-        logger = getLogger(__name__)
         logger.debug('renewing expired aws token')
         ret = self._cursor._execute_helper(
             self._command)  # rerun the command to get the credential
@@ -632,8 +670,6 @@ class SnowflakeFileTransferAgent(object):
 
         Currently only the file metas generated for PUT/GET on a GCP account need the presigned urls.
         """
-        logger = getLogger(__name__)
-
         storage_client_class = SnowflakeFileTransferAgent.get_storage_client(
             self._stage_location_type)
 
@@ -641,7 +677,7 @@ class SnowflakeFileTransferAgent(object):
         if storage_client_class is not SnowflakeRemoteStorageUtil:
             return
 
-        storage_util_class = SnowflakeRemoteStorageUtil.getForStorageType(
+        storage_util_class = SnowflakeRemoteStorageUtil.get_for_storage_type(
             self._stage_location_type)
 
         # presigned url only applies to GCS
@@ -655,7 +691,7 @@ class SnowflakeFileTransferAgent(object):
                 file_path_to_be_replaced = self.get_local_file_path_from_put_command(
                     self._command)
 
-                for meta in self._file_metadata:
+                for m in self._file_metadata:
                     # At this point the connector has already figured out and
                     # validated that the local file exists and has also decided
                     # upon the destination file name and the compression type.
@@ -668,7 +704,7 @@ class SnowflakeFileTransferAgent(object):
                     # GS only looks at the file name at the end of local file
                     # path to figure out the remote object name. Hence the prefix
                     # for local path is not necessary in the reconstructed command.
-                    file_path_to_replace_with = meta['dst_file_name']
+                    file_path_to_replace_with = m.dst_file_name
                     command_with_single_file = self._command
                     command_with_single_file = command_with_single_file.replace(
                         file_path_to_be_replaced,
@@ -679,16 +715,14 @@ class SnowflakeFileTransferAgent(object):
 
                     ret = self._cursor._execute_helper(command_with_single_file)
 
-                    if ret.get('data', dict()).get('stageInfo', None):
-                        meta['stage_info'] = ret['data']['stageInfo']
-                        meta['presigned_url'] = meta['stage_info'].get(
-                            'presignedUrl', None)
+                    if ret.get('data', dict()).get('stageInfo'):
+                        m.stage_info = ret['data']['stageInfo']
+                        m.presigned_url = m.stage_info.get('presignedUrl')
             elif self._command_type == CMD_TYPE_DOWNLOAD:
                 logger.debug('updating download file metas with presigned urls')
 
-                for idx, meta in enumerate(self._file_metadata):
-                    meta['presigned_url'] = self._presigned_urls[idx] \
-                        if len(self._presigned_urls) > idx else None
+                for idx, m in enumerate(self._file_metadata):
+                    m.presigned_url = self._presigned_urls[idx] if len(self._presigned_urls) > idx else None
 
     def result(self):
         converter_class = self._cursor._connection.converter_class
@@ -696,32 +730,28 @@ class SnowflakeFileTransferAgent(object):
         if self._command_type == CMD_TYPE_UPLOAD:
             if hasattr(self, '_results'):
                 for meta in self._results:
-                    if meta['src_compression_type'] is not None:
-                        src_compression_type = meta['src_compression_type'][
-                            'name']
+                    if meta.src_compression_type is not None:
+                        src_compression_type = meta.src_compression_type.name
                     else:
                         src_compression_type = 'NONE'
 
-                    if meta['dst_compression_type'] is not None:
-                        dst_compression_type = meta['dst_compression_type'][
-                            'name']
+                    if meta.dst_compression_type is not None:
+                        dst_compression_type = meta.dst_compression_type.name
                     else:
                         dst_compression_type = 'NONE'
 
-                    error_details = meta.get('error_details', '')
+                    error_details = meta.error_details or ''
 
-                    src_file_size = meta['src_file_size'] \
-                        if converter_class != SnowflakeConverterSnowSQL \
-                        else str(meta['src_file_size'])
+                    src_file_size = meta.src_file_size if converter_class != SnowflakeConverterSnowSQL \
+                        else str(meta.src_file_size)
 
-                    dst_file_size = meta['dst_file_size'] \
-                        if converter_class != SnowflakeConverterSnowSQL \
-                        else str(meta['dst_file_size'])
+                    dst_file_size = meta.dst_file_size if converter_class != SnowflakeConverterSnowSQL \
+                        else str(meta.dst_file_size)
 
                     logger.debug("raise_put_get_error: %s, %s, %s, %s, %s",
                                  self._raise_put_get_error,
-                                 meta['result_status'],
-                                 type(meta['result_status']),
+                                 meta.result_status,
+                                 type(meta.result_status),
                                  ResultStatus.ERROR,
                                  type(ResultStatus.ERROR))
                     if self._raise_put_get_error and error_details:
@@ -734,36 +764,36 @@ class SnowflakeFileTransferAgent(object):
                             }
                         )
                     rowset.append([
-                        meta['name'],
-                        meta['dst_file_name'],
+                        meta.name,
+                        meta.dst_file_name,
                         src_file_size,
                         dst_file_size,
                         src_compression_type,
                         dst_compression_type,
-                        meta['result_status'],
+                        meta.result_status,
                         error_details
                     ])
             return {
                 'rowtype': [
-                    RESULT_TEXT_COLUMN_DESC('source'),
-                    RESULT_TEXT_COLUMN_DESC('target'),
-                    RESULT_FIXED_COLUMN_DESC('source_size'),
-                    RESULT_FIXED_COLUMN_DESC('target_size'),
-                    RESULT_TEXT_COLUMN_DESC('source_compression'),
-                    RESULT_TEXT_COLUMN_DESC('target_compression'),
-                    RESULT_TEXT_COLUMN_DESC('status'),
-                    RESULT_TEXT_COLUMN_DESC('message'),
+                    result_text_column_desc('source'),
+                    result_text_column_desc('target'),
+                    result_fixed_column_desc('source_size'),
+                    result_fixed_column_desc('target_size'),
+                    result_text_column_desc('source_compression'),
+                    result_text_column_desc('target_compression'),
+                    result_text_column_desc('status'),
+                    result_text_column_desc('message'),
                 ],
                 'rowset': sorted(rowset),
             }
         else:  # DOWNLOAD
             if hasattr(self, '_results'):
                 for meta in self._results:
-                    dst_file_size = meta['dst_file_size'] \
+                    dst_file_size = meta.dst_file_size \
                         if converter_class != SnowflakeConverterSnowSQL \
-                        else str(meta['dst_file_size'])
+                        else str(meta.dst_file_size)
 
-                    error_details = meta.get('error_details', '')
+                    error_details = meta.error_details or ''
 
                     if self._raise_put_get_error and error_details:
                         Error.errorhandler_wrapper(
@@ -776,17 +806,17 @@ class SnowflakeFileTransferAgent(object):
                         )
 
                     rowset.append([
-                        meta['dst_file_name'],
+                        meta.dst_file_name,
                         dst_file_size,
-                        meta['result_status'],
+                        meta.result_status,
                         error_details
                     ])
             return {
                 'rowtype': [
-                    RESULT_TEXT_COLUMN_DESC('file'),
-                    RESULT_FIXED_COLUMN_DESC('size'),
-                    RESULT_TEXT_COLUMN_DESC('status'),
-                    RESULT_TEXT_COLUMN_DESC('message'),
+                    result_text_column_desc('file'),
+                    result_fixed_column_desc('size'),
+                    result_text_column_desc('status'),
+                    result_text_column_desc('message'),
                 ],
                 'rowset': sorted(rowset),
             }
@@ -882,10 +912,8 @@ class SnowflakeFileTransferAgent(object):
                     {
                         'msg': (
                             "The number of downloading files doesn't match "
-                            "the encryption materials: "
-                            "files={files}, encmat={encmat}").format(
-                            files=len(self._ret['data']['src_locations']),
-                            encmat=len(self._encryption_material)),
+                            f"the encryption materials: files={len(self._ret['data']['src_locations'])}, "
+                            f"encmat={len(self._encryption_material)}"),
                         'errno':
                             ER_INTERNAL_NOT_MATCH_ENCRYPT_MATERIAL
                     })
@@ -905,32 +933,24 @@ class SnowflakeFileTransferAgent(object):
                     })
 
         self._parallel = self._ret['data'].get('parallel', 1)
-        self._overwrite = self._force_put_overwrite or \
-                          self._ret['data'].get('overwrite', False)
+        self._overwrite = self._force_put_overwrite or self._ret['data'].get('overwrite', False)
         self._stage_location_type = self._ret['data']['stageInfo'][
             'locationType'].upper()
         self._stage_location = self._ret['data']['stageInfo']['location']
         self._stage_info = self._ret['data']['stageInfo']
-        self._presigned_urls = self._ret['data'].get('presignedUrls', None)
+        self._presigned_urls = self._ret['data'].get('presignedUrls')
 
         if self.get_storage_client(self._stage_location_type) is None:
             Error.errorhandler_wrapper(
                 self._cursor.connection, self._cursor,
                 OperationalError,
                 {
-                    'msg': ('Destination location type is not valid: '
-                             '{stage_location_type}').format(
-                        stage_location_type=self._stage_location_type,
-                    ),
+                    'msg': f'Destination location type is not valid: {self._stage_location_type}',
                     'errno': ER_INVALID_STAGE_FS
                 })
 
     def _init_file_metadata(self):
-        logger.debug("command type: %s", self._command_type)
-
-        # The list of self-sufficient file metas that are sent to
-        # remote storage clients to get operated on.
-        self._file_metadata = []
+        logger.debug(f"command type: {self._command_type}")
 
         if self._command_type == CMD_TYPE_UPLOAD:
             if len(self._src_files) == 0:
@@ -941,8 +961,7 @@ class SnowflakeFileTransferAgent(object):
                     self._cursor.connection, self._cursor,
                     ProgrammingError,
                     {
-                        'msg': "File doesn't exist: {file}".format(
-                            file=file_name),
+                        'msg': f"File doesn't exist: {file_name}",
                         'errno': ER_FILE_NOT_EXISTS
                     })
             if not self._source_from_stream:
@@ -952,8 +971,7 @@ class SnowflakeFileTransferAgent(object):
                             self._cursor.connection, self._cursor,
                             ProgrammingError,
                             {
-                                'msg': "File doesn't exist: {file}".format(
-                                    file=file_name),
+                                'msg': f"File doesn't exist: {file_name}",
                                 'errno': ER_FILE_NOT_EXISTS
                             })
                     elif os.path.isdir(file_name):
@@ -961,33 +979,34 @@ class SnowflakeFileTransferAgent(object):
                             self._cursor.connection, self._cursor,
                             ProgrammingError,
                             {
-                                'msg': ("Not a file but "
-                                         "a directory: {file}").format(
-                                    file=file_name),
+                                'msg': f"Not a file but a directory: {file_name}",
                                 'errno': ER_FILE_NOT_EXISTS
                             })
                     statinfo = os.stat(file_name)
-                    self._file_metadata += [{
-                        'name': os.path.basename(file_name),
-                        'src_file_name': file_name,
-                        'src_file_size': statinfo.st_size,
-                        'stage_location_type': self._stage_location_type,
-                        'stage_info': self._stage_info,
-                    }]
+                    self._file_metadata.append(
+                        SnowflakeFileMeta(
+                            name=os.path.basename(file_name),
+                            src_file_name=file_name,
+                            src_file_size=statinfo.st_size,
+                            stage_location_type=self._stage_location_type,
+                            stage_info=self._stage_info,
+                            encryption_material=self._encryption_material[0] if len(self._encryption_material) > 0 else None
+                        )
+                    )
             else:
                 file_name = self._src_files[0]
-                self._file_metadata += [{
-                    'name': os.path.basename(file_name),
-                    'src_file_name': file_name,
-                    'src_stream': self._source_from_stream,
-                    'src_file_size': self._source_from_stream.seek(0, os.SEEK_END),
-                    'stage_location_type': self._stage_location_type,
-                    'stage_info': self._stage_info,
-                }]
+                self._file_metadata.append(
+                    SnowflakeFileMeta(
+                        name=os.path.basename(file_name),
+                        src_file_name=file_name,
+                        src_stream=self._source_from_stream,
+                        src_file_size=self._source_from_stream.seek(0, os.SEEK_END),
+                        stage_location_type=self._stage_location_type,
+                        stage_info=self._stage_info,
+                        encryption_material=self._encryption_material[0] if len(self._encryption_material) > 0 else None
+                    )
+                )
                 self._source_from_stream.seek(0)
-            if len(self._encryption_material) > 0:
-                for meta in self._file_metadata:
-                    meta['encryption_material'] = self._encryption_material[0]
         elif self._command_type == CMD_TYPE_DOWNLOAD:
             for file_name in self._src_files:
                 if len(file_name) > 0:
@@ -995,19 +1014,18 @@ class SnowflakeFileTransferAgent(object):
                     first_path_sep = file_name.find('/')
                     dst_file_name = file_name[first_path_sep + 1:] \
                         if first_path_sep >= 0 else file_name
-                    self._file_metadata += [{
-                        'name': os.path.basename(file_name),
-                        'src_file_name': file_name,
-                        'dst_file_name': dst_file_name,
-                        'stage_location_type': self._stage_location_type,
-                        'stage_info': self._stage_info,
-                        'local_location': self._local_location,
-                    }]
-            for meta in self._file_metadata:
-                file_name = meta['src_file_name']
-                if file_name in self._src_file_to_encryption_material:
-                    meta['encryption_material'] = \
-                        self._src_file_to_encryption_material[file_name]
+                    self._file_metadata.append(
+                        SnowflakeFileMeta(
+                            name=os.path.basename(file_name),
+                            src_file_name=file_name,
+                            dst_file_name=dst_file_name,
+                            stage_location_type=self._stage_location_type,
+                            stage_info=self._stage_info,
+                            local_location=self._local_location,
+                            encryption_material=self._src_file_to_encryption_material[file_name]
+                            if file_name in self._src_file_to_encryption_material else None,
+                        )
+                    )
 
     def _process_file_compression_type(self):
         user_specified_source_compression = None
@@ -1016,26 +1034,20 @@ class SnowflakeFileTransferAgent(object):
         elif self._source_compression == 'none':
             auto_detect = False
         else:
-            user_specified_source_compression = \
-                FileCompressionType.lookupByMimeSubType(
-                    self._source_compression)
-            if user_specified_source_compression is None or not \
-                    user_specified_source_compression['is_supported']:
+            user_specified_source_compression: 'CompressionType' = lookup_by_mime_sub_type(self._source_compression)
+            if user_specified_source_compression is None or not user_specified_source_compression.is_supported:
                 Error.errorhandler_wrapper(
                     self._cursor.connection, self._cursor,
                     ProgrammingError,
                     {
-                        'msg': ('Feature is not supported: '
-                                 '{0}').format(
-                            user_specified_source_compression
-                        ),
+                        'msg': f'Feature is not supported: {user_specified_source_compression}',
                         'errno': ER_COMPRESSION_NOT_SUPPORTED
                     })
 
             auto_detect = False
 
-        for meta in self._file_metadata:
-            file_name = meta['src_file_name']
+        for m in self._file_metadata:
+            file_name = m.src_file_name
 
             current_file_compression_type = None
             if auto_detect:
@@ -1063,59 +1075,51 @@ class SnowflakeFileTransferAgent(object):
                 if encoding is not None:
                     logger.debug('detected the encoding %s: file=%s',
                                  encoding, file_name)
-                    current_file_compression_type = \
-                        FileCompressionType.lookupByMimeSubType(encoding)
+                    current_file_compression_type = lookup_by_mime_sub_type(encoding)
                 else:
                     logger.debug('no file encoding was detected: file=%s',
                                  file_name)
 
-                if current_file_compression_type is not None and not \
-                        current_file_compression_type['is_supported']:
+                if current_file_compression_type is not None and not current_file_compression_type.is_supported:
                     Error.errorhandler_wrapper(
-                        self._cursor.connection, self._cursor,
+                        self._cursor.connection,
+                        self._cursor,
                         ProgrammingError,
                         {
-                            'msg': ('Feature is not supported: '
-                                     '{0}').format(
-                                current_file_compression_type
-                            ),
+                            'msg': f'Feature is not supported: {current_file_compression_type}',
                             'errno': ER_COMPRESSION_NOT_SUPPORTED
-                        })
+                        }
+                    )
             else:
-                current_file_compression_type = \
-                    user_specified_source_compression
+                current_file_compression_type = user_specified_source_compression
 
             if current_file_compression_type is not None:
-                meta['src_compression_type'] = current_file_compression_type
-                if current_file_compression_type['is_supported']:
-                    meta['dst_compression_type'] = \
-                        current_file_compression_type
-                    meta['require_compress'] = False
-                    meta['dst_file_name'] = meta['name']
+                m.src_compression_type = current_file_compression_type
+                if current_file_compression_type.is_supported:
+                    m.dst_compression_type = current_file_compression_type
+                    m.require_compress = False
+                    m.dst_file_name = m.name
                 else:
                     Error.errorhandler_wrapper(
-                        self._cursor.connection, self._cursor,
+                        self._cursor.connection,
+                        self._cursor,
                         ProgrammingError,
                         {
-                            'msg': ('Feature is not supported: '
-                                     '{0}').format(
-                                current_file_compression_type
-                            ), 'errno': ER_COMPRESSION_NOT_SUPPORTED
-                        })
+                            'msg': f'Feature is not supported: {current_file_compression_type}',
+                            'errno': ER_COMPRESSION_NOT_SUPPORTED
+                        }
+                    )
             else:
                 # src is not compressed but the destination want to be
                 # compressed unless the users disable it
-                meta['require_compress'] = self._auto_compress
-                meta['src_compression_type'] = None
+                m.require_compress = self._auto_compress
+                m.src_compression_type = None
                 if self._auto_compress:
-                    meta['dst_file_name'] = \
-                        meta['name'] + \
-                        FileCompressionType.Types['GZIP']['file_extension']
-                    meta['dst_compression_type'] = \
-                        FileCompressionType.Types['GZIP']
+                    m.dst_file_name = m.name + CompressionTypes['GZIP'].file_extension
+                    m.dst_compression_type = CompressionTypes['GZIP']
                 else:
-                    meta['dst_file_name'] = meta['name']
-                    meta['dst_compression_type'] = None
+                    m.dst_file_name = m.name
+                    m.dst_compression_type = None
 
     def get_local_file_path_from_put_command(self, command):
         """Get the local file path from PUT command (Logic adopted from JDBC, written by Polita).
@@ -1137,7 +1141,6 @@ class SnowflakeFileTransferAgent(object):
         file_path_begin_index += len(FILE_PROTOCOL)
 
         file_path = ""
-        file_path_end_index = 0
 
         if is_file_path_quoted:
             file_path_end_index = command.find("'", file_path_begin_index)

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -100,7 +100,7 @@ class SnowflakeFileMeta:
     get_azure_callback: Optional[Type['SnowflakeProgressPercentage']] = None
     get_callback_output_stream: Optional[IO[str]] = None
     show_progress_bar: bool = False
-    multipart_threshold: int = -1
+    multipart_threshold: int = 67108864  # Historical value
     parallel: int = 1
     presigned_url: Optional[str] = None
     overwrite: bool = False

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -67,20 +67,27 @@ class SnowflakeGCSUtil:
         return client
 
     @staticmethod
-    def upload_file(data_file: str, meta: Dict[str, Any], encryption_metadata: Any, max_concurrency: int):
-        """Uploads the local file to remote storage.
+    def upload_file(data_file: str,
+                    meta: Dict[str, Any],
+                    encryption_metadata: Any,
+                    max_concurrency: int,
+                    multipart_threshold: int,
+                    ):
+        """Uploads the local file to GCS's blob storage.
 
         Args:
             data_file: File path on local system.
             meta: The File meta object (contains credentials and remote location).
             encryption_metadata: Encryption metadata to be set on object.
-            max_concurrency: Not applicable to GCS.
+            max_concurrency: The maximum number of threads to used to upload. Not applicable to GCS.
+            multipart_threshold: The number of bytes after which size a file should be uploaded concurrently in chunks.
+                Not applicable to GCS.
 
         Raises:
             HTTPError if some http errors occurred.
 
         Returns:
-            None, if uploading was successful.
+            None.
         """
         upload_url = meta.get('presigned_url', None)
         access_token = None

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -185,7 +185,7 @@ class SnowflakeGCSUtil:
             meta.result_status = ResultStatus.NEED_RETRY
             return
         finally:
-            if meta.src_stream is not None:
+            if meta.src_stream is None:
                 upload_src.close()
 
         if meta.put_callback is not None:

--- a/src/snowflake/connector/gcs_util.py
+++ b/src/snowflake/connector/gcs_util.py
@@ -8,12 +8,15 @@ import json
 import os
 from collections import namedtuple
 from logging import getLogger
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from .compat import quote
-from .constants import HTTP_HEADER_CONTENT_ENCODING, SHA256_DIGEST, FileHeader, ResultStatus
+from .constants import HTTP_HEADER_CONTENT_ENCODING, FileHeader, ResultStatus
 from .encryption_util import EncryptionMetadata
 from .vendored import requests
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .file_transfer_agent import SnowflakeFileMeta
 
 logger = getLogger(__name__)
 
@@ -41,7 +44,7 @@ class SnowflakeGCSUtil:
 
     @staticmethod
     def create_client(stage_info: Dict[str, Any],
-                      use_accelerate_endpoint: bool = False):
+                      use_accelerate_endpoint: bool = False) -> Optional[str]:
         """Creates a client object with given stage credentials.
 
         Args:
@@ -55,20 +58,19 @@ class SnowflakeGCSUtil:
         security_token = stage_credentials.get('GCS_ACCESS_TOKEN')
 
         if security_token:
-            logger.debug("len(GCS_ACCESS_TOKEN): %s", len(security_token))
+            logger.debug(f"len(GCS_ACCESS_TOKEN): {len(security_token)}")
             logger.debug("Access token is saved as client for renew")
             client = security_token
 
         else:
-            logger.debug("No access token received from GS, constructing "
-                         "anonymous client")
+            logger.debug("No access token received from GS, constructing anonymous client")
             client = None
 
         return client
 
     @staticmethod
     def upload_file(data_file: str,
-                    meta: Dict[str, Any],
+                    meta: 'SnowflakeFileMeta',
                     encryption_metadata: Any,
                     max_concurrency: int,
                     multipart_threshold: int,
@@ -89,17 +91,17 @@ class SnowflakeGCSUtil:
         Returns:
             None.
         """
-        upload_url = meta.get('presigned_url', None)
-        access_token = None
+        upload_url = meta.presigned_url
+        access_token: Optional[str] = None
 
         if not upload_url:
-            upload_url = SnowflakeGCSUtil.generate_file_url(meta['stage_info']['location'],
-                                                            meta['dst_file_name'].lstrip('/'))
-            access_token = meta['client']
+            upload_url = SnowflakeGCSUtil.generate_file_url(meta.stage_info['location'],
+                                                            meta.dst_file_name.lstrip('/'))
+            access_token = meta.client
 
         content_encoding = ""
-        if meta.get('dst_compression_type') is not None:
-            content_encoding = meta['dst_compression_type']['name'].lower()
+        if meta.dst_compression_type is not None:
+            content_encoding = meta.dst_compression_type.name.lower()
 
         # We set the contentEncoding to blank for GZIP files. We don't
         # want GCS to think our gzip files are gzips because it makes
@@ -111,7 +113,7 @@ class SnowflakeGCSUtil:
 
         gcs_headers = {
             HTTP_HEADER_CONTENT_ENCODING: content_encoding,
-            GCS_METADATA_SFC_DIGEST: meta[SHA256_DIGEST],
+            GCS_METADATA_SFC_DIGEST: meta.sha256_digest,
         }
         if access_token:
             gcs_headers.update({
@@ -141,10 +143,10 @@ class SnowflakeGCSUtil:
 
         try:
             upload_src = None
-            if 'src_stream' not in meta:
+            if meta.src_stream is None:
                 upload_src = open(data_file, 'rb')
             else:
-                upload_src = meta.get('real_src_stream', meta['src_stream'])
+                upload_src = meta.real_src_stream or meta.src_stream
 
             response = requests.put(
                 url=upload_url,
@@ -162,49 +164,48 @@ class SnowflakeGCSUtil:
             # According to the above resource, GCS recommends retrying
             # for the following error codes.
             if errh.response.status_code in [403, 408, 429, 500, 503]:
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.last_error = errh
+                meta.result_status = ResultStatus.NEED_RETRY
                 return
             elif ((not access_token) and errh.response.status_code == 400 and
-                  ('last_error' not in meta or meta['last_error'].response.status_code != 400)):
+                  (meta.last_error is None or meta.last_error.response.status_code != 400)):
                 # Only attempt to renew urls if this isn't the second time this happens
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.RENEW_PRESIGNED_URL
+                meta.last_error = errh
+                meta.result_status = ResultStatus.RENEW_PRESIGNED_URL
                 return
             elif access_token and SnowflakeGCSUtil.is_token_expired(errh.response):
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.last_error = errh
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return
             # raise anything else
             raise errh
         except requests.exceptions.Timeout as errt:
-            logger.debug("GCS file upload Timeout Error: %s", errt)
-            meta['last_error'] = errt
-            meta['result_status'] = ResultStatus.NEED_RETRY
+            logger.debug(f"GCS file upload Timeout Error: {errt}")
+            meta.last_error = errt
+            meta.result_status = ResultStatus.NEED_RETRY
             return
         finally:
-            if 'src_stream' not in meta:
+            if meta.src_stream is not None:
                 upload_src.close()
 
-        if meta['put_callback']:
-            meta['put_callback'](
+        if meta.put_callback is not None:
+            meta.put_callback(
                 data_file,
-                meta['src_file_size'],
-                output_stream=meta['put_callback_output_stream'],
-                show_progress_bar=meta['show_progress_bar'])(
-                meta['src_file_size'])
+                meta.src_file_size,
+                output_stream=meta.put_callback_output_stream,
+                show_progress_bar=meta.show_progress_bar)(
+                meta.src_file_size)
 
         logger.debug('DONE putting a file')
-        meta['dst_file_size'] = meta['upload_size']
-        meta['result_status'] = ResultStatus.UPLOADED
+        meta.dst_file_size = meta.upload_size
+        meta.result_status = ResultStatus.UPLOADED
 
-        meta[GCS_FILE_HEADER_DIGEST] = gcs_headers[GCS_METADATA_SFC_DIGEST]
-        meta[GCS_FILE_HEADER_CONTENT_LENGTH] = meta['upload_size']
-        meta[GCS_FILE_HEADER_ENCRYPTION_METADATA] = \
-            gcs_headers.get(GCS_METADATA_ENCRYPTIONDATAPROP, None)
+        meta.gcs_file_header_digest = gcs_headers[GCS_METADATA_SFC_DIGEST]
+        meta.gcs_file_header_content_length = meta.upload_size
+        meta.gcs_file_header_encryption_metadata = json.loads(gcs_headers.get(GCS_METADATA_ENCRYPTIONDATAPROP, "null"))
 
     @staticmethod
-    def _native_download_file(meta: Dict[str, Any], full_dst_file_name: str, max_concurrency: int):
+    def _native_download_file(meta: 'SnowflakeFileMeta', full_dst_file_name: str, max_concurrency: int):
         """Downloads the remote object to local file.
 
         Args:
@@ -218,14 +219,14 @@ class SnowflakeGCSUtil:
         Returns:
             None, if downloading was successful.
         """
-        download_url = meta.get('presigned_url', None)
+        download_url = meta.presigned_url
         gcs_headers = None
-        access_token = None
+        access_token: Optional[str] = None
 
         if not download_url:
-            download_url = SnowflakeGCSUtil.generate_file_url(meta['stage_info']['location'],
-                                                              meta['src_file_name'].lstrip('/'))
-            access_token = meta['client']
+            download_url = SnowflakeGCSUtil.generate_file_url(meta.stage_info['location'],
+                                                              meta.src_file_name.lstrip('/'))
+            access_token = meta.client
             gcs_headers = {'Authorization': f'Bearer {access_token}'}
 
         try:
@@ -237,7 +238,7 @@ class SnowflakeGCSUtil:
                                                  decode_content=False):
                     fd.write(chunk)
         except requests.exceptions.HTTPError as errh:
-            logger.debug("GCS file download Http Error: %s", errh)
+            logger.debug(f"GCS file download Http Error: {errh}")
             # Presigned urls can be generated for any xml-api operation
             # offered by GCS. Hence the error codes expected are similar
             # to xml api.
@@ -246,25 +247,25 @@ class SnowflakeGCSUtil:
             # According to the above resource, GCS recommends retrying
             # for the following error codes.
             if errh.response.status_code in [403, 408, 429, 500, 503]:
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.last_error = errh
+                meta.result_status = ResultStatus.NEED_RETRY
                 return
             elif ((not access_token) and errh.response.status_code == 400 and
-                  ('last_error' not in meta or meta['last_error'].errh.response.status_code != 400)):
+                  (meta.last_error is None or meta.last_error.errh.response.status_code != 400)):
                 # Only attempt to renew urls if this isn't the second time this happens
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.RENEW_PRESIGNED_URL
+                meta.last_error = errh
+                meta.result_status = ResultStatus.RENEW_PRESIGNED_URL
                 return
             elif access_token and SnowflakeGCSUtil.is_token_expired(errh.response):
-                meta['last_error'] = errh
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.last_error = errh
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return
             # raise anything else
             raise errh
         except requests.exceptions.Timeout as errt:
-            logger.debug("GCS file download Timeout Error: %s", errt)
-            meta['last_error'] = errt
-            meta['result_status'] = ResultStatus.NEED_RETRY
+            logger.debug(f"GCS file download Timeout Error: {errt}")
+            meta.last_error = errt
+            meta.result_status = ResultStatus.NEED_RETRY
             return
 
         encryption_metadata = None
@@ -285,26 +286,25 @@ class SnowflakeGCSUtil:
         # Sadly, we can only determine the src file size after we've
         # downloaded it, unlike the other cloud providers where the
         # metadata can be read beforehand.
-        meta['src_file_size'] = os.path.getsize(full_dst_file_name)
+        meta.src_file_size = os.path.getsize(full_dst_file_name)
 
-        if meta['get_callback']:
-            meta['get_callback'](
-                meta['src_file_name'],
-                meta['src_file_size'],
-                output_stream=meta['get_callback_output_stream'],
-                show_progress_bar=meta['show_progress_bar'])(
-                meta['src_file_size'])
+        if meta.get_callback:
+            meta.get_callback(
+                meta.src_file_name,
+                meta.src_file_size,
+                output_stream=meta.get_callback_output_stream,
+                show_progress_bar=meta.show_progress_bar)(
+                meta.src_file_size)
 
         logger.debug('DONE getting a file')
-        meta['result_status'] = ResultStatus.DOWNLOADED
+        meta.result_status = ResultStatus.DOWNLOADED
 
-        meta[GCS_FILE_HEADER_DIGEST] = response.headers.get(
-            GCS_METADATA_SFC_DIGEST, None)
-        meta[GCS_FILE_HEADER_CONTENT_LENGTH] = len(response.content)
-        meta[GCS_FILE_HEADER_ENCRYPTION_METADATA] = encryption_metadata
+        meta.gcs_file_header_digest = response.headers.get(GCS_METADATA_SFC_DIGEST)
+        meta.gcs_file_header_content_length = len(response.content)
+        meta.gcs_file_header_encryption_metadata = encryption_metadata
 
     @staticmethod
-    def get_file_header(meta: Dict[str, Any], filename: str) -> FileHeader:
+    def get_file_header(meta: 'SnowflakeFileMeta', filename: str) -> Optional[FileHeader]:
         """Gets the remote file's metadata.
 
         Args:
@@ -318,24 +318,20 @@ class SnowflakeGCSUtil:
         Notes:
             Sometimes this method is called to verify that the file has indeed been uploaded. In cases of presigned
             url, we have no way of verifying that, except with the http status code of 200 which we have already
-            confirmed and set the meta['result_status'] = UPLOADED/DOWNLOADED.
+            confirmed and set the meta.result_status = UPLOADED/DOWNLOADED.
         """
-        if meta.get('result_status', None) == ResultStatus.UPLOADED \
-                or meta.get('result_status', None) == ResultStatus.DOWNLOADED:
+        if meta.result_status == ResultStatus.UPLOADED or meta.result_status == ResultStatus.DOWNLOADED:
             return FileHeader(
-                digest=meta.get(
-                    GCS_FILE_HEADER_DIGEST, None),
-                content_length=meta.get(
-                    GCS_FILE_HEADER_CONTENT_LENGTH, None),
-                encryption_metadata=meta.get(
-                    GCS_FILE_HEADER_ENCRYPTION_METADATA, None),
+                digest=meta.gcs_file_header_digest,
+                content_length=meta.gcs_file_header_content_length,
+                encryption_metadata=meta.gcs_file_header_encryption_metadata,
             )
         else:
-            if meta.get('presigned_url', None):
-                meta['result_status'] = ResultStatus.NOT_FOUND_FILE
+            if meta.presigned_url:
+                meta.result_status = ResultStatus.NOT_FOUND_FILE
             else:
-                url = SnowflakeGCSUtil.generate_file_url(meta['stage_info']['location'], filename.lstrip('/'))
-                access_token = meta['client']
+                url = SnowflakeGCSUtil.generate_file_url(meta.stage_info['location'], filename.lstrip('/'))
+                access_token: str = meta.client
                 gcs_headers = {'Authorization': f'Bearer {access_token}'}
                 try:
                     response = requests.head(url, headers=gcs_headers)
@@ -357,7 +353,7 @@ class SnowflakeGCSUtil:
                                 if GCS_METADATA_MATDESC_KEY in response.headers
                                 else None,
                             )
-                    meta['result_status'] = ResultStatus.UPLOADED
+                    meta.result_status = ResultStatus.UPLOADED
                     return FileHeader(
                         digest=digest,
                         content_length=content_length,
@@ -365,17 +361,17 @@ class SnowflakeGCSUtil:
                     )
                 except requests.exceptions.HTTPError as errh:
                     if errh.response.status_code in [403, 408, 429, 500, 503]:
-                        meta['last_error'] = errh
-                        meta['result_status'] = ResultStatus.NEED_RETRY
+                        meta.last_error = errh
+                        meta.result_status = ResultStatus.NEED_RETRY
                         return
                     if errh.response.status_code == 404:
-                        meta['result_status'] = ResultStatus.NOT_FOUND_FILE
+                        meta.result_status = ResultStatus.NOT_FOUND_FILE
                     elif SnowflakeGCSUtil.is_token_expired(errh.response):
-                        meta['last_error'] = errh
-                        meta['result_status'] = ResultStatus.RENEW_TOKEN
+                        meta.last_error = errh
+                        meta.result_status = ResultStatus.RENEW_TOKEN
                     else:
-                        meta['last_error'] = errh
-                        meta['result_status'] = ResultStatus.ERROR
+                        meta.last_error = errh
+                        meta.result_status = ResultStatus.ERROR
                         raise errh
 
         return FileHeader(
@@ -385,7 +381,7 @@ class SnowflakeGCSUtil:
         )
 
     @staticmethod
-    def extract_bucket_name_and_path(stage_location: str):
+    def extract_bucket_name_and_path(stage_location: str) -> GcsLocation:
         container_name = stage_location
         path = ''
 
@@ -399,12 +395,12 @@ class SnowflakeGCSUtil:
         return GcsLocation(bucket_name=container_name, path=path)
 
     @staticmethod
-    def generate_file_url(stage_location: str, filename: str):
+    def generate_file_url(stage_location: str, filename: str) -> str:
         gcs_location = SnowflakeGCSUtil.extract_bucket_name_and_path(stage_location)
         full_file_path = f'{gcs_location.path}{filename}'
         return f'https://storage.googleapis.com/{gcs_location.bucket_name}/{quote(full_file_path)}'
 
     @staticmethod
-    def is_token_expired(response: Any):
+    def is_token_expired(response: Any) -> bool:
         # Looking further as java gcs client code, I find that token only need refresh if error is 401
         return response.status_code == 401

--- a/src/snowflake/connector/local_util.py
+++ b/src/snowflake/connector/local_util.py
@@ -8,8 +8,12 @@ from __future__ import division
 
 import os
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 from .constants import ResultStatus
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .file_transfer_agent import SnowflakeFileMeta
 
 
 class SnowflakeLocalUtil(object):
@@ -18,41 +22,32 @@ class SnowflakeLocalUtil(object):
         return None
 
     @staticmethod
-    def upload_one_file_with_retry(meta):
+    def upload_one_file_with_retry(meta: 'SnowflakeFileMeta') -> None:
         logger = getLogger(__name__)
-        logger.debug(
-            "src_file_name=[%s], "
-            "real_src_file_name=[%s], "
-            "stage_info=[%s], "
-            "dst_file_name=[%s]",
-            meta['src_file_name'],
-            meta['real_src_file_name'],
-            meta['stage_info'],
-            meta['dst_file_name']
-        )
+        logger.debug(f"src_file_name=[{meta.src_file_name}], real_src_file_name=[{meta.real_src_file_name}], "
+                     f"stage_info=[{meta.stage_info}], dst_file_name=[{meta.dst_file_name}]")
         frd = None
-        if 'src_stream' not in meta:
-            frd = open(meta['real_src_file_name'], 'rb')
+        if meta.src_stream is None:
+            frd = open(meta.real_src_file_name, 'rb')
         else:
-            frd = meta.get('real_src_stream', meta['src_stream'])
+            frd = meta.real_src_stream or meta.src_stream
         with open(os.path.join(
-                os.path.expanduser(meta['stage_info']['location']),
-                meta['dst_file_name']), 'wb') as output:
+                os.path.expanduser(meta.stage_info['location']),
+                meta.dst_file_name), 'wb') as output:
             output.writelines(frd)
 
-        meta['dst_file_size'] = meta['upload_size']
-        meta['result_status'] = ResultStatus.UPLOADED
+        meta.dst_file_size = meta.upload_size
+        meta.result_status = ResultStatus.UPLOADED
 
     @staticmethod
-    def download_one_file(meta):
+    def download_one_file(meta: 'SnowflakeFileMeta') -> None:
         full_src_file_name = os.path.join(
-            os.path.expanduser(meta['stage_info']['location']),
-            meta['src_file_name'] if not meta['src_file_name'].startswith(
-                os.sep) else
-            meta['src_file_name'][1:])
+            os.path.expanduser(meta.stage_info['location']),
+            meta.src_file_name if not meta.src_file_name.startswith(os.sep) else
+            meta.src_file_name[1:])
         full_dst_file_name = os.path.join(
-            meta['local_location'],
-            os.path.basename(meta['dst_file_name']))
+            meta.local_location,
+            os.path.basename(meta.dst_file_name))
         base_dir = os.path.dirname(full_dst_file_name)
         if not os.path.exists(base_dir):
             os.makedirs(base_dir)
@@ -61,5 +56,5 @@ class SnowflakeLocalUtil(object):
             with open(full_dst_file_name, 'wb+') as output:
                 output.writelines(frd)
         statinfo = os.stat(full_dst_file_name)
-        meta['dst_file_size'] = statinfo.st_size
-        meta['result_status'] = ResultStatus.DOWNLOADED
+        meta.dst_file_size = statinfo.st_size
+        meta.result_status = ResultStatus.DOWNLOADED

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -708,7 +708,7 @@ class SnowflakeRestful(object):
                         stack_trace=traceback.format_exc()
                     )
                     if isinstance(cause, Error):
-                        Error.errorhandler_wrapper(conn, None, cause)
+                        Error.errorhandler_wrapper_from_cause(conn, None, cause)
                     else:
                         self.handle_invalid_certificate_error(
                             conn, full_url, cause)

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -106,7 +106,7 @@ class SnowflakeRemoteStorageUtil(object):
         last_err = None
         max_retry = DEFAULT_MAX_RETRY
         for retry in range(max_retry):
-            if meta.overwrite is None:
+            if not meta.overwrite:
                 file_header = util_class.get_file_header(
                     meta, meta.dst_file_name)
 
@@ -118,7 +118,7 @@ class SnowflakeRemoteStorageUtil(object):
                     meta.result_status = ResultStatus.SKIPPED
                     return
 
-            if meta.overwrite is not None or meta.result_status == ResultStatus.NOT_FOUND_FILE:
+            if meta.overwrite or meta.result_status == ResultStatus.NOT_FOUND_FILE:
                 util_class.upload_file(
                     data_file,
                     meta,

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -12,6 +12,7 @@ import time
 from collections import namedtuple
 from io import BytesIO
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 from .azure_util import SnowflakeAzureUtil
 from .constants import ResultStatus
@@ -19,8 +20,13 @@ from .encryption_util import SnowflakeEncryptionUtil
 from .gcs_util import SnowflakeGCSUtil
 from .s3_util import SnowflakeS3Util
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .file_transfer_agent import SnowflakeFileMeta
+
 DEFAULT_CONCURRENCY = 1
 DEFAULT_MAX_RETRY = 5
+
+logger = getLogger(__name__)
 
 """
 Encryption Material
@@ -41,167 +47,149 @@ class NeedRenewTokenError(Exception):
 class SnowflakeRemoteStorageUtil(object):
 
     @staticmethod
-    def getForStorageType(type):
-        if (type == 'S3'):
+    def get_for_storage_type(_type):
+        if _type == 'S3':
             return SnowflakeS3Util
-        elif (type == 'AZURE'):
+        elif _type == 'AZURE':
             return SnowflakeAzureUtil
-        elif (type == 'GCS'):
+        elif _type == 'GCS':
             return SnowflakeGCSUtil
         else:
             return None
 
     @staticmethod
     def create_client(stage_info, use_accelerate_endpoint=False):
-        util_class = SnowflakeRemoteStorageUtil.getForStorageType(
+        util_class = SnowflakeRemoteStorageUtil.get_for_storage_type(
             stage_info['locationType'])
         return util_class.create_client(
             stage_info,
             use_accelerate_endpoint=use_accelerate_endpoint)
 
     @staticmethod
-    def upload_one_file(meta):
+    def upload_one_file(meta: 'SnowflakeFileMeta') -> None:
         """Uploads a file to S3."""
-        logger = getLogger(__name__)
         encryption_metadata = None
 
-        if 'encryption_material' in meta:
-            if 'src_stream' not in meta:
+        if meta.encryption_material is not None:
+            if meta.src_stream is None:
                 (encryption_metadata,
                  data_file) = SnowflakeEncryptionUtil.encrypt_file(
-                    meta['encryption_material'],
-                    meta['real_src_file_name'], tmp_dir=meta['tmp_dir'])
-                logger.debug(
-                    'encrypted data file=%s, size=%s', data_file,
-                    os.path.getsize(data_file))
+                    meta.encryption_material,
+                    meta.real_src_file_name, tmp_dir=meta.tmp_dir)
+                logger.debug(f'encrypted data file={data_file}, size={os.path.getsize(data_file)}')
             else:
                 encrypted_stream = BytesIO()
-                src_stream = meta.get('real_src_stream', meta['src_stream'])
+                src_stream = meta.real_src_stream or meta.src_stream
                 src_stream.seek(0)
                 encryption_metadata = SnowflakeEncryptionUtil.encrypt_stream(
-                    meta['encryption_material'],
+                    meta.encryption_material,
                     src_stream,
                     encrypted_stream
                 )
                 src_stream.seek(0)
-                logger.debug(
-                    'encrypted data stream size=%s', encrypted_stream.seek(0, os.SEEK_END))
+                logger.debug(f'encrypted data stream size={encrypted_stream.seek(0, os.SEEK_END)}')
                 encrypted_stream.seek(0)
-                if 'real_src_stream' in meta:
-                    meta['real_src_stream'].close()
-                meta['real_src_stream'] = encrypted_stream
-                data_file = meta['real_src_file_name']
+                if meta.real_src_stream is not None:
+                    meta.real_src_stream.close()
+                meta.real_src_stream = encrypted_stream
+                data_file = meta.real_src_file_name
         else:
             logger.debug('not encrypted data file')
-            data_file = meta['real_src_file_name']
+            data_file = meta.real_src_file_name
 
-        util_class = SnowflakeRemoteStorageUtil.getForStorageType(
-            meta['stage_info']['locationType'])
+        util_class = SnowflakeRemoteStorageUtil.get_for_storage_type(
+            meta.stage_info['locationType'])
 
-        logger.debug('putting a file: %s, %s',
-                     meta['stage_info']['location'], meta['dst_file_name'])
+        logger.debug(f"putting a file: {meta.stage_info['location']}, {meta.dst_file_name}")
 
-        max_concurrency = meta['parallel']
+        max_concurrency = meta.parallel
         last_err = None
         max_retry = DEFAULT_MAX_RETRY
         for retry in range(max_retry):
-            if not meta.get('overwrite'):
+            if meta.overwrite is None:
                 file_header = util_class.get_file_header(
-                    meta, meta['dst_file_name'])
+                    meta, meta.dst_file_name)
 
                 if file_header and \
-                        meta['result_status'] == ResultStatus.UPLOADED:
-                    logger.debug(
-                        'file already exists location="%s", file_name="%s"',
-                        meta['stage_info']['location'],
-                        meta['dst_file_name'])
-                    meta['dst_file_size'] = 0
-                    meta['result_status'] = ResultStatus.SKIPPED
+                        meta.result_status == ResultStatus.UPLOADED:
+                    logger.debug(f'file already exists location="{meta.stage_info["location"]}", '
+                                 f'file_name="{meta.dst_file_name}"')
+                    meta.dst_file_size = 0
+                    meta.result_status = ResultStatus.SKIPPED
                     return
 
-            if meta.get('overwrite') or meta.get('result_status') == ResultStatus.NOT_FOUND_FILE:
+            if meta.overwrite is not None or meta.result_status == ResultStatus.NOT_FOUND_FILE:
                 util_class.upload_file(
                     data_file,
                     meta,
                     encryption_metadata,
                     max_concurrency,
-                    multipart_threshold=meta['multipart_threshold']
+                    multipart_threshold=meta.multipart_threshold
                 )
 
-            if (meta['result_status'] == ResultStatus.UPLOADED):
+            if meta.result_status == ResultStatus.UPLOADED:
                 return
-            elif (meta['result_status'] == ResultStatus.RENEW_TOKEN):
+            elif meta.result_status == ResultStatus.RENEW_TOKEN:
                 return
-            elif (meta['result_status'] == ResultStatus.RENEW_PRESIGNED_URL):
+            elif meta.result_status == ResultStatus.RENEW_PRESIGNED_URL:
                 return
-            elif (meta['result_status'] == ResultStatus.NEED_RETRY):
-                last_err = meta['last_error']
-                logger.debug(
-                    'Failed to upload a file: %s, err: %s. Retrying with '
-                    'max concurrency: %s',
-                    data_file, last_err, max_concurrency)
-                if 'no_sleeping_time' not in meta:
+            elif meta.result_status == ResultStatus.NEED_RETRY:
+                last_err = meta.last_error
+                logger.debug(f'Failed to upload a file: {data_file}, err: {last_err}. Retrying with '
+                             f'max concurrency: {max_concurrency}')
+                if not meta.no_sleeping_time:
                     sleeping_time = min(2 ** retry, 16)
-                    logger.debug("sleeping: %s", sleeping_time)
+                    logger.debug(f"sleeping {sleeping_time}")
                     time.sleep(sleeping_time)
-            elif (meta[
-                      'result_status'] == ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY):
-                last_err = meta['last_error']
-                max_concurrency = meta['parallel'] - int(
-                    retry * meta['parallel'] / max_retry)
+            elif meta.result_status == ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY:
+                last_err = meta.last_error
+                max_concurrency = meta.parallel - int(
+                    retry * meta.parallel / max_retry)
                 max_concurrency = max(DEFAULT_CONCURRENCY, max_concurrency)
-                meta['last_max_concurrency'] = max_concurrency
+                meta.last_max_concurrency = max_concurrency
 
                 logger.debug(
-                    'Failed to upload a file: %s, err: %s. Retrying with '
-                    'max concurrency: %s',
-                    data_file, last_err, max_concurrency)
-                if 'no_sleeping_time' not in meta:
+                    f'Failed to upload a file: {data_file}, err: {last_err}. Retrying with '
+                    f'max concurrency: {max_concurrency}')
+                if meta.no_sleeping_time is None:
                     sleeping_time = min(2 ** retry, 16)
-                    logger.debug("sleeping: %s", sleeping_time)
+                    logger.debug(f"sleeping: {sleeping_time}")
                     time.sleep(sleeping_time)
         else:
             if last_err:
                 raise last_err
             else:
-                msg = "Unknown Error in uploading a file: {}".format(data_file)
+                msg = f"Unknown Error in uploading a file: {data_file}"
                 raise Exception(msg)
 
     @staticmethod
-    def download_one_file(meta):
+    def download_one_file(meta: 'SnowflakeFileMeta') -> None:
         """Downloads a file from S3."""
-        logger = getLogger(__name__)
-        full_dst_file_name = os.path.join(
-            meta['local_location'],
-            os.path.basename(meta['dst_file_name']))
+        full_dst_file_name = os.path.join(meta.local_location, os.path.basename(meta.dst_file_name))
         full_dst_file_name = os.path.realpath(full_dst_file_name)
         # TODO: validate full_dst_file_name is under the writable directory
         base_dir = os.path.dirname(full_dst_file_name)
         if not os.path.exists(base_dir):
             os.makedirs(base_dir)
 
-        util_class = SnowflakeRemoteStorageUtil.getForStorageType(
-            meta['stage_info']['locationType'])
-        file_header = util_class.get_file_header(meta, meta['src_file_name'])
+        util_class = SnowflakeRemoteStorageUtil.get_for_storage_type(meta.stage_info['locationType'])
+        file_header = util_class.get_file_header(meta, meta.src_file_name)
 
         if file_header:
-            meta['src_file_size'] = file_header.content_length
+            meta.src_file_size = file_header.content_length
 
-        full_dst_file_name = os.path.join(
-            meta['local_location'],
-            os.path.basename(meta['dst_file_name']))
+        full_dst_file_name = os.path.join(meta.local_location, os.path.basename(meta.dst_file_name))
         full_dst_file_name = os.path.realpath(full_dst_file_name)
 
-        max_concurrency = meta['parallel']
+        max_concurrency = meta.parallel
         last_err = None
         max_retry = DEFAULT_MAX_RETRY
         for retry in range(max_retry):
             util_class._native_download_file(meta, full_dst_file_name,
                                              max_concurrency)
-            if (meta['result_status'] == ResultStatus.DOWNLOADED):
-                if 'encryption_material' in meta:
-                    logger.debug(
-                        'encrypted data file=%s', full_dst_file_name)
+            if meta.result_status == ResultStatus.DOWNLOADED:
+                if meta.encryption_material is not None:
+                    logger.debug(f'encrypted data file={full_dst_file_name}')
 
                     # For storage utils that do not have the privilege of
                     # getting the metadata early, both object and metadata
@@ -211,83 +199,72 @@ class SnowflakeRemoteStorageUtil(object):
                     # preserve the idea of getting metadata in the first place.
                     # One example of this is the utils that use presigned url
                     # for upload/download and not the storage client library.
-                    if meta.get('presigned_url', None):
-                        file_header = util_class.get_file_header(meta, meta[
-                            'src_file_name'])
+                    if meta.presigned_url is not None:
+                        file_header = util_class.get_file_header(meta, meta.src_file_name)
 
                     tmp_dst_file_name = SnowflakeEncryptionUtil.decrypt_file(
                         file_header.encryption_metadata,
-                        meta['encryption_material'],
-                        full_dst_file_name, tmp_dir=meta['tmp_dir'])
+                        meta.encryption_material,
+                        full_dst_file_name, tmp_dir=meta.tmp_dir)
                     shutil.copyfile(tmp_dst_file_name, full_dst_file_name)
                     os.unlink(tmp_dst_file_name)
                 else:
-                    logger.debug('not encrypted data file=%s',
-                                 full_dst_file_name)
+                    logger.debug(f'not encrypted data file={full_dst_file_name}')
 
-                statinfo = os.stat(full_dst_file_name)
-                meta['dst_file_size'] = statinfo.st_size
+                stat_info = os.stat(full_dst_file_name)
+                meta.dst_file_size = stat_info.st_size
                 return
-            elif (meta['result_status'] == ResultStatus.RENEW_PRESIGNED_URL):
+            elif meta.result_status == ResultStatus.RENEW_PRESIGNED_URL:
                 return
-            elif (meta['result_status'] == ResultStatus.RENEW_TOKEN):
+            elif meta.result_status == ResultStatus.RENEW_TOKEN:
                 return
-            elif (meta[
-                      'result_status'] == ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY):
-                max_concurrency = meta['parallel'] - int(
-                    retry * meta['parallel'] / max_retry)
+            elif meta.result_status == ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY:
+                max_concurrency = meta.parallel - int(retry * meta.parallel / max_retry)
                 max_concurrency = max(DEFAULT_CONCURRENCY, max_concurrency)
-                meta['last_max_concurrency'] = max_concurrency
-                last_err = meta['last_error']
-                logger.debug(
-                    'Failed to download a file: %s, err: %s. Retrying with '
-                    'max concurrency: %s',
-                    full_dst_file_name, last_err, max_concurrency)
-                if 'no_sleeping_time' not in meta:
+                meta.last_max_concurrency = max_concurrency
+                last_err = meta.last_error
+                logger.debug(f'Failed to download a file: {full_dst_file_name}, err: {last_err}. Retrying with '
+                             f'max concurrency: {max_concurrency}')
+                if not meta.no_sleeping_time:
                     sleeping_time = min(2 ** retry, 16)
                     logger.debug("sleeping: %s", sleeping_time)
                     time.sleep(sleeping_time)
-            elif (meta['result_status'] == ResultStatus.NEED_RETRY):
-                last_err = meta['last_error']
+            elif meta.result_status == ResultStatus.NEED_RETRY:
+                last_err = meta.last_error
                 logger.debug(
-                    'Failed to download a file: %s, err: %s. Retrying with '
-                    'max concurrency: %s',
-                    full_dst_file_name, last_err, max_concurrency)
-                if 'no_sleeping_time' not in meta:
+                    f'Failed to download a file: {full_dst_file_name}, err: {last_err}. Retrying with '
+                    f'max concurrency: {max_concurrency}')
+                if not meta.no_sleeping_time:
                     sleeping_time = min(2 ** retry, 16)
-                    logger.debug("sleeping: %s", sleeping_time)
+                    logger.debug(f"sleeping: {sleeping_time}")
                     time.sleep(sleeping_time)
         else:
             if last_err:
                 raise last_err
             else:
-                msg = "Unknown Error in downloading a file: {}".format(full_dst_file_name)
+                msg = f"Unknown Error in downloading a file: {full_dst_file_name}"
                 raise Exception(msg)
 
     @staticmethod
-    def upload_one_file_with_retry(meta):
+    def upload_one_file_with_retry(meta: 'SnowflakeFileMeta') -> None:
         """Uploads one file with retry."""
-        logger = getLogger(__name__)
-
-        util_class = SnowflakeRemoteStorageUtil.getForStorageType(
-            meta['stage_info']['locationType'])
+        util_class = SnowflakeRemoteStorageUtil.get_for_storage_type(meta.stage_info['locationType'])
         for _ in range(10):
             # retry
             SnowflakeRemoteStorageUtil.upload_one_file(meta)
-            if meta['result_status'] == ResultStatus.UPLOADED:
+            if meta.result_status == ResultStatus.UPLOADED:
                 for _ in range(10):
-                    util_class.get_file_header(
-                        meta, meta['dst_file_name'])
-                    if meta['result_status'] == ResultStatus.NOT_FOUND_FILE:
+                    util_class.get_file_header(meta, meta.dst_file_name)
+                    if meta.result_status == ResultStatus.NOT_FOUND_FILE:
                         time.sleep(1)  # wait 1 second
                         logger.debug('not found. double checking...')
                         continue
                     break
                 else:
                     # not found. retry with the outer loop
-                    logger.debug('not found. gave up. reuploading...')
+                    logger.debug('not found. gave up. re-uploading...')
                     continue
             break
         else:
             # could not upload a file even after retry
-            meta['result_status'] = ResultStatus.ERROR
+            meta.result_status = ResultStatus.ERROR

--- a/src/snowflake/connector/remote_storage_util.py
+++ b/src/snowflake/connector/remote_storage_util.py
@@ -124,7 +124,8 @@ class SnowflakeRemoteStorageUtil(object):
                     data_file,
                     meta,
                     encryption_metadata,
-                    max_concurrency
+                    max_concurrency,
+                    multipart_threshold=meta['multipart_threshold']
                 )
 
             if (meta['result_status'] == ResultStatus.UPLOADED):

--- a/src/snowflake/connector/s3_util.py
+++ b/src/snowflake/connector/s3_util.py
@@ -8,17 +8,22 @@ import logging
 import os
 from collections import namedtuple
 from logging import getLogger
-from typing import Any, Dict
+from typing import TYPE_CHECKING
 
 import boto3
 import botocore.exceptions
 import OpenSSL
 from boto3.exceptions import RetriesExceededError, S3UploadFailedError
 from boto3.s3.transfer import TransferConfig
+from boto3.session import Session
 from botocore.client import Config
 
-from .constants import HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_VALUE_OCTET_STREAM, SHA256_DIGEST, FileHeader, ResultStatus
+from .compat import asdict
+from .constants import HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_VALUE_OCTET_STREAM, FileHeader, ResultStatus
 from .encryption_util import EncryptionMetadata
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .file_transfer_agent import SnowflakeFileMeta
 
 logger = getLogger(__name__)
 
@@ -47,7 +52,7 @@ class SnowflakeS3Util:
     """S3 Utility class."""
 
     @staticmethod
-    def create_client(stage_info, use_accelerate_endpoint=False):
+    def create_client(stage_info, use_accelerate_endpoint=False) -> Session.resource:
         """Creates a client object with a stage credential.
 
         Args:
@@ -98,30 +103,26 @@ class SnowflakeS3Util:
             s3path=s3path)
 
     @staticmethod
-    def _get_s3_object(meta, filename):
-        client = meta['client']
-        s3location = SnowflakeS3Util.extract_bucket_name_and_path(
-            meta['stage_info']['location'])
+    def _get_s3_object(meta: 'SnowflakeFileMeta', filename):
+        client = meta.client
+        s3location = SnowflakeS3Util.extract_bucket_name_and_path(meta.stage_info['location'])
         s3path = s3location.s3path + filename.lstrip('/')
 
         if logger.getEffectiveLevel() == logging.DEBUG:
             tmp_meta = {}
             log_black_list = ('stage_credentials', 'creds', 'encryption_material')
-            for k, v in meta.items():
+            for k, v in asdict(meta).items():
                 if k not in log_black_list:
                     tmp_meta[k] = v
             logger.debug(
-                "s3location.bucket_name: %s, "
-                "s3location.s3path: %s, "
-                "s3fullpath: %s, "
-                'meta: %s',
-                s3location.bucket_name,
-                s3location.s3path,
-                s3path, tmp_meta)
+                f"s3location.bucket_name: {s3location.bucket_name}, "
+                f"s3location.s3path: {s3location.s3path}, "
+                f"s3full_path: {s3path}, "
+                f"meta: {tmp_meta}")
         return client.Object(s3location.bucket_name, s3path)
 
     @staticmethod
-    def get_file_header(meta, filename):
+    def get_file_header(meta: 'SnowflakeFileMeta', filename):
         """Gets the remote file's metadata.
 
         Args:
@@ -139,31 +140,26 @@ class SnowflakeS3Util:
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == EXPIRED_TOKEN:
                 logger.debug("AWS Token expired. Renew and retry")
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return None
             elif e.response['Error']['Code'] == '404':
-                logger.debug('not found. bucket: %s, path: %s',
-                             akey.bucket_name, akey.key)
-                meta['result_status'] = ResultStatus.NOT_FOUND_FILE
+                logger.debug(f'not found. bucket: {akey.bucket_name}, path: {akey.key}')
+                meta.result_status = ResultStatus.NOT_FOUND_FILE
                 return FileHeader(
                     digest=None,
                     content_length=None,
                     encryption_metadata=None,
                 )
             elif e.response['Error']['Code'] == '400':
-                logger.debug('Bad request, token needs to be renewed: %s. '
-                             'bucket: %s, path: %s',
-                             e.response['Error']['Message'],
-                             akey.bucket_name, akey.key)
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                logger.debug(f'Bad request, token needs to be renewed: {e.response["Error"]["Message"]}. '
+                             f'bucket: {akey.bucket_name}, path: {akey.key}')
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return None
-            logger.debug(
-                "Failed to get metadata for %s, %s: %s",
-                akey.bucket_name, akey.key, e)
-            meta['result_status'] = ResultStatus.ERROR
+            logger.debug(f"Failed to get metadata for {akey.bucket_name}, {akey.key}: {e}")
+            meta.result_status = ResultStatus.ERROR
             return None
 
-        meta['result_status'] = ResultStatus.UPLOADED
+        meta.result_status = ResultStatus.UPLOADED
         encryption_metadata = EncryptionMetadata(
             key=akey.metadata.get(AMZ_KEY),
             iv=akey.metadata.get(AMZ_IV),
@@ -178,8 +174,7 @@ class SnowflakeS3Util:
 
     @staticmethod
     def upload_file(data_file: str,
-                    # TODO replace with a custom dataclass instead of a dictionary that holds arbitrary data
-                    meta: Dict[str, Any],
+                    meta: 'SnowflakeFileMeta',
                     encryption_metadata: 'EncryptionMetadata',
                     max_concurrency: int,
                     multipart_threshold: int,
@@ -202,19 +197,19 @@ class SnowflakeS3Util:
         try:
             s3_metadata = {
                 HTTP_HEADER_CONTENT_TYPE: HTTP_HEADER_VALUE_OCTET_STREAM,
-                SFC_DIGEST: meta[SHA256_DIGEST],
+                SFC_DIGEST: meta.sha256_digest,
             }
-            if (encryption_metadata):
+            if encryption_metadata:
                 s3_metadata.update({
                     AMZ_IV: encryption_metadata.iv,
                     AMZ_KEY: encryption_metadata.key,
                     AMZ_MATDESC: encryption_metadata.matdesc,
                 })
             s3location = SnowflakeS3Util.extract_bucket_name_and_path(
-                meta['stage_info']['location'])
-            s3path = s3location.s3path + meta['dst_file_name'].lstrip('/')
+                meta.stage_info['location'])
+            s3path = s3location.s3path + meta.dst_file_name.lstrip('/')
 
-            akey = meta['client'].Object(s3location.bucket_name, s3path)
+            akey = meta.client.Object(s3location.bucket_name, s3path)
             extra_args = {'Metadata': s3_metadata}
             config = TransferConfig(
                 multipart_threshold=multipart_threshold,
@@ -225,105 +220,96 @@ class SnowflakeS3Util:
             if 'src_stream' not in meta:
                 akey.upload_file(
                     data_file,
-                    Callback=meta['put_callback'](
+                    Callback=meta.put_callback(
                         data_file,
                         os.path.getsize(data_file),
-                        output_stream=meta['put_callback_output_stream'],
-                        show_progress_bar=meta['show_progress_bar']) if meta['put_callback'] else None,
+                        output_stream=meta.put_callback_output_stream,
+                        show_progress_bar=meta.show_progress_bar) if meta.put_callback else None,
                     ExtraArgs=extra_args,
                     Config=config
                 )
             else:
-                upload_stream = meta.get('real_src_stream', meta['src_stream'])
+                upload_stream = meta.real_src_stream or meta.src_stream
                 upload_size = upload_stream.seek(0, os.SEEK_END)
                 upload_stream.seek(0)
 
                 akey.upload_fileobj(
                     upload_stream,
-                    Callback=meta['put_callback'](
+                    Callback=meta.put_callback(
                         data_file,
                         upload_size,
-                        output_stream=meta['put_callback_output_stream'],
-                        show_progress_bar=meta['show_progress_bar']) if meta['put_callback'] else None,
+                        output_stream=meta.put_callback_output_stream,
+                        show_progress_bar=meta.show_progress_bar) if meta.put_callback else None,
                     ExtraArgs=extra_args,
                     Config=config,
                 )
 
             logger.debug('DONE putting a file')
-            meta['dst_file_size'] = meta['upload_size']
-            meta['result_status'] = ResultStatus.UPLOADED
+            meta.dst_file_size = meta.upload_size
+            meta.result_status = ResultStatus.UPLOADED
         except botocore.exceptions.ClientError as err:
             if err.response['Error']['Code'] == EXPIRED_TOKEN:
                 logger.debug("AWS Token expired. Renew and retry")
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return
-            logger.debug(
-                "Failed to upload a file: %s, err: %s",
-                data_file, err, exc_info=True)
+            logger.debug(f"Failed to upload a file: {data_file}, err: {err}", exc_info=True)
             raise err
         except S3UploadFailedError as err:
             if EXPIRED_TOKEN in str(err):
                 # Since AWS token expiration error can be encapsulated in
                 # S3UploadFailedError, the text match is required to
                 # identify the case.
-                logger.debug(
-                    'Failed to upload a file: %s, err: %s. Renewing '
-                    'AWS Token and Retrying',
-                    data_file, err)
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                logger.debug(f'Failed to upload a file: {data_file}, err: {err}. Renewing AWS Token and Retrying')
+                meta.result_status = ResultStatus.RENEW_TOKEN
                 return
 
-            meta['last_error'] = err
-            meta['result_status'] = ResultStatus.NEED_RETRY
+            meta.last_error = err
+            meta.result_status = ResultStatus.NEED_RETRY
         except OpenSSL.SSL.SysCallError as err:
-            meta['last_error'] = err
+            meta.last_error = err
             if err.args[0] == ERRORNO_WSAECONNABORTED:
                 # connection was disconnected by S3
                 # because of too many connections. retry with
                 # less concurrency to mitigate it
-                meta[
-                    'result_status'] = ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY
+                meta.result_status = ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY
             else:
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.result_status = ResultStatus.NEED_RETRY
 
     @staticmethod
-    def _native_download_file(meta, full_dst_file_name, max_concurrency):
+    def _native_download_file(meta: 'SnowflakeFileMeta', full_dst_file_name, max_concurrency):
         try:
-            akey = SnowflakeS3Util._get_s3_object(meta, meta['src_file_name'])
+            akey = SnowflakeS3Util._get_s3_object(meta, meta.src_file_name)
             akey.download_file(
                 full_dst_file_name,
-                Callback=meta['get_callback'](
-                    meta['src_file_name'],
-                    meta['src_file_size'],
-                    output_stream=meta['get_callback_output_stream'],
-                    show_progress_bar=meta['show_progress_bar']) if
-                meta['get_callback'] else None,
+                Callback=meta.get_callback(
+                    meta.src_file_name,
+                    meta.src_file_size,
+                    output_stream=meta.get_callback_output_stream,
+                    show_progress_bar=meta.show_progress_bar) if
+                meta.get_callback else None,
                 Config=TransferConfig(
-                    multipart_threshold=SnowflakeS3Util.DATA_SIZE_THRESHOLD,
+                    multipart_threshold=meta.multipart_threshold,
                     max_concurrency=max_concurrency,
                     num_download_attempts=10,
                 )
             )
-            meta['result_status'] = ResultStatus.DOWNLOADED
+            meta.result_status = ResultStatus.DOWNLOADED
         except botocore.exceptions.ClientError as err:
             if err.response['Error']['Code'] == EXPIRED_TOKEN:
-                meta['result_status'] = ResultStatus.RENEW_TOKEN
+                meta.result_status = ResultStatus.RENEW_TOKEN
             else:
-                logger.debug(
-                    "Failed to download a file: %s, err: %s",
-                    full_dst_file_name, err, exc_info=True)
+                logger.debug(f"Failed to download a file: {full_dst_file_name}, err: {err}", exc_info=True)
                 raise err
         except RetriesExceededError as err:
-            meta['result_status'] = ResultStatus.NEED_RETRY
-            meta['last_error'] = err
+            meta.result_status = ResultStatus.NEED_RETRY
+            meta.last_error = err
         except OpenSSL.SSL.SysCallError as err:
-            meta['last_error'] = err
+            meta.last_error = err
             if err.args[0] == ERRORNO_WSAECONNABORTED:
                 # connection was disconnected by S3
                 # because of too many connections. retry with
                 # less concurrency to mitigate it
 
-                meta[
-                    'result_status'] = ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY
+                meta.result_status = ResultStatus.NEED_RETRY_WITH_LOWER_CONCURRENCY
             else:
-                meta['result_status'] = ResultStatus.NEED_RETRY
+                meta.result_status = ResultStatus.NEED_RETRY

--- a/src/snowflake/connector/s3_util.py
+++ b/src/snowflake/connector/s3_util.py
@@ -18,7 +18,6 @@ from boto3.s3.transfer import TransferConfig
 from boto3.session import Session
 from botocore.client import Config
 
-from .compat import asdict
 from .constants import HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_VALUE_OCTET_STREAM, FileHeader, ResultStatus
 from .encryption_util import EncryptionMetadata
 
@@ -111,7 +110,7 @@ class SnowflakeS3Util:
         if logger.getEffectiveLevel() == logging.DEBUG:
             tmp_meta = {}
             log_black_list = ('stage_credentials', 'creds', 'encryption_material')
-            for k, v in asdict(meta).items():
+            for k, v in meta.__dict__.items():
                 if k not in log_black_list:
                     tmp_meta[k] = v
             logger.debug(

--- a/src/snowflake/connector/s3_util.py
+++ b/src/snowflake/connector/s3_util.py
@@ -216,7 +216,7 @@ class SnowflakeS3Util:
                 num_download_attempts=10,
             )
 
-            if 'src_stream' not in meta:
+            if meta.src_stream is None:
                 akey.upload_file(
                     data_file,
                     Callback=meta.put_callback(

--- a/test/integ/test_dbapi.py
+++ b/test/integ/test_dbapi.py
@@ -123,7 +123,6 @@ def test_exceptions_as_connection_attributes(conn_cnx):
         except AttributeError:
             # Compatibility for olddriver tests
             assert con.Warning == errors.Warning
-        assert con.Warning == errors._Warning
         assert con.Error == errors.Error
         assert con.InterfaceError == errors.InterfaceError
         assert con.DatabaseError == errors.DatabaseError

--- a/test/integ/test_dbapi.py
+++ b/test/integ/test_dbapi.py
@@ -9,7 +9,6 @@
 Adapted from a script by M-A Lemburg and taken from the MySQL python driver.
 """
 
-import sys
 import time
 
 import pytest
@@ -102,12 +101,12 @@ def test_paramstyle():
 
 def test_exceptions():
     # required exceptions should be defined in a hierarchy
-    if sys.version_info[0] > 2:
+    try:
+        assert issubclass(errors._Warning, Exception)
+    except AttributeError:
+        # Compatibility for olddriver tests
         assert issubclass(errors.Warning, Exception)
-        assert issubclass(errors.Error, Exception)
-    else:
-        assert issubclass(errors.Warning, StandardError)
-        assert issubclass(errors.Error, StandardError)
+    assert issubclass(errors.Error, Exception)
     assert issubclass(errors.InterfaceError, errors.Error)
     assert issubclass(errors.DatabaseError, errors.Error)
     assert issubclass(errors.OperationalError, errors.Error)
@@ -117,9 +116,14 @@ def test_exceptions():
     assert issubclass(errors.NotSupportedError, errors.Error)
 
 
-def test_ExceptionsAsConnectionAttributes(conn_cnx):
+def test_exceptions_as_connection_attributes(conn_cnx):
     with conn_cnx() as con:
-        assert con.Warning == errors.Warning
+        try:
+            assert con.Warning == errors._Warning
+        except AttributeError:
+            # Compatibility for olddriver tests
+            assert con.Warning == errors.Warning
+        assert con.Warning == errors._Warning
         assert con.Error == errors.Error
         assert con.InterfaceError == errors.InterfaceError
         assert con.DatabaseError == errors.DatabaseError

--- a/test/integ/test_large_put.py
+++ b/test/integ/test_large_put.py
@@ -12,7 +12,6 @@ from ..generate_test_files import generate_k_lines_of_n_files
 
 
 @pytest.mark.aws
-@pytest.mark.flaky(reruns=3)
 def test_put_copy_large_files(tmpdir, conn_cnx, db_parameters):
     """[s3] Puts and Copies into large files."""
     # generates N files

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -546,11 +546,8 @@ def test_put_collision(tmpdir, conn_cnx, db_parameters):
                                           tmp_dir=str(tmpdir.mkdir('data2')))
     files2 = os.path.join(tmp_dir, 'file*')
 
-    stage_name = "test_put_collision/{}".format(db_parameters['name'])
-    with conn_cnx(
-            user=db_parameters['user'],
-            account=db_parameters['account'],
-            password=db_parameters['password']) as cnx:
+    stage_name = random_string(5, "test_put_collision_")
+    with conn_cnx() as cnx:
         cnx.cursor().execute("RM @~/{}".format(stage_name))
         try:
             # upload all files

--- a/test/unit/test_gcs_util.py
+++ b/test/unit/test_gcs_util.py
@@ -10,9 +10,14 @@ import mock
 import pytest
 
 from snowflake.connector.constants import ResultStatus
-from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
 
 from ..randomize import random_string
+
+try:
+    from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
+except ImportError:  # NOQA
+    # Compatibility for olddriver tests
+    SnowflakeFileMeta = dict
 
 pytestmark = pytest.mark.gcp
 

--- a/test/unit/test_gcs_util.py
+++ b/test/unit/test_gcs_util.py
@@ -10,6 +10,7 @@ import mock
 import pytest
 
 from snowflake.connector.constants import ResultStatus
+from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
 
 from ..randomize import random_string
 
@@ -37,42 +38,26 @@ def test_create_client(caplog):
     assert client == 'fake_token'
 
 
-@pytest.mark.xfail(reason='Newer version support access token. This test is obsoleted')
-def test_native_download_access_token(caplog):
-    """Tests that GCS access token error is correctly logged when downloading."""
-    caplog.set_level(logging.DEBUG, 'snowflake.connector')
-    meta = {}
-    SnowflakeGCSUtil._native_download_file(meta, None, 99)
-    assert meta['result_status'] == ResultStatus.ERROR
-    assert (('snowflake.connector.gcs_util', logging.ERROR, "GCS download operation with an access token is "
-                                                            "currently unsupported") in caplog.record_tuples)
-
-
-@pytest.mark.xfail(reason='Newer version support access token. This test is obsoleted')
-def test_native_upload_access_token(caplog):
-    """Tests that GCS access token error is correctly logged when uploading."""
-    caplog.set_level(logging.DEBUG, 'snowflake.connector')
-    meta = {}
-    SnowflakeGCSUtil.upload_file(None, meta, None, 99)
-    assert meta['result_status'] == ResultStatus.ERROR
-    assert (('snowflake.connector.gcs_util', logging.ERROR, "GCS upload operation with an access token is "
-                                                            "currently unsupported") in caplog.record_tuples)
-
-
 @pytest.mark.parametrize('errno', [403, 408, 429, 500, 503])
 def test_upload_retry_errors(errno, tmpdir):
     """Tests whether retryable errors are handled correctly when upploading."""
     f_name = str(tmpdir.join('some_file.txt'))
     resp = requests.Response()
     resp.status_code = errno
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=f_name,
+        src_file_name=f_name,
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with open(f_name, 'w') as f:
         f.write(random_string(15))
     with mock.patch('snowflake.connector.vendored.requests.put' if vendored_request else 'requests.put',
                     side_effect=requests.exceptions.HTTPError(response=resp)):
-        SnowflakeGCSUtil.upload_file(f_name, meta, None, 99)
-        assert isinstance(meta['last_error'], requests.exceptions.HTTPError)
-        assert meta['result_status'] == ResultStatus.NEED_RETRY
+        SnowflakeGCSUtil.upload_file(f_name, meta, None, 99, 64000)
+        assert isinstance(meta.last_error, requests.exceptions.HTTPError)
+        assert meta.result_status == ResultStatus.NEED_RETRY
 
 
 def test_upload_uncaught_exception(tmpdir):
@@ -80,73 +65,109 @@ def test_upload_uncaught_exception(tmpdir):
     f_name = str(tmpdir.join('some_file.txt'))
     resp = requests.Response()
     resp.status_code = 501
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=f_name,
+        src_file_name=f_name,
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with open(f_name, 'w') as f:
         f.write(random_string(15))
     with mock.patch('snowflake.connector.vendored.requests.put' if vendored_request else 'requests.put',
                     side_effect=requests.exceptions.HTTPError(response=resp)):
         with pytest.raises(requests.exceptions.HTTPError):
-            SnowflakeGCSUtil.upload_file(f_name, meta, None, 99)
+            SnowflakeGCSUtil.upload_file(f_name, meta, None, 99, 64000)
 
 
 @pytest.mark.parametrize('errno', [403, 408, 429, 500, 503])
-def test_download_retry_errors(errno, tmpdir):
+def test_download_retry_errors(errno, tmp_path):
     """Tests whether retryable errors are handled correctly when downloading."""
     resp = requests.Response()
     resp.status_code = errno
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=str(tmp_path / 'some_file'),
+        src_file_name=str(tmp_path / 'some_file'),
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with mock.patch('snowflake.connector.vendored.requests.get' if vendored_request else 'requests.get',
                     side_effect=requests.exceptions.HTTPError(response=resp)):
-        SnowflakeGCSUtil._native_download_file(meta, str(tmpdir), 99)
-        assert isinstance(meta['last_error'], requests.exceptions.HTTPError)
-        assert meta['result_status'] == ResultStatus.NEED_RETRY
+        SnowflakeGCSUtil._native_download_file(meta, str(tmp_path), 99)
+        assert isinstance(meta.last_error, requests.exceptions.HTTPError)
+        assert meta.result_status == ResultStatus.NEED_RETRY
 
 
-def test_download_uncaught_exception(tmpdir):
+def test_download_uncaught_exception(tmp_path):
     """Tests whether non-retryable errors are handled correctly when downloading."""
     resp = requests.Response()
     resp.status_code = 501
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=str(tmp_path / 'some_file'),
+        src_file_name=str(tmp_path / 'some_file'),
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with mock.patch('snowflake.connector.vendored.requests.get' if vendored_request else 'requests.get',
                     side_effect=requests.exceptions.HTTPError(response=resp)):
         with pytest.raises(requests.exceptions.HTTPError):
-            SnowflakeGCSUtil._native_download_file(meta, str(tmpdir), 99)
+            SnowflakeGCSUtil._native_download_file(meta, str(tmp_path), 99)
 
 
-def test_upload_put_timeout(tmpdir, caplog):
+def test_upload_put_timeout(tmp_path, caplog):
     """Tests whether timeout error is handled correctly when uploading."""
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
-    f_name = str(tmpdir.join('some_file.txt'))
+    f_name = str(tmp_path / 'some_file.txt')
     resp = requests.Response()
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=f_name,
+        src_file_name=f_name,
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with open(f_name, 'w') as f:
         f.write(random_string(15))
     with mock.patch('snowflake.connector.vendored.requests.put' if vendored_request else 'requests.put',
                     side_effect=requests.exceptions.Timeout(response=resp)):
-        SnowflakeGCSUtil.upload_file(f_name, meta, None, 99)
-    assert isinstance(meta['last_error'], requests.exceptions.Timeout)
-    assert meta['result_status'] == ResultStatus.NEED_RETRY
+        SnowflakeGCSUtil.upload_file(f_name, meta, None, 99, 64000)
+    assert isinstance(meta.last_error, requests.exceptions.Timeout)
+    assert meta.result_status == ResultStatus.NEED_RETRY
     assert all([log in caplog.record_tuples for log in [
         ('snowflake.connector.gcs_util', logging.DEBUG, 'GCS file upload Timeout Error: ')
     ]])
 
 
-def test_upload_get_timeout(tmpdir, caplog):
+def test_upload_get_timeout(tmp_path, caplog):
     """Tests whether timeout error is handled correctly when downloading."""
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
     resp = requests.Response()
-    meta = {'presigned_url': ['some_url'], 'sha256_digest': 'asd'}
+    meta = SnowflakeFileMeta(
+        name=str(tmp_path / 'some_file'),
+        src_file_name=str(tmp_path / 'some_file'),
+        stage_location_type='GCS',
+        presigned_url='some_url',
+        sha256_digest='asd',
+    )
     with mock.patch('snowflake.connector.vendored.requests.get' if vendored_request else 'requests.get',
                     side_effect=requests.exceptions.Timeout(response=resp)):
-        SnowflakeGCSUtil._native_download_file(meta, str(tmpdir), 99)
-    assert isinstance(meta['last_error'], requests.exceptions.Timeout)
-    assert meta['result_status'] == ResultStatus.NEED_RETRY
+        SnowflakeGCSUtil._native_download_file(meta, str(tmp_path), 99)
+    assert isinstance(meta.last_error, requests.exceptions.Timeout)
+    assert meta.result_status == ResultStatus.NEED_RETRY
     assert ('snowflake.connector.gcs_util', logging.DEBUG, 'GCS file download Timeout Error: ') in caplog.record_tuples
 
 
-def test_get_file_header_none_with_presigned_url():
+def test_get_file_header_none_with_presigned_url(tmp_path):
     """Tests whether default file handle created by get_file_header is as expected."""
-    file_header = SnowflakeGCSUtil.get_file_header({"presigned_url": "www.example.com"}, 'file')
+    meta = SnowflakeFileMeta(
+        name=str(tmp_path / 'some_file'),
+        src_file_name=str(tmp_path / 'some_file'),
+        stage_location_type='GCS',
+        presigned_url='www.example.com',
+    )
+    file_header = SnowflakeGCSUtil.get_file_header(meta, 'file')
     assert file_header.digest is None
     assert file_header.content_length is None
     assert file_header.encryption_metadata is None

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -19,10 +19,16 @@ from boto3.exceptions import Boto3Error, RetriesExceededError, S3UploadFailedErr
 from mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.constants import SHA256_DIGEST, ResultStatus
+from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
 from snowflake.connector.remote_storage_util import DEFAULT_MAX_RETRY, SnowflakeRemoteStorageUtil
 from snowflake.connector.s3_util import ERRORNO_WSAECONNABORTED, SnowflakeS3Util
 
 THIS_DIR = path.dirname(path.realpath(__file__))
+MINIMAL_METADATA = SnowflakeFileMeta(
+    name='file.txt',
+    stage_location_type='S3',
+    src_file_name='file.txt',
+)
 
 
 def test_extract_bucket_name_and_path():
@@ -55,7 +61,6 @@ def test_extract_bucket_name_and_path():
     assert s3_loc.s3path == '//'
 
 
-# FIXME
 def test_upload_one_file_to_s3_wsaeconnaborted():
     """Tests Upload one file to S3 with retry on ERRORNO_WSAECONNABORTED.
 
@@ -70,11 +75,12 @@ def test_upload_one_file_to_s3_wsaeconnaborted():
     client.Object.return_value = s3object
     initial_parallel = 100
     upload_meta = {
+        'name': 'data1.txt.gz',
+        'stage_location_type': 'S3',
         'no_sleeping_time': True,
         'parallel': initial_parallel,
         'put_callback': None,
         'put_callback_output_stream': None,
-        'existing_files': [],
         'client': client,
         SHA256_DIGEST: '123456789abcdef',
         'stage_info': {
@@ -87,29 +93,22 @@ def test_upload_one_file_to_s3_wsaeconnaborted():
     }
     upload_meta['real_src_file_name'] = upload_meta['src_file_name']
     upload_meta['upload_size'] = os.stat(upload_meta['src_file_name']).st_size
-    tmp_upload_meta = upload_meta.copy()
-    try:
-        SnowflakeRemoteStorageUtil.upload_one_file(tmp_upload_meta)
-        raise Exception("Should fail with OpenSSL.SSL.SysCallError")
-    except OpenSSL.SSL.SysCallError:
-        assert upload_file.call_count == DEFAULT_MAX_RETRY
-        assert 'last_max_concurrency' in tmp_upload_meta
-        assert tmp_upload_meta[
-                   'last_max_concurrency'
-               ] == initial_parallel / DEFAULT_MAX_RETRY
+    meta = SnowflakeFileMeta(**upload_meta)
+    with pytest.raises(OpenSSL.SSL.SysCallError):
+        SnowflakeRemoteStorageUtil.upload_one_file(meta)
+    assert upload_file.call_count == DEFAULT_MAX_RETRY
+    assert meta.last_max_concurrency is not None
+    assert meta.last_max_concurrency == initial_parallel / DEFAULT_MAX_RETRY
 
     # min parallel == 1
     upload_file.reset_mock()
     initial_parallel = 4
-    upload_meta['parallel'] = initial_parallel
-    tmp_upload_meta = upload_meta.copy()
-    try:
-        SnowflakeRemoteStorageUtil.upload_one_file(tmp_upload_meta)
-        raise Exception("Should fail with OpenSSL.SSL.SysCallError")
-    except OpenSSL.SSL.SysCallError:
-        assert upload_file.call_count == DEFAULT_MAX_RETRY
-        assert 'last_max_concurrency' in tmp_upload_meta
-        assert tmp_upload_meta['last_max_concurrency'] == 1
+    meta.parallel = initial_parallel
+    with pytest.raises(OpenSSL.SSL.SysCallError):
+        SnowflakeRemoteStorageUtil.upload_one_file(meta)
+    assert upload_file.call_count == DEFAULT_MAX_RETRY
+    assert meta.last_max_concurrency is not None
+    assert meta.last_max_concurrency == 1
 
 
 def test_upload_one_file_to_s3_econnreset():
@@ -130,11 +129,12 @@ def test_upload_one_file_to_s3_econnreset():
         client.Object.return_value = s3object
         initial_parallel = 100
         upload_meta = {
+            'name': 'data1.txt.gz',
+            'stage_location_type': 'S3',
             'no_sleeping_time': True,
             'parallel': initial_parallel,
             'put_callback': None,
             'put_callback_output_stream': None,
-            'existing_files': [],
             SHA256_DIGEST: '123456789abcdef',
             'stage_info': {
                 'location': 'sfc-teststage/rwyitestacco/users/1234/',
@@ -146,14 +146,12 @@ def test_upload_one_file_to_s3_econnreset():
             'overwrite': True,
         }
         upload_meta['real_src_file_name'] = upload_meta['src_file_name']
-        upload_meta[
-            'upload_size'] = os.stat(upload_meta['src_file_name']).st_size
-        try:
-            SnowflakeRemoteStorageUtil.upload_one_file(upload_meta)
-            raise Exception("Should fail with OpenSSL.SSL.SysCallError")
-        except OpenSSL.SSL.SysCallError:
-            assert upload_file.call_count == DEFAULT_MAX_RETRY
-            assert 'last_max_concurrency' not in upload_meta
+        upload_meta['upload_size'] = os.stat(upload_meta['src_file_name']).st_size
+        meta = SnowflakeFileMeta(**upload_meta)
+        with pytest.raises(OpenSSL.SSL.SysCallError):
+            SnowflakeRemoteStorageUtil.upload_one_file(meta)
+        assert upload_file.call_count == DEFAULT_MAX_RETRY
+        assert 'last_max_concurrency' not in upload_meta
 
 
 def test_get_s3_file_object_http_400_error():
@@ -171,16 +169,20 @@ def test_get_s3_file_object_http_400_error():
     client.load.return_value = None
     type(client).s3path = PropertyMock(return_value='s3://testbucket/')
     meta = {
+        'name': 'data1.txt.gz',
+        'stage_location_type': 'S3',
+        'src_file_name': path.join(THIS_DIR, '../data', 'put_get_1.txt'),
         'client': client,
         'stage_info': {
             'location': 'sfc-teststage/rwyitestacco/users/1234/',
             'locationType': 'S3',
         }
     }
+    meta = SnowflakeFileMeta(**meta)
     filename = "/path1/file2.txt"
     akey = SnowflakeS3Util.get_file_header(meta, filename)
     assert akey is None
-    assert meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_upload_file_with_s3_upload_failed_error():
@@ -194,11 +196,12 @@ def test_upload_file_with_s3_upload_failed_error():
         metadata=defaultdict(str), upload_file=upload_file)
     initial_parallel = 100
     upload_meta = {
+        'name': 'data1.txt.gz',
+        'stage_location_type': 'S3',
         'no_sleeping_time': True,
         'parallel': initial_parallel,
         'put_callback': None,
         'put_callback_output_stream': None,
-        'existing_files': [],
         SHA256_DIGEST: '123456789abcdef',
         'stage_info': {
             'location': 'sfc-teststage/rwyitestacco/users/1234/',
@@ -210,31 +213,31 @@ def test_upload_file_with_s3_upload_failed_error():
         'overwrite': True,
     }
     upload_meta['real_src_file_name'] = upload_meta['src_file_name']
-    upload_meta[
-        'upload_size'] = os.stat(upload_meta['src_file_name']).st_size
+    upload_meta['upload_size'] = os.stat(upload_meta['src_file_name']).st_size
+    meta = SnowflakeFileMeta(**upload_meta)
 
-    akey = SnowflakeRemoteStorageUtil.upload_one_file(upload_meta)
+    akey = SnowflakeRemoteStorageUtil.upload_one_file(meta)
     assert akey is None
-    assert upload_meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_get_header_expiry_error(caplog):
     """Tests whether token expiry error is handled as expected when getting header."""
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
-    meta = {}
+    meta = MINIMAL_METADATA
     mock_resource = MagicMock()
     mock_resource.load.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 'ExpiredToken', 'Message': 'Just testing'}}, 'Testing')
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util._get_s3_object', return_value=mock_resource):
         SnowflakeS3Util.get_file_header(meta, 'file.txt')
     assert ('snowflake.connector.s3_util', logging.DEBUG, 'AWS Token expired. Renew and retry') in caplog.record_tuples
-    assert meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_get_header_unexpected_error(caplog):
     """Tests whether unexpected errors are handled as expected when getting header."""
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
-    meta = {}
+    meta = MINIMAL_METADATA
     mock_resource = MagicMock()
     mock_resource.load.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': '???', 'Message': 'Just testing'}}, 'Testing')
@@ -246,7 +249,7 @@ def test_get_header_unexpected_error(caplog):
             logging.DEBUG,
             'Failed to get metadata for bucket, key: An error occurred (???) when calling '
             'the Testing operation: Just testing') in caplog.record_tuples
-    assert meta['result_status'] == ResultStatus.ERROR
+    assert meta.result_status == ResultStatus.ERROR
 
 
 def test_upload_expiry_error(caplog):
@@ -256,15 +259,19 @@ def test_upload_expiry_error(caplog):
     mock_resource.Object.return_value = mock_object
     mock_object.upload_file.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 'ExpiredToken', 'Message': 'Just testing'}}, 'Testing')
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'dst_file_name': 'f',
             'put_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util.extract_bucket_name_and_path'):
-        assert SnowflakeS3Util.upload_file('f', meta, {}, 4) is None
+        assert SnowflakeS3Util.upload_file('f', meta, None, 4, 67108864) is None
     assert ('snowflake.connector.s3_util', logging.DEBUG, 'AWS Token expired. Renew and retry') in caplog.record_tuples
-    assert meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_upload_unknown_error(caplog):
@@ -276,15 +283,19 @@ def test_upload_unknown_error(caplog):
     mock_object.key = 'key'
     mock_object.upload_file.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 'unknown', 'Message': 'Just testing'}}, 'Testing')
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'dst_file_name': 'f',
             'put_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util.extract_bucket_name_and_path'):
         with pytest.raises(botocore.exceptions.ClientError,
                            match=r'An error occurred \(unknown\) when calling the Testing operation: Just testing'):
-            SnowflakeS3Util.upload_file('f', meta, {}, 4)
+            SnowflakeS3Util.upload_file('f', meta, {}, 4, 67108864)
 
 
 def test_upload_failed_error(caplog):
@@ -293,17 +304,21 @@ def test_upload_failed_error(caplog):
     mock_resource, mock_object = MagicMock(), MagicMock()
     mock_resource.Object.return_value = mock_object
     mock_object.upload_file.side_effect = S3UploadFailedError('ExpiredToken')
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'dst_file_name': 'f',
             'put_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util.extract_bucket_name_and_path'):
-        assert SnowflakeS3Util.upload_file('f', meta, {}, 4) is None
+        assert SnowflakeS3Util.upload_file('f', meta, {}, 4, 67108864) is None
     assert ('snowflake.connector.s3_util',
             logging.DEBUG,
             'Failed to upload a file: f, err: ExpiredToken. Renewing AWS Token and Retrying') in caplog.record_tuples
-    assert meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_download_expiry_error(caplog):
@@ -312,7 +327,10 @@ def test_download_expiry_error(caplog):
     mock_resource = MagicMock()
     mock_resource.download_file.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 'ExpiredToken', 'Message': 'Just testing'}}, 'Testing')
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'src_file_name': 'f',
@@ -320,9 +338,10 @@ def test_download_expiry_error(caplog):
             'get_callback_output_stream': None,
             'show_progress_bar': False,
             'get_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util._get_s3_object', return_value=mock_resource):
         SnowflakeS3Util._native_download_file(meta, 'f', 4)
-    assert meta['result_status'] == ResultStatus.RENEW_TOKEN
+    assert meta.result_status == ResultStatus.RENEW_TOKEN
 
 
 def test_download_unknown_error(caplog):
@@ -331,7 +350,10 @@ def test_download_unknown_error(caplog):
     mock_resource = MagicMock()
     mock_resource.download_file.side_effect = botocore.exceptions.ClientError(
         {'Error': {'Code': 'unknown', 'Message': 'Just testing'}}, 'Testing')
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'src_file_name': 'f',
@@ -339,6 +361,7 @@ def test_download_unknown_error(caplog):
             'get_callback_output_stream': None,
             'show_progress_bar': False,
             'get_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util._get_s3_object', return_value=mock_resource):
         with pytest.raises(botocore.exceptions.ClientError,
                            match=r'An error occurred \(unknown\) when calling the Testing operation: Just testing'):
@@ -354,7 +377,10 @@ def test_download_retry_exceeded_error(caplog):
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
     mock_resource = MagicMock()
     mock_resource.download_file.side_effect = RetriesExceededError(Boto3Error())
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'src_file_name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'src_file_name': 'f',
@@ -362,10 +388,11 @@ def test_download_retry_exceeded_error(caplog):
             'get_callback_output_stream': None,
             'show_progress_bar': False,
             'get_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util._get_s3_object', return_value=mock_resource):
         SnowflakeS3Util._native_download_file(meta, 'f', 4)
-    assert meta['last_error'] is mock_resource.download_file.side_effect
-    assert meta['result_status'] == ResultStatus.NEED_RETRY
+    assert meta.last_error is mock_resource.download_file.side_effect
+    assert meta.result_status == ResultStatus.NEED_RETRY
 
 
 @pytest.mark.parametrize('error_no, result_status', [
@@ -377,7 +404,9 @@ def test_download_syscall_error(caplog, error_no, result_status):
     caplog.set_level(logging.DEBUG, 'snowflake.connector')
     mock_resource = MagicMock()
     mock_resource.download_file.side_effect = OpenSSL.SSL.SysCallError(error_no)
-    meta = {'client': mock_resource,
+    meta = {'name': 'f',
+            'stage_location_type': 'S3',
+            'client': mock_resource,
             'sha256_digest': 'asd',
             'stage_info': {'location': 'loc'},
             'src_file_name': 'f',
@@ -385,7 +414,8 @@ def test_download_syscall_error(caplog, error_no, result_status):
             'get_callback_output_stream': None,
             'show_progress_bar': False,
             'get_callback': None}
+    meta = SnowflakeFileMeta(**meta)
     with mock.patch('snowflake.connector.s3_util.SnowflakeS3Util._get_s3_object', return_value=mock_resource):
         SnowflakeS3Util._native_download_file(meta, 'f', 4)
-    assert meta['last_error'] is mock_resource.download_file.side_effect
-    assert meta['result_status'] == result_status
+    assert meta.last_error is mock_resource.download_file.side_effect
+    assert meta.result_status == result_status

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -55,6 +55,7 @@ def test_extract_bucket_name_and_path():
     assert s3_loc.s3path == '//'
 
 
+# FIXME
 def test_upload_one_file_to_s3_wsaeconnaborted():
     """Tests Upload one file to S3 with retry on ERRORNO_WSAECONNABORTED.
 

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -19,9 +19,14 @@ from boto3.exceptions import Boto3Error, RetriesExceededError, S3UploadFailedErr
 from mock import MagicMock, Mock, PropertyMock
 
 from snowflake.connector.constants import SHA256_DIGEST, ResultStatus
-from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
 from snowflake.connector.remote_storage_util import DEFAULT_MAX_RETRY, SnowflakeRemoteStorageUtil
 from snowflake.connector.s3_util import ERRORNO_WSAECONNABORTED, SnowflakeS3Util
+
+try:
+    from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
+except ImportError:  # NOQA
+    # Compatibility for olddriver tests
+    SnowflakeFileMeta = dict
 
 THIS_DIR = path.dirname(path.realpath(__file__))
 MINIMAL_METADATA = SnowflakeFileMeta(


### PR DESCRIPTION
Adds support for the upcoming `THRESHOLD` keyword in `PUT` statements. While adding this I found that file metadatas were these very dynamic dictionaries, so it was pretty complicated to see where they went when I added them. So I well-defined them with `dataclasses`.

I also did some smaller code cleanups, like updated logging messages, and changed around some class names to be PEP-8 compliant.