### PR TITLE
Snow 295621 python connector version bump (#643)

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -10,6 +10,11 @@ Release Notes
 -------------------------------------------------------------------------------
 
 
+- v2.4.1(March 04,2021)
+
+   - Make connection object exit() aware of status of parameter `autocommit`
+
+
 - v2.4.0(March 04,2021)
 
    - Added support for Python 3.9 and PyArrow 3.0.x.

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 4, 0, None)
+VERSION = (2, 4, 1, None)


### PR DESCRIPTION
* SNOW-295621: Bumped up PythonConnector PATCH version from 2.4.0 to 2.4.1