### PR TITLE
Add parsing logic to match VALUES clause in nested insertion queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,6 @@ setup(
         "idna>=2.5,<3",
         "certifi>=2017.4.17",
         'dataclasses<1.0;python_version=="3.6"',
-        "regex",
     ],
     namespace_packages=["snowflake"],
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,7 @@ setup(
         "idna>=2.5,<3",
         "certifi>=2017.4.17",
         'dataclasses<1.0;python_version=="3.6"',
+        "regex",
     ],
     namespace_packages=["snowflake"],
     packages=[

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -14,6 +14,8 @@ from logging import getLogger
 from threading import Lock, Timer
 from typing import IO, TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
+import regex
+
 from .bind_upload_agent import BindUploadAgent, BindUploadError
 from .compat import BASE_EXCEPTION_CLASS
 from .constants import (
@@ -129,6 +131,7 @@ class SnowflakeCursor(object):
         Calling a function is expensive in Python and most of these getters are unnecessary.
     """
 
+    BALANCED_PARENTHESES_RE = regex.compile(r"\((?>[^()]|(?R))*\)")
     PUT_SQL_RE = re.compile(r"^(?:/\*.*\*/\s*)*put\s+", flags=re.IGNORECASE)
     GET_SQL_RE = re.compile(r"^(?:/\*.*\*/\s*)*get\s+", flags=re.IGNORECASE)
     INSERT_SQL_RE = re.compile(r"^insert\s+into", flags=re.IGNORECASE)
@@ -887,8 +890,7 @@ class SnowflakeCursor(object):
                     Error.errorhandler_wrapper(
                         self.connection, self, InterfaceError, errorvalue
                     )
-
-                fmt = m.group(1)
+                fmt = self.BALANCED_PARENTHESES_RE.match(m.group(1)).group(0)
                 values = []
                 for param in seqparams:
                     logger.debug("parameter: %s", param)

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -254,3 +254,30 @@ def parse_account(account):
         parsed_account = account
 
     return parsed_account
+
+
+def parse_pyformat_insertion_values(text: str) -> str:
+    """Parses the text after 'VALUES' in an insertion query and return a pair of balanced parentheses with any text
+    in between.
+
+    Args:
+        text: the VALUES clause of an insertion query, should have no leading whitespace
+    """
+    open = 0
+    in_quotes = False
+    for i in range(len(text)):
+        if not in_quotes:
+            if text[i] == "(":
+                open += 1
+            elif text[i] == ")":
+                open -= 1
+            elif text[i] == "'":
+                in_quotes = True
+        elif text[i] == "'":
+            in_quotes = False
+
+        if open == 0:
+            return text[: i + 1]
+        elif open < 0:
+            raise ValueError("Parser finds more closing brackets than opening brackets")
+    raise ValueError("Parser cannot find balanced parentheses.")

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -621,6 +621,7 @@ def test_executemany(conn, db_parameters):
         c.close()
 
 
+@pytest.mark.skipolddriver
 def test_executemany_nested_insertion(conn_cnx, request):
     table_name = random_string(5, prefix="_test_executemany_nested_insertion")
     sql = f"INSERT INTO {table_name}(c1) (SELECT PARSE_JSON(column1) as raw from values (%(raw)s))"

--- a/test/unit/test_text_util.py
+++ b/test/unit/test_text_util.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+
+import pytest
+
+from snowflake.connector.cursor import SnowflakeCursor
+
+
+@pytest.mark.skipolddriver
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("insert into test(c1) values   (%s)", "(%s)"),
+        ("insert into test(c1, c2) values (%s, %s)", "(%s, %s)"),
+        ("insert into test(c1, c2) VALUES (%d, 123)", "(%d, 123)"),
+        (
+            "insert into test(c1, c2) values (  %d,  %f, 123, %s   )  ;",
+            "(  %d,  %f, 123, %s   )",
+        ),
+        ("insert into test(c1, c2) values (%s, '))((()(())(')", "(%s, '))((()(())(')"),
+        (
+            "insert into test(c1, c2) values (%s, '))((()(())(')))))))",
+            "(%s, '))((()(())(')",
+        ),
+        (
+            "insert into test (c1) (select parse_json(column1) as raw from values (%(raw)s))",
+            "(%(raw)s)",
+        ),
+    ],
+)
+def test_match_insert_sql_values(sql: str, expected: str):
+    from snowflake.connector.util_text import parse_pyformat_insertion_values
+
+    text = SnowflakeCursor.INSERT_SQL_VALUES_RE.match(sql)
+    assert text, "Failed to match VALUES clause"
+    assert parse_pyformat_insertion_values(text.group(1)) == expected


### PR DESCRIPTION
This is a fix for [SNOW-299744](https://snowflakecomputing.atlassian.net/browse/SNOW-299744), where we extract "a single pair of parentheses with any text in between, as long as they contain balanced parenthesis" from the `VALUES clause ` (i.e. ` (<possibly_nested_subqueries>)` in ` INSERT INTO <table> VALUES (<possibly_nested_subqueries>)`). The parser function counts `(` and `)` outside of single quote strings and returns the first balanced substring it finds, i.e. Input: `(%s, %d, '))((' )()`, Output: `(%s, %d, '))((' )`.