### PR TITLE
Fixing the regex pattern of fmt fetching in INSERT

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -134,7 +134,7 @@ class SnowflakeCursor(object):
     INSERT_SQL_RE = re.compile(r"^insert\s+into", flags=re.IGNORECASE)
     COMMENT_SQL_RE = re.compile(r"/\*.*\*/")
     INSERT_SQL_VALUES_RE = re.compile(
-        r".*VALUES\s*(\(.*\)).*", re.IGNORECASE | re.MULTILINE | re.DOTALL
+        r".*VALUES\s*(\(\%\(.*\)s\)).*", re.IGNORECASE | re.MULTILINE | re.DOTALL
     )
     ALTER_SESSION_RE = re.compile(
         r"alter\s+session\s+set\s+(.*)=\'?([^\']+)\'?\s*;",


### PR DESCRIPTION
Old behavior 
Buggy - fmt contains the second `)` which closes the `(SELECT`
```
In [46]: c = 'INSERT INTO "MESSAGES" (raw) (SELECT PARSE_JSON(column1) as raw from values (%(raw)s))'

In [47]: c = 'INSERT INTO "MESSAGES" (raw) (SELECT PARSE_JSON(column1) as raw from values (%(raw)s))'

In [48]: INSERT_SQL_VALUES_RE = re.compile(r'.*VALUES\s*(\(.*\)).*', re.IGNORECASE | re.MULTILINE | re.DOTALL)

In [49]: m = INSERT_SQL_VALUES_RE.match(c)

In [50]: m.group(1)
Out[50]: '(%(raw)s))'
```
**New behavior**
The fmt is correct
```
In [51]: INSERT_SQL_VALUES_RE = re.compile(r'.*VALUES\s*(\(\%\(.*\)s\)).*', re.IGNORECASE | re.MULTILINE | re.DOTALL)

In [52]: c = 'INSERT INTO "MESSAGES" (raw) (SELECT PARSE_JSON(column1) as raw from values (%(raw)s))'

In [53]: m = INSERT_SQL_VALUES_RE.match(c)

In [54]: m.group(1)
Out[54]: '(%(raw)s)'
```