### PR TITLE
SNOW-302368 new Arrow NUMBER to Decimal converter option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,18 @@ with open(os.path.join(THIS_DIR, "DESCRIPTION.rst"), encoding="utf-8") as f:
 
 
 # Parse command line flags
-options = {k: "OFF" for k in ["--opt", "--debug"]}
-for flag in options.keys():
+
+# This list defines the options definitions in a set
+options_def = {
+    "--debug",
+}
+
+# Options is the final parsed command line options
+options = {e.lstrip("-"): False for e in options_def}
+
+for flag in options_def:
     if flag in sys.argv:
-        options[flag] = "ON"
+        options[flag.lstrip("-")] = True
         sys.argv.remove(flag)
 
 extensions = None
@@ -91,6 +99,9 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
         }
 
         def build_extension(self, ext):
+            if options["debug"]:
+                ext.extra_compile_args.append("-g")
+                ext.extra_link_args.append("-g")
             current_dir = os.getcwd()
 
             if ext.name == "snowflake.connector.arrow_iterator":
@@ -292,4 +303,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
+    zip_safe=False,
 )

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -160,7 +160,7 @@ cdef class EmptyPyArrowIterator:
     def __next__(self):
        raise StopIteration
 
-    def init(self, str iter_unit):
+    def init(self, str iter_unit, bint number_to_decimal):
         pass
 
 

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -44,15 +44,27 @@ cdef extern from "cpp/ArrowIterator/CArrowIterator.hpp" namespace "sf":
 
 cdef extern from "cpp/ArrowIterator/CArrowChunkIterator.hpp" namespace "sf":
     cdef cppclass CArrowChunkIterator(CArrowIterator):
-        CArrowChunkIterator(PyObject* context, vector[shared_ptr[CRecordBatch]]* batches, PyObject* use_numpy) except +
+        CArrowChunkIterator(
+                PyObject* context,
+                vector[shared_ptr[CRecordBatch]]* batches,
+                PyObject* use_numpy,
+        ) except +
 
     cdef cppclass DictCArrowChunkIterator(CArrowChunkIterator):
-        DictCArrowChunkIterator(PyObject* context, vector[shared_ptr[CRecordBatch]]* batches, PyObject* use_numpy) except +
+        DictCArrowChunkIterator(
+                PyObject* context,
+                vector[shared_ptr[CRecordBatch]]* batches,
+                PyObject* use_numpy
+        ) except +
 
 
 cdef extern from "cpp/ArrowIterator/CArrowTableIterator.hpp" namespace "sf":
     cdef cppclass CArrowTableIterator(CArrowIterator):
-        CArrowTableIterator(PyObject* context, vector[shared_ptr[CRecordBatch]]* batches) except +
+        CArrowTableIterator(
+            PyObject* context,
+            vector[shared_ptr[CRecordBatch]]* batches,
+            bint number_to_decimal,
+        ) except +
 
 
 cdef extern from "arrow/api.h" namespace "arrow" nogil:
@@ -168,8 +180,14 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
     # https://docs.snowflake.com/en/user-guide/sqlalchemy.html#numpy-data-type-support
     cdef object use_numpy
 
-    def __cinit__(self, object cursor, object py_inputstream, object arrow_context, object use_dict_result,
-                  object numpy):
+    def __cinit__(
+            self,
+            object cursor,
+            object py_inputstream,
+            object arrow_context,
+            object use_dict_result,
+            object numpy,
+    ):
         cdef shared_ptr[InputStream] input_stream
         cdef shared_ptr[CRecordBatch] record_batch
         cdef CStatus ret
@@ -235,15 +253,25 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
         else:
             return ret
 
-    def init(self, str iter_unit):
+    def init(self, str iter_unit, bint number_to_decimal):
         # init chunk (row) iterator or table iterator
         if iter_unit != ROW_UNIT and iter_unit != TABLE_UNIT:
             raise NotImplementedError
         elif iter_unit == ROW_UNIT:
-            self.cIterator = new CArrowChunkIterator(<PyObject*>self.context, &self.batches, <PyObject *>self.use_numpy) \
-                if not self.use_dict_result \
-                else new DictCArrowChunkIterator(<PyObject*>self.context, &self.batches, <PyObject *>self.use_numpy)
+            self.cIterator = new CArrowChunkIterator(
+                <PyObject*>self.context,
+                &self.batches,
+                <PyObject *>self.use_numpy,
+            ) if not self.use_dict_result else new DictCArrowChunkIterator(
+                <PyObject*>self.context,
+                &self.batches,
+                <PyObject *>self.use_numpy
+            )
 
         elif iter_unit == TABLE_UNIT:
