### PR TITLE
SNOW-294266 make connection object exit autocommit aware

### DIFF
--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -11,7 +11,7 @@ from datetime import date, datetime
 from datetime import time as dt_t
 from datetime import timedelta
 from logging import getLogger
-from typing import Any, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import pytz
 
@@ -129,24 +129,22 @@ def _generate_tzinfo_from_tzoffset(tzoffset_minutes: int) -> pytz._FixedOffset:
 
 class SnowflakeConverter(object):
     def __init__(self, **kwargs):
-        self._parameters = {}
+        self._parameters: Dict[str, Union[str, int, bool]] = {}
         self._use_numpy = kwargs.get('use_numpy', False) and numpy is not None
 
         logger.debug('use_numpy: %s', self._use_numpy)
 
-    def set_parameters(self, parameters):
-        self._parameters = {}
-        for kv in parameters:
-            self._parameters[kv['name']] = kv['value']
+    def set_parameters(self, new_parameters: Dict) -> None:
+        self._parameters = new_parameters
 
-    def set_parameter(self, param, value):
+    def set_parameter(self, param: Any, value: Any) -> None:
         self._parameters[param] = value
 
-    def get_parameters(self):
+    def get_parameters(self) -> Dict[str, Union[str, int, bool]]:
         return self._parameters
 
-    def get_parameter(self, param):
-        return self._parameters[param] if param in self._parameters else None
+    def get_parameter(self, param: str) -> Optional[Union[str, int, bool]]:
+        return self._parameters.get(param)
 
     #
     # FROM Snowflake to Python Objects

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -415,7 +415,9 @@ class SnowflakeCursor(object):
                 logger.debug('cancelled timebomb in finally')
 
         if 'data' in ret and 'parameters' in ret['data']:
-            for kv in ret['data']['parameters']:
+            parameters = ret['data']['parameters']
+            # Set session parameters for cursor object
+            for kv in parameters:
                 if 'TIMESTAMP_OUTPUT_FORMAT' in kv['name']:
                     self._timestamp_output_format = kv['value']
                 if 'TIMESTAMP_NTZ_OUTPUT_FORMAT' in kv['name']:
@@ -432,8 +434,8 @@ class SnowflakeCursor(object):
                     self._timezone = kv['value']
                 if 'BINARY_OUTPUT_FORMAT' in kv['name']:
                     self._binary_output_format = kv['value']
-            self._connection._set_parameters(
-                ret, self._connection._session_parameters)
+            # Set session parameters for connection object
+            self._connection._update_parameters({p['name']: p['value'] for p in parameters})
 
         self._sequence_counter = -1
         return ret

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -926,3 +926,16 @@ def test_process_param_error(conn_cnx):
                             side_effect=Exception('test')):
                 conn._process_params(mock.Mock())
             assert pe.errno == ER_FAILED_PROCESSING_PYFORMAT
+
+
+@pytest.mark.parametrize('auto_commit', [True, False])
+def test_autocommit(conn_cnx, db_parameters, auto_commit):
+    conn = snowflake.connector.connect(**db_parameters)
+    with mock.patch.object(conn, 'commit') as mocked_commit:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(f"alter session set autocommit = {auto_commit}")
+    if auto_commit:
+        assert not mocked_commit.called
+    else:
+        assert mocked_commit.called

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -928,7 +928,7 @@ def test_process_param_error(conn_cnx):
             assert pe.errno == ER_FAILED_PROCESSING_PYFORMAT
 
 
-@pytest.mark.parametrize('auto_commit', [True, False])
+@pytest.mark.parametrize('auto_commit', [pytest.param(True, marks=pytest.mark.skipolddriver), False])
 def test_autocommit(conn_cnx, db_parameters, auto_commit):
     conn = snowflake.connector.connect(**db_parameters)
     with mock.patch.object(conn, 'commit') as mocked_commit:


### PR DESCRIPTION
SNOW-294266
The implicit commit in `SnowflakeConnection.__exit__` is causing mayhem when the session parameter `autocommit` is set to true. This PR makes the connection object `rollback`/`commit` upon closure only if `autocommit` is turned off, or is missing.