### PR TITLE
SNOW-298303 improve .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,11 @@
-exclude: '^(.*egg.info.*|.*/parameters.py|src/snowflake/connector/vendored/.*/).*$'
+exclude: ^src/snowflake/connector/vendored/
 repos:
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.1
-    hooks:
-    -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.7.0
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,6 +13,9 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: check-ast
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
     -   id: flake8
         additional_dependencies: ["flake8-bugbear == 19.3.0", "flake8-docstrings"]
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
@@ -47,7 +46,7 @@ repos:
             - --license-filepath
             - license_header.txt
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.19.0
+    rev: v2.10.0
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/myint/rstcheck

--- a/ci/change_snowflake_test_pwd.py
+++ b/ci/change_snowflake_test_pwd.py
@@ -41,7 +41,8 @@ def generate_known_ssm_file():
 
 
 if __name__ == '__main__':
-    from parameters import CONNECTION_PARAMETERS
     from jenkins_test_parameters import SNOWFLAKE_TEST_PASSWORD_NEW
+
+    from parameters import CONNECTION_PARAMETERS
     change_password()
     generate_known_ssm_file()

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ pandas_requirements = [
 ]
 
 try:
-    from Cython.Distutils import build_ext
-    from Cython.Build import cythonize
-    import pyarrow
     import numpy
+    import pyarrow
+    from Cython.Build import cythonize
+    from Cython.Distutils import build_ext
     _ABLE_TO_COMPILE_EXTENSIONS = True
 except ImportError:
     warnings.warn("Cannot compile native C code, because of a missing build dependency")

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -42,8 +42,10 @@ from .remote_storage_util import SnowflakeFileEncryptionMaterial, SnowflakeRemot
 from .s3_util import SnowflakeS3Util
 
 if TYPE_CHECKING:  # pragma: no cover
-    from snowflake.connector.cursor import SnowflakeCursor
     from azure.storage.blob import BlobServiceClient
+
+    from snowflake.connector.cursor import SnowflakeCursor
+
     from .file_compression_type import CompressionType
 
 S3_FS = 'S3'

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -42,7 +42,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     # force versioned dylibs onto oscrypto ssl on catalina
     if sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.15'):
-        from oscrypto import use_openssl, _module_values
+        from oscrypto import _module_values, use_openssl
         if _module_values['backend'] is None:
             use_openssl(libcrypto_path='/usr/lib/libcrypto.35.dylib', libssl_path='/usr/lib/libssl.35.dylib')
     from oscrypto import asymmetric
@@ -380,7 +380,7 @@ class SnowflakeOCSPAsn1Crypto(SnowflakeOCSP):
 
     def extract_certificate_chain(self, connection):
         """Gets certificate chain and extract the key info from OpenSSL connection."""