-            self.cIterator = new CArrowTableIterator(<PyObject*>self.context, &self.batches)
+            self.cIterator = new CArrowTableIterator(
+                <PyObject*>self.context,
+                &self.batches,
+                number_to_decimal,
+            )
         self.unit = iter_unit

--- a/src/snowflake/connector/arrow_result.pyx
+++ b/src/snowflake/connector/arrow_result.pyx
@@ -72,7 +72,8 @@ cdef class ArrowResult:
             arrow_bytes = b64decode(rowset_b64)
             self._arrow_context = ArrowConverterContext(self._connection._session_parameters)
             self._current_chunk_row = PyArrowIterator(
-                self._cursor, io.BytesIO(arrow_bytes),
+                self._cursor,
+                io.BytesIO(arrow_bytes),
                 self._arrow_context,
                 self._use_dict_result,
                 self._use_numpy,

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -184,6 +184,8 @@ DEFAULT_CONFIGURATION = {
         False,
         bool,
     ),  # only use openssl instead of python only crypto modules
+    # whether to convert Arrow number values to decimal instead of doubles
+    "arrow_number_to_decimal": (False, bool),
 }
 
 APPLICATION_RE = re.compile(r"[\w\d_]+")
@@ -456,6 +458,14 @@ class SnowflakeConnection(object):
     @property
     def use_openssl_only(self):
         return self._use_openssl_only
+
+    @property
+    def arrow_number_to_decimal(self):
+        return self._arrow_number_to_decimal
+
+    @arrow_number_to_decimal.setter
+    def arrow_number_to_decimal(self, value: bool):
+        self._arrow_number_to_decimal = value
 
     def connect(self, **kwargs):
         """Establishes connection to Snowflake."""

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.hpp
@@ -23,7 +23,11 @@ public:
   /**
    * Constructor
    */
-  CArrowTableIterator(PyObject* context, std::vector<std::shared_ptr<arrow::RecordBatch>>* batches);
+  CArrowTableIterator(
+  PyObject* context,
+  std::vector<std::shared_ptr<arrow::RecordBatch>>* batches,
+  bool number_to_decimal
+  );
 
   /**
    * Destructor
@@ -52,6 +56,7 @@ private:
 
   /** local time zone */
   char* m_timezone;
