### PR TITLE
SNOW-292477 Add pytest-xdist dependency and -n auto option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,7 @@ setup(
             'pytest-cov',
             'pytest-rerunfailures',
             'pytest-timeout',
+            'pytest-xdist',
             'coverage',
             'pexpect',
             'mock',

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ setenv =
     unit-integ: SNOWFLAKE_TEST_TYPE = (unit or integ)
     !unit-!integ: SNOWFLAKE_TEST_TYPE = (unit or integ)
     unit: SNOWFLAKE_TEST_TYPE = unit
+    unit: SNOWFLAKE_PYTEST_OPTS = {env:SNOWFLAKE_PYTEST_OPTS:} -n auto
     integ: SNOWFLAKE_TEST_TYPE = integ
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
@@ -87,6 +88,7 @@ deps =
     pytest-cov
     pytest-rerunfailures
     pytest-timeout
+    pytest-xdist
     mock
 skip_install = True
 setenv = {[testenv]setenv}


### PR DESCRIPTION
[SNOW-292477](https://snowflakecomputing.atlassian.net/browse/SNOW-292477?atlOrigin=eyJpIjoiOWY1N2U2YTE4ZjU4NDAxODk1OGZlZDJlMzA5ODU1MDQiLCJwIjoiaiJ9)

Enabled by the pytest plugin `pytest-xdist`, specifying `pytest -n auto`  detects the number of CPU's (denoted `x`) and run tests in parallel  using `x` processes.