-        from OpenSSL.crypto import dump_certificate, FILETYPE_ASN1
+        from OpenSSL.crypto import FILETYPE_ASN1, dump_certificate
         cert_map = OrderedDict()
         logger.debug(
             "# of certificates: %s",

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1268,6 +1268,7 @@ class SnowflakeOCSP(object):
                     self.read_cert_bundle(ca_bundle)
                 else:
                     import sys
+
                     # This import that depends on these libraries is to import certificates from them,
                     # we would like to have these as up to date as possible.
                     from requests import certs

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,6 +34,7 @@ def filter_log() -> None:
     """
     import logging
     import pathlib
+
     from snowflake.connector.secret_detector import SecretDetector
 
     if not isinstance(SecretDetector, logging.Formatter):

--- a/test/integ/pandas/test_unit_arrow_chunk_iterator.py
+++ b/test/integ/pandas/test_unit_arrow_chunk_iterator.py
@@ -28,16 +28,16 @@ except ImportError:
     tzlocal = None
 
 try:
+    import pyarrow
+    from pyarrow import RecordBatch  # NOQA
     from pyarrow import RecordBatchStreamReader  # NOQA
     from pyarrow import RecordBatchStreamWriter  # NOQA
-    from pyarrow import RecordBatch  # NOQA
-    import pyarrow
 except ImportError:
     pass
 
 try:
-    from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
     from snowflake.connector.arrow_iterator import ROW_UNIT  # NOQA
+    from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
     no_arrow_iterator_ext = False
 except ImportError:
     no_arrow_iterator_ext = True

--- a/test/integ/pandas/test_unit_arrow_result.py
+++ b/test/integ/pandas/test_unit_arrow_result.py
@@ -20,16 +20,16 @@ except ImportError:
     installed_pandas = False
 
 try:
+    import pyarrow
+    from pyarrow import RecordBatch  # NOQA
     from pyarrow import RecordBatchStreamReader  # NOQA
     from pyarrow import RecordBatchStreamWriter  # NOQA
-    from pyarrow import RecordBatch  # NOQA
-    import pyarrow
 except ImportError:
     pass
 
 try:
-    from snowflake.connector.arrow_result import ArrowResult  # NOQA
     from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
+    from snowflake.connector.arrow_result import ArrowResult  # NOQA
     no_arrow_iterator_ext = False
 except ImportError:
     no_arrow_iterator_ext = True

--- a/test/integ/sso/test_connection_manual.py
+++ b/test/integ/sso/test_connection_manual.py
@@ -33,12 +33,12 @@ except ImportError:
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_SSO)
+    from parameters import CONNECTION_PARAMETERS_SSO
 except ImportError:
     CONNECTION_PARAMETERS_SSO = {}
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_client_session_keep_alive.py
+++ b/test/integ/test_client_session_keep_alive.py
@@ -11,12 +11,12 @@ import pytest
 import snowflake.connector
 
 try:
-    from parameters import (CONNECTION_PARAMETERS)
+    from parameters import CONNECTION_PARAMETERS
 except ImportError:
     CONNECTION_PARAMETERS = {}
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_concurrent_create_objects.py
+++ b/test/integ/test_concurrent_create_objects.py
@@ -12,7 +12,7 @@ import pytest
 from snowflake.connector import ProgrammingError
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_concurrent_insert.py
+++ b/test/integ/test_concurrent_insert.py
@@ -13,7 +13,7 @@ import snowflake.connector
 from snowflake.connector.errors import ProgrammingError
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except Exception:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -31,7 +31,7 @@ from snowflake.connector.network import APPLICATION_SNOWSQL, ReauthenticationReq
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 
 try:  # pragma: no cover
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -25,11 +25,7 @@ from ..randomize import random_string
 
 try:
     from snowflake.connector.constants import PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT
-    from snowflake.connector.errorcode import (
-        ER_NO_ARROW_RESULT,
-        ER_NO_PYARROW,
-        ER_NO_PYARROW_SNOWSQL,
-    )
+    from snowflake.connector.errorcode import ER_NO_ARROW_RESULT, ER_NO_PYARROW, ER_NO_PYARROW_SNOWSQL
 except ImportError:
     PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = None
     ER_NO_ARROW_RESULT = None

--- a/test/integ/test_load_unload.py
+++ b/test/integ/test_load_unload.py
@@ -13,7 +13,7 @@ from os import path
 import pytest
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -28,7 +28,7 @@ from ..integ_helpers import put
 from ..randomize import random_string
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -338,6 +338,7 @@ def _put_list_rm_files_in_stage(tmpdir, conn_cnx, db_parameters, elem):
     data_file_name = elem['data_file_name']
 
     from io import open
+
     from snowflake.connector.compat import UTF8
     tmp_dir = str(tmpdir.mkdir('data'))
     data_file = os.path.join(tmp_dir, data_file_name)

--- a/test/integ/test_put_get_with_gcp_account.py
+++ b/test/integ/test_put_get_with_gcp_account.py
@@ -301,7 +301,7 @@ def test_get_gcp_file_object_http_400_error(tmpdir, conn_cnx, db_parameters):
         with cnx.cursor() as csr:
             csr.execute("create or replace table {} (a int, b string)".format(table_name))
             try:
-                from snowflake.connector.vendored.requests import put, get
+                from snowflake.connector.vendored.requests import get, put
 
                 def mocked_put(*args, **kwargs):
                     if mocked_put.counter == 0:
@@ -407,7 +407,7 @@ def test_get_gcp_file_object_http_recoverable_error_refresh_with_downscoped(tmpd
             csr.execute('ALTER SESSION SET GCS_USE_DOWNSCOPED_CREDENTIAL = TRUE')
             csr.execute("create or replace table {} (a int, b string)".format(table_name))
             try:
-                from snowflake.connector.vendored.requests import put, get, head
+                from snowflake.connector.vendored.requests import get, head, put
 
                 def mocked_put(*args, **kwargs):
                     if mocked_put.counter == 0:

--- a/test/integ/test_qmark.py
+++ b/test/integ/test_qmark.py
@@ -105,6 +105,7 @@ def test_qmark_paramstyle_enabled(negative_conn_cnx, db_parameters):
 def test_binding_datetime_qmark(conn_cnx, db_parameters):
     """Ensures datetime can bound."""
     import datetime
+
     import snowflake.connector
     snowflake.connector.paramstyle = 'qmark'
     try:

--- a/test/integ/test_query_cancelling.py
+++ b/test/integ/test_query_cancelling.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 logging.basicConfig(level=logging.CRITICAL)
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_session_parameters.py
+++ b/test/integ/test_session_parameters.py
@@ -9,7 +9,7 @@ import pytest
 import snowflake.connector
 
 try:  # pragma: no cover
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/integ/test_statement_parameter_binding.py
+++ b/test/integ/test_statement_parameter_binding.py
@@ -10,7 +10,7 @@ import pytest
 import pytz
 
 try:
-    from parameters import (CONNECTION_PARAMETERS_ADMIN)
+    from parameters import CONNECTION_PARAMETERS_ADMIN
 except ImportError:
     CONNECTION_PARAMETERS_ADMIN = {}
 

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -23,8 +23,8 @@ from snowflake.connector.ssl_wrap_socket import _openssl_connect
 from ..randomize import random_string
 
 try:
-    from snowflake.connector.errorcode import ER_OCSP_RESPONSE_CERT_STATUS_REVOKED, \
-        ER_OCSP_RESPONSE_FETCH_FAILURE  # NOQA
+    from snowflake.connector.errorcode import ER_OCSP_RESPONSE_FETCH_FAILURE  # NOQA
+    from snowflake.connector.errorcode import ER_OCSP_RESPONSE_CERT_STATUS_REVOKED
 except ImportError:
     ER_OCSP_RESPONSE_CERT_STATUS_REVOKED = None
     ER_OCSP_RESPONSE_FETCH_FAILURE = None
@@ -299,8 +299,8 @@ def test_concurrent_ocsp_requests(tmpdir):
 def _validate_certs_using_ocsp(url, cache_file_name):
     """Validate OCSP response. Deleting memory cache and file cache randomly."""
     logger = logging.getLogger('test')
-    import time
     import random
+    import time
     time.sleep(random.randint(0, 3))
     if random.random() < 0.2:
         logger.info('clearing up cache: OCSP_VALIDATION_CACHE')

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -23,7 +23,7 @@ from snowflake.connector.remote_storage_util import DEFAULT_MAX_RETRY, Snowflake
 from snowflake.connector.s3_util import ERRORNO_WSAECONNABORTED, SnowflakeS3Util
 
 try:
-    from snowflake.connector.file_transfer_agent import SnowflakeFileMeta, SFResourceMeta
+    from snowflake.connector.file_transfer_agent import SFResourceMeta, SnowflakeFileMeta
 except ImportError:  # NOQA
     # Compatibility for olddriver tests
     SnowflakeFileMeta = dict


### PR DESCRIPTION
apologies for the drive-by, was looking at this repo for another reason

- pre-commit only runs on checked-in files, so I fixed `exclude`
- `seed-isort-config` is unnecessary for isort >= 5
- upgraded all the hooks
- `flake8` has its own pre-commit config now (and is removed from
  pre-commit/pre-commit-hooks)

you might also be interested in https://pre-commit.ci :)