+  const bool m_convert_number_to_decimal;
 
   /**
    * Reconstruct record batches with type conversion in place
@@ -74,10 +79,39 @@ private:
     const std::shared_ptr<arrow::Array>& newColumn,
     std::vector<std::shared_ptr<arrow::Field>>& futureFields,
     std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
-    bool& needsRebuild);
+    bool& needsRebuild
+    );
 
   /**
-   * convert scaled fixed number column to double column
+   * convert scaled fixed number column to Decimal, or Double column based on setting
+   */
+  void convertScaledFixedNumberColumn(
+    const unsigned int batchIdx,
+    const int colIdx,
+    const std::shared_ptr<arrow::Field> field,
+    const std::shared_ptr<arrow::Array> columnArray,
+    const unsigned int scale,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild
+  );
+
+  /**
+   * convert scaled fixed number column to Decimal column
+   */
+  void convertScaledFixedNumberColumnToDecimalColumn(
+    const unsigned int batchIdx,
+    const int colIdx,
+    const std::shared_ptr<arrow::Field> field,
+    const std::shared_ptr<arrow::Array> columnArray,
+    const unsigned int scale,
+    std::vector<std::shared_ptr<arrow::Field>>& futureFields,
+    std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
+    bool& needsRebuild
+    );
+
+  /**
+   * convert scaled fixed number column to Double column
    */
   void convertScaledFixedNumberColumnToDoubleColumn(
     const unsigned int batchIdx,
@@ -87,7 +121,8 @@ private:
     const unsigned int scale,
     std::vector<std::shared_ptr<arrow::Field>>& futureFields,
     std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
-    bool& needsRebuild);
+    bool& needsRebuild
+    );
 
   /**
    * convert Snowflake Time column (Arrow int32/int64) to Arrow Time column
@@ -101,7 +136,8 @@ private:
     const int scale,
     std::vector<std::shared_ptr<arrow::Field>>& futureFields,
     std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
-    bool& needsRebuild);
+    bool& needsRebuild
+    );
 
   /**
    * convert Snowflake TimestampNTZ/TimestampLTZ column to Arrow Timestamp column
@@ -115,7 +151,8 @@ private:
     std::vector<std::shared_ptr<arrow::Field>>& futureFields,
     std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
     bool& needsRebuild,
-    const std::string timezone="");
+    const std::string timezone=""
+    );
 
   /**
    * convert Snowflake TimestampTZ column to Arrow Timestamp column in UTC
@@ -131,7 +168,8 @@ private:
     const int byteLength,
     std::vector<std::shared_ptr<arrow::Field>>& futureFields,
     std::vector<std::shared_ptr<arrow::Array>>& futureColumns,
-    bool& needsRebuild);
+    bool& needsRebuild
+    );
 
   /**
    * convert scaled fixed number to double

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -12,7 +12,7 @@ import time
 import uuid
 from logging import getLogger
 from threading import Lock, Timer
-from typing import IO, TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import IO, TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
 from .bind_upload_agent import BindUploadAgent, BindUploadError
 from .compat import BASE_EXCEPTION_CLASS
@@ -145,7 +145,7 @@ class SnowflakeCursor(object):
         self,
         connection: "SnowflakeConnection",
         use_dict_result: bool = False,
-        json_result_class: object = JsonResult,
+        json_result_class: Type["JsonResult"] = JsonResult,
     ):
         """Inits a SnowflakeCursor with a connection.
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -739,7 +739,10 @@ class SnowflakeCursor(object):
         if self._query_result_format == "arrow":
             self.check_can_use_arrow_resultset()
             self._result = ArrowResult(
-                data, self, use_dict_result=self._use_dict_result
+                data,
+                self,
+                use_dict_result=self._use_dict_result,
+                number_to_decimal=self._connection.arrow_number_to_decimal,
             )
         else:
             self._result = self._json_result_class(data, self)

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -3,13 +3,14 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 #
-
+import decimal
 import itertools
 import random
 import time
 from datetime import datetime
 from decimal import Decimal
 
+import numpy
 import pytest
 
 try:
@@ -908,3 +909,33 @@ def test_query_resultscan_combos(conn_cnx, query_format, resultscan_format):
         if isinstance(scanned_results, pandas.DataFrame):
             scanned_results = [tuple(e) for e in scanned_results.values.tolist()]
         assert results == scanned_results
+
+
+@pytest.mark.parametrize("use_decimal", (False, True))
+def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
+    with conn_cnx() as con:
+        with con.cursor() as cur:
+            cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
+            result_df = cur.fetch_pandas_all(convert_number_to_decimal=use_decimal)
+            a_column = result_df["A"]
+            if use_decimal:
+                assert isinstance(a_column.values[0], decimal.Decimal), type(
+                    a_column.values[0]
+                )
+            else:
+                assert isinstance(a_column.values[0], numpy.float64), type(
+                    a_column.values[0]
+                )
+
+
+@pytest.mark.parametrize("use_decimal", (False, True))
+def test_number_fetchbatches_retrieve_type(conn_cnx, use_decimal):
+    with conn_cnx() as con:
+        with con.cursor() as cur:
+            cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
+            for batch in cur.fetch_pandas_batches(number_to_decimal=use_decimal):
+                a_column = batch["A"]
+                assert isinstance(
+                    a_column.values[0],
+                    decimal.Decimal if use_decimal else numpy.float64,
+                ), type(a_column.values[0])

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -913,10 +913,10 @@ def test_query_resultscan_combos(conn_cnx, query_format, resultscan_format):
 
 @pytest.mark.parametrize("use_decimal", (False, True))
 def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
-    with conn_cnx() as con:
+    with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:
             cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
-            result_df = cur.fetch_pandas_all(convert_number_to_decimal=use_decimal)
+            result_df = cur.fetch_pandas_all()
             a_column = result_df["A"]
             if use_decimal:
                 assert isinstance(a_column.values[0], decimal.Decimal), type(
@@ -930,10 +930,10 @@ def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
 
 @pytest.mark.parametrize("use_decimal", (False, True))
 def test_number_fetchbatches_retrieve_type(conn_cnx, use_decimal):
-    with conn_cnx() as con:
+    with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:
             cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
-            for batch in cur.fetch_pandas_batches(number_to_decimal=use_decimal):
+            for batch in cur.fetch_pandas_batches():
                 a_column = batch["A"]
                 assert isinstance(
                     a_column.values[0],

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -912,42 +912,37 @@ def test_query_resultscan_combos(conn_cnx, query_format, resultscan_format):
 
 
 @pytest.mark.parametrize(
-    "use_decimal",
+    "use_decimal,expected",
     [
-        False,
-        pytest.param(True, marks=pytest.mark.skipolddriver),
+        (False, numpy.float64),
+        pytest.param(True, decimal.Decimal, marks=pytest.mark.skipolddriver),
     ],
 )
-def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
+def test_number_fetchall_retrieve_type(conn_cnx, use_decimal, expected):
     with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:
             cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
             result_df = cur.fetch_pandas_all()
             a_column = result_df["A"]
-            if use_decimal:
-                assert isinstance(a_column.values[0], decimal.Decimal), type(
-                    a_column.values[0]
-                )
-            else:
-                assert isinstance(a_column.values[0], numpy.float64), type(
-                    a_column.values[0]
-                )
+            assert isinstance(a_column.values[0], expected), type(a_column.values[0])
 
 
 @pytest.mark.parametrize(
-    "use_decimal",
+    "use_decimal,expected",
     [
-        False,
-        pytest.param(True, marks=pytest.mark.skipolddriver),
+        (
+            False,
+            numpy.float64,
+        ),
+        pytest.param(True, decimal.Decimal, marks=pytest.mark.skipolddriver),
     ],
 )
-def test_number_fetchbatches_retrieve_type(conn_cnx, use_decimal):
+def test_number_fetchbatches_retrieve_type(conn_cnx, use_decimal: bool, expected: type):
     with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:
             cur.execute("SELECT 12345600.87654301::NUMBER(18, 8) a")
             for batch in cur.fetch_pandas_batches():
                 a_column = batch["A"]
-                assert isinstance(
-                    a_column.values[0],
-                    decimal.Decimal if use_decimal else numpy.float64,
-                ), type(a_column.values[0])
+                assert isinstance(a_column.values[0], expected), type(
+                    a_column.values[0]
+                )

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -911,7 +911,13 @@ def test_query_resultscan_combos(conn_cnx, query_format, resultscan_format):
         assert results == scanned_results
 
 
-@pytest.mark.parametrize("use_decimal", (False, True))
+@pytest.mark.parametrize(
+    "use_decimal",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skipolddriver),
+    ],
+)
 def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
     with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:
@@ -928,7 +934,13 @@ def test_number_fetchall_retrieve_type(conn_cnx, use_decimal):
                 )
 
 
-@pytest.mark.parametrize("use_decimal", (False, True))
+@pytest.mark.parametrize(
+    "use_decimal",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skipolddriver),
+    ],
+)
 def test_number_fetchbatches_retrieve_type(conn_cnx, use_decimal):
     with conn_cnx(arrow_number_to_decimal=use_decimal) as con:
         with con.cursor() as cur:

--- a/test/integ/pandas/test_unit_arrow_chunk_iterator.py
+++ b/test/integ/pandas/test_unit_arrow_chunk_iterator.py
@@ -664,7 +664,7 @@ def iterate_over_test_chunk(
     stream.seek(0)
     context = ArrowConverterContext()
     it = PyArrowIterator(None, stream, context, False, False)
-    it.init(ROW_UNIT)
+    it.init(ROW_UNIT, False)
 
     count = 0
     while True:


### PR DESCRIPTION
SNOW-302368
This PR adds a way to turn `NUMBER` columns into `decimal.Decimal` when retrieved to keep infinite precision while using Arrow. When compared to #668 I needed to turn the function argument into a connection parameter, because of the case when Arrow is used automatically by the back-end then there's no way to pass an argument to the `__next__` function of the iterator through the results.

While I don't exactly like putting all options as connection parameters I think we should rework our setting system to have most of them configurable on all of the following levels:
* connection
* cursor
* statement (execution)

I have filed myself the following ticket SNOW-302368 to come up with a good system for adding and handling these settings on all 3 of these levels at the same time.