### PR TITLE
SNOW-294004: Bumped up PythonConnector MINOR version from 2.3.10 to 2.4.0

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -10,6 +10,16 @@ Release Notes
 -------------------------------------------------------------------------------
 
 
+- v2.4.0(March 04,2021)
+
+   - Added support for Python 3.9 and PyArrow 3.0.x.
+   - Added support for the upcoming multipart PUT threshold keyword.
+   - Added support for using the PUT command with a file-like object.
+   - Added some compilation flags to ease building conda community package.
+   - Removed the pytz pin because it doesn't follow semantic versioning release format.
+   - Added support for optimizing batch inserts through bulk array binding.
+
+
 - v2.3.10(February 01,2021)
 
    - Improved query ID logging and added request GUID logging.

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 3, 10, None)
+VERSION = (2, 4, 0, None)


### PR DESCRIPTION
….4.0 (#638)

@noreview - This is an automated process. No review is required