### PR TITLE
SNOW-174153 Client side SQL splitting to use ANTLR4 to parse SQL…

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,13 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11 for x64
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Display Java version
-        run: java -version
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -57,6 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Set up JDK 8 for x64
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Display Java version
+        run: java -version
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -65,6 +65,8 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Upgrade setuptools, pip and wheel
         run: python -m pip install -U setuptools pip wheel
+      - name: Install certifi for antlr downloading
+        run: python -m pip install certifi
       - name: Creating source distribution
         run: python setup.py sdist
       - name: Show sdist generated
@@ -80,6 +82,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up JDK 8 for x64
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Display Java version
+        run: java -version
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -106,6 +115,8 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
+      - name: Setup Java
+        run: yum install -y java
       - uses: actions/checkout@v1
       - name: Updating path
         run: |
@@ -207,6 +218,13 @@ jobs:
           path: dist
       - name: Show sdist downloaded
         run: ls -lh dist
+      - name: Set up JDK 8 for x64
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Display Java version
+        run: java -version
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -65,8 +65,6 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Upgrade setuptools, pip and wheel
         run: python -m pip install -U setuptools pip wheel
-      - name: Install certifi for antlr downloading
-        run: python -m pip install certifi
       - name: Creating source distribution
         run: python setup.py sdist
       - name: Show sdist generated

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Display Java version
+        run: java -version
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include src/snowflake/connector *.py *.pyx
 include LICENSE.txt
 include NOTICE
 recursive-include src/snowflake/connector/cpp *.cpp *.hpp
+include src/snowflake/connector/antl *.g *.py
 prune test

--- a/ci/docker/connector_build/Dockerfile
+++ b/ci/docker/connector_build/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 WORKDIR /home/user
 RUN chmod 777 /home/user
 RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout bfc6d8b82d8c37b8ca1e386081fd800e81c6ab4a
-
+RUN yum install -y java
 ENV PATH="${PATH}:/opt/python/cp36-cp36m/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ requires = [
     "cython",
     # Must be kept in sync with the `setup_requirements` in `setup.py`
     "pyarrow>=5.0.0,<5.1.0",
+    'certifi>=2017.4.17'
 ]

--- a/setup.py
+++ b/setup.py
@@ -220,11 +220,13 @@ setup(
         "charset_normalizer~=2.0.0",
         "idna>=2.5,<4",
         "certifi>=2017.4.17",
+        "antlr4-python3-runtime",
     ],
     namespace_packages=["snowflake"],
     packages=[
         "snowflake.connector",
         "snowflake.connector.tool",
+        "snowflake.connector.antlr",
         "snowflake.connector.vendored",
         "snowflake.connector.vendored.requests",
         "snowflake.connector.vendored.urllib3",

--- a/setup.py
+++ b/setup.py
@@ -87,13 +87,28 @@ if _ABLE_TO_ANTLR_CODEGEN:
                     "grammar file %s does not exist." % self.grammar_file
                 )
 
+        def download_with_certifi(self, url, dstpath):
+            try:
+                import certifi
+
+                has_certifi = True
+            except ImportError as ie:
+                warnings.warn(f"No certifi package installed {ie}")
+                has_certifi = False
+
+            if not os.path.exists(dstpath):
+                if has_certifi:
+                    resp = urllib.request.urlopen(url, cafile=certifi.where())
+                else:
+                    resp = urllib.request.urlopen(url)
+                file_data = resp.read()
+                with open(dstpath, "wb") as f:
+                    f.write(file_data)
+
         def run(self):
             # download antlr-4.9.2-complete.jar
             jar_path = os.path.join(THIS_DIR, self.ANTLR_JAR)
-
-            if not os.path.exists(jar_path):
-                urllib.request.urlretrieve(self.antlr_url, jar_path)
-
+            self.download_with_certifi(self.antlr_url, jar_path)
             # run command to generate python stub
             command = [
                 "java",

--- a/src/snowflake/connector/antlr/__init__.py
+++ b/src/snowflake/connector/antlr/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#

--- a/src/snowflake/connector/antlr/querySeparator.g
+++ b/src/snowflake/connector/antlr/querySeparator.g
@@ -18,7 +18,7 @@ def any_prefix(self, strlist):
 @parser::members {
     import re
     self.createFuncProcMatch = re.compile(
-        r'CREATE(OR|REPLACE|TEMP|TEMPORARY|VOLATILE|SECURE|EXTERNAL|\s)*(PROCEDURE|FUNCTION)')
+        r'CREATE(\w|\s)*(PROCEDURE|FUNCTION)')
 
 def isCreateFuncProc(self):
         tok_list = self.ahead("CREATE")
@@ -218,11 +218,11 @@ URLPath:
 
 // Use NonSeparator so comment is not part of a "GeneralWord"
 GeneralWord :
-    {not self.any_prefix(["/*"])}? NonSeparator+
+    NonSeparator+
     ;
 
 NonSeparator :
-    ~(';' | ' '|'\r'|'\t'|'\n'|'\u000C' | '{' | '}' | '[' | ']' | '(' | ')' | '/' )
+    ~(';' | ' '|'\r'|'\t'|'\n'|'\u000C' | '{' | '}' | '[' | ']' | '(' | ')' | '/' | '-')
     ;
 
 NonWhiteSpace //non ';' and white space chars (that form a keyword, identifier, name, etc)
@@ -278,7 +278,7 @@ noKeywordStatement :
     ;
 
 createFunctionStatement :
-    KW_CREATE orReplace? temporary? KW_SECURE? KW_EXTERNAL? funcOrProc
+    KW_CREATE orReplace? (temporary | KW_SECURE | KW_EXTERNAL | word)* funcOrProc
     word* KW_AS
     funcOrProcBody
     SEMICOLON*

--- a/src/snowflake/connector/antlr/querySeparator.g
+++ b/src/snowflake/connector/antlr/querySeparator.g
@@ -88,7 +88,7 @@ DOUBLE_LT       : '<<' ;
 DOUBLE_GT       : '>>' ;
 COLON           : ':'  ;
 COMMA           : ','  ;
-SEMICOLON       : ';'  ;
+CLI_DELIMITER   : ';'  '>'?; // ';>' is special delimiter for Snowsql to recognize the statement requires Async run.
 
 // Bracketing of arrays, list, expressions
 LPAREN    : '(' ;
@@ -245,17 +245,17 @@ queriesText
     ;
 
 statement :
-    SEMICOLON*
+    CLI_DELIMITER*
     ({self.isCreateFuncProc()}? createFunctionStatement // create function/proc as begin...end
     | transactionStatement // not seeking begin trans.. commit/end
     | anonymousBlock  // (declare..)? begin...end
     | SpecialCommand
     | normalStatements //other than create func / begin / end
-    ) SEMICOLON*
+    ) CLI_DELIMITER*
     ;
 
 anonymousBlock :
-    (KW_DECLARE (noKeywordStatement SEMICOLON*)+)? beginEndBlock
+    (KW_DECLARE (noKeywordStatement CLI_DELIMITER*)+)? beginEndBlock
     ;
 
 transactionStatement :
@@ -263,7 +263,7 @@ transactionStatement :
     ;
 
 normalStatements :
-    SEMICOLON* statementBody SEMICOLON*
+    CLI_DELIMITER* statementBody CLI_DELIMITER*
     ;
 
 caseExpr : KW_CASE statementBody KW_END
@@ -281,7 +281,7 @@ createFunctionStatement :
     KW_CREATE orReplace? (temporary | KW_SECURE | KW_EXTERNAL | word)* funcOrProc
     word* KW_AS
     funcOrProcBody
-    SEMICOLON*
+    CLI_DELIMITER*
     ;
 
 orReplace :

--- a/src/snowflake/connector/antlr/querySeparator.g
+++ b/src/snowflake/connector/antlr/querySeparator.g
@@ -1,9 +1,6 @@
 grammar querySeparator;
 
-// Method for hacky StorageUrlIdentifier fix
-// https://stackoverflow.com/questions/8797484/antlr-lexer-tokens-that-match-similar-strings-what-if-the-greedy-lexer-makes-a?rq=1
-// Uses look ahead to check if given string is next up in the input
-
+// Method for hacky look ahead for createFuncProc pattern detection
 
 @parser::members {
     import re

--- a/src/snowflake/connector/antlr/querySeparator.g
+++ b/src/snowflake/connector/antlr/querySeparator.g
@@ -1,0 +1,288 @@
+grammar querySeparator;
+
+// Method for hacky StorageUrlIdentifier fix
+// https://stackoverflow.com/questions/8797484/antlr-lexer-tokens-that-match-similar-strings-what-if-the-greedy-lexer-makes-a?rq=1
+// Uses look ahead to check if given string is next up in the input
+
+
+@parser::members {
+    import re
+    self.createFuncProcMatch = re.compile(
+        r'CREATE(OR|REPLACE|TEMP|TEMPORARY|VOLATILE|SECURE|EXTERNAL|\s)*(PROCEDURE|FUNCTION)')
+
+def isCreateFuncProc(self):
+        tok_list = self.ahead("CREATE")
+        if len(tok_list) < 2:
+            return False
+
+        input_str = ' '.join(tok_list)
+        result = self.createFuncProcMatch.match(input_str)
+        if result is None:
+            #print("not match CREATEFUNC:" + input_str)
+            return False
+
+        #print("got CREATEFUNC:" + input_str)
+        return True
+
+def ahead(self, begin_tok):
+        MAX_SQL_LEN = 1024 * 1024 * 1024
+        look_ahead = []
+
+        next = self._input.LT(1)
+        if next.text.upper() != begin_tok:
+           return []
+        i = 0
+        while i < MAX_SQL_LEN:
+            i += 1
+            next = self._input.LT(i)
+            if (not next is None) and (next.type == Token.EOF):
+                break
+            look_ahead.append(next.text.upper())
+
+        return look_ahead
+}
+
+// To support case insensitive keywords
+fragment A_ :'a' | 'A';
+fragment B_ :'b' | 'B';
+fragment C_ :'c' | 'C';
+fragment D_ :'d' | 'D';
+fragment E_ :'e' | 'E';
+fragment F_ :'f' | 'F';
+fragment G_ :'g' | 'G';
+fragment H_ :'h' | 'H';
+fragment I_ :'i' | 'I';
+fragment J_ :'j' | 'J';
+fragment K_ :'k' | 'K';
+fragment L_ :'l' | 'L';
+fragment M_ :'m' | 'M';
+fragment N_ :'n' | 'N';
+fragment O_ :'o' | 'O';
+fragment P_ :'p' | 'P';
+fragment Q_ :'q' | 'Q';
+fragment R_ :'r' | 'R';
+fragment S_ :'s' | 'S';
+fragment T_ :'t' | 'T';
+fragment U_ :'u' | 'U';
+fragment V_ :'v' | 'V';
+fragment W_ :'w' | 'W';
+fragment X_ :'x' | 'X';
+fragment Y_ :'y' | 'Y';
+fragment Z_ :'z' | 'Z';
+
+
+// Separators
+DOT             : '.'  ; // generated as a part of Number rule
+DOUBLE_COLON    : '::' ;
+DOUBLE_LT       : '<<' ;
+DOUBLE_GT       : '>>' ;
+COLON           : ':'  ;
+COMMA           : ','  ;
+SEMICOLON       : ';'  ;
+
+// Bracketing of arrays, list, expressions
+LPAREN    : '(' ;
+RPAREN    : ')' ;
+LSQUARE   : '[' ;
+RSQUARE   : ']' ;
+LCURLY    : '{' ;
+RCURLY    : '}' ;
+
+// Operators
+AMPERSAND            : '&';
+BITWISEOR            : '|';
+BITWISEXOR           : '^';
+EQUAL                : '='  | '==';
+COLONEQUAL           : ':=' ;
+NOTEQUAL             : '<>' | '!=';
+LESSTHANOREQUALTO    : '<=' ;
+LESSTHAN             : '<'  ;
+GREATERTHANOREQUALTO : '>=' ;
+GREATERTHAN          : '>'  ;
+ARROW                : '->' ;
+CONCATENATION        : '||' ;
+DOUBLE_ARROW         : '=>' ;
+DIVIDE               : '/'  ;
+PLUS                 : '+'  ;
+MINUS                : '-'  ;
+STAR                 : '*'  ;
+MOD                  : '%'  ;
+
+DOLLAR     : '$';
+TILDE      : '~';
+QUESTION   : '?';
+UNDERSCORE : '_';
+
+WS :
+    (' '|'\r'|'\t'|'\n'|'\u000C') -> channel(HIDDEN)
+    ;
+
+KW_BEGIN : B_ E_ G_ I_ N_ ;
+KW_END : E_ N_ D_ ;
+KW_CREATE : C_ R_ E_ A_ T_ E_ ;
+KW_DECLARE : D_ E_ C_ L_ A_ R_ E_;
+KW_AS : A_ S_ ;
+KW_FUNCTION : F_ U_ N_ C_ T_ I_ O_ N_ ;
+KW_PROCEDURE : P_ R_ O_ C_ E_ D_ U_ R_ E_;
+KW_OR : O_ R_ ;
+KW_REPLACE : R_ E_ P_ L_ A_ C_ E_ ;
+KW_TEMP : T_ E_ M_ P_ ;
+KW_TEMPORARY : T_ E_ M_ P_ O_ R_ A_ R_ Y_ ;
+KW_VOLATILE : V_ O_ L_ A_ T_ I_ L_ E_ ;
+KW_SECURE : S_ E_ C_ U_ R_ E_ ;
+KW_EXTERNAL : E_ X_ T_ E_ R_ N_ A_ L_ ;
+KW_CASE : C_ A_ S_ E_ ;
+KW_TRANSACTION : T_ R_ A_ N_ S_ A_ C_ T_ I_ O_ N_ ;
+KW_WORK : W_ O_ R_ K_ ;
+KW_NAME : N_ A_ M_ E_ ;
+
+//when we expect a block
+allKeywordsExceptEnd :
+    KW_BEGIN | KW_CREATE | KW_DECLARE | KW_AS | KW_FUNCTION | KW_PROCEDURE
+    | KW_OR | KW_REPLACE | KW_TEMP | KW_TEMPORARY | KW_VOLATILE | KW_SECURE
+    | KW_EXTERNAL | KW_TRANSACTION | KW_NAME | KW_WORK
+    ;
+
+// LITERALS
+fragment Letter
+    : 'a'..'z' | 'A'..'Z'
+    ;
+
+fragment Digit
+    : '0'..'9'
+    ;
+
+//----------------------------------------------------------------------------
+// String specification
+
+// A simple string is a single quoted series of character.
+// Supports Unix-like escaping for control character, e.g \n, \t...
+// but also Unicode specification (\uXXXX).
+// To include a ' in the string, use either '' (standard SQL) or \' (SQL extensions)
+fragment StringLiteralSimple:
+      '\'' ( '\'\'' | '\\' . | ~( '\\' | '\'' ) )* '\'';
+
+// Here-strings are $$ ... $$
+fragment StringLiteralHere:
+      '$$' ( '$' ~'$' | ~'$' )* '$$'
+    ;
+
+StringLiteral :
+    StringLiteralSimple
+  | StringLiteralHere
+  ;
+
+allOperators :
+    AMPERSAND
+    | BITWISEOR | BITWISEXOR
+    | EQUAL | COLONEQUAL | NOTEQUAL | LESSTHANOREQUALTO
+    | LESSTHAN | GREATERTHANOREQUALTO | GREATERTHAN
+    | ARROW | CONCATENATION  | DOUBLE_ARROW
+    | DIVIDE | PLUS | MINUS | STAR | MOD
+    ;
+
+allSymbols : // no semicolon
+    DOT | DOUBLE_COLON | DOUBLE_LT  | DOUBLE_GT | COLON | COMMA
+    | LPAREN | RPAREN | LSQUARE | RSQUARE | LCURLY | RCURLY
+    | DOLLAR | UNDERSCORE | TILDE | QUESTION | '!' | '\\' | '@'
+    ;
+
+GeneralWord :
+    NonWhiteSpace+
+    ;
+
+NonWhiteSpace //non ';' and white space chars (that form a keyword, identifier, name, etc)
+    : ~(';' | ' '|'\r'|'\t'|'\n'|'\u000C')
+    ;
+
+//----------------------------------------------------------------------------
+// Support 3 variations on comments
+// double slash or double dash comment until the end of line
+//   (final newline is optional... ok if no newline at EOF)
+//
+// /* comment... */ ignore everything between /* and */
+
+COMMENT:
+   ( '--' ~('\n'|'\r')* '\r'? '\n'?
+   | '//' ~('\n'|'\r')* '\r'? '\n'?
+   | '/*' ( . )*? '*/'
+   ) -> channel(HIDDEN)
+   ;
+SpecialCommand :
+    '!' Letter+ ~('\n'|'\r')* '\r'? '\n'?
+    ;
+
+// chars not separated by whitespace or ';'
+word :
+    (UNDERSCORE | allOperators | allSymbols | GeneralWord)+
+    ;
+
+// entry point of sql statement splitting
+
+queriesText
+    : statement* EOF
+    ;
+
+statement :
+    SEMICOLON*
+    ({self.isCreateFuncProc()}? createFunctionStatement // create function/proc as begin...end
+    | transactionStatement // not seeking begin trans.. commit/end
+    | anonymousBlock  // (declare..)? begin...end
+    | SpecialCommand
+    | normalStatements //other than create func / begin / end
+    ) SEMICOLON*
+    ;
+
+anonymousBlock :
+    (KW_DECLARE (noKeywordStatement SEMICOLON*)+)? beginEndBlock
+    ;
+
+transactionStatement :
+    KW_BEGIN (KW_WORK | KW_TRANSACTION)? (KW_NAME word)?
+    ;
+
+normalStatements :
+    SEMICOLON* statementBody SEMICOLON*
+    ;
+
+caseExpr : KW_CASE statementBody KW_END
+    ;
+
+statementBody :
+    (allKeywordsExceptEnd | word | StringLiteral | caseExpr)+
+    ;
+
+noKeywordStatement :
+    (word | StringLiteral)+
+    ;
+
+createFunctionStatement :
+    KW_CREATE orReplace? temporary? KW_SECURE? KW_EXTERNAL? funcOrProc
+    word* KW_AS
+    funcOrProcBody
+    SEMICOLON*
+    ;
+
+orReplace :
+      KW_OR KW_REPLACE
+    ;
+
+temporary :
+      ( KW_TEMP | KW_TEMPORARY | KW_VOLATILE )
+    ;
+
+funcOrProc :
+    KW_FUNCTION | KW_PROCEDURE
+    ;
+
+funcOrProcBody :
+    StringLiteral
+    | anonymousBlock
+    ;
+
+beginEndBlock : KW_BEGIN statementInBlock* KW_END word? ;
+
+//do not consider createFuncProc in block
+statementInBlock :
+    statement+
+    ;

--- a/src/snowflake/connector/antlr/sep_gen.sh
+++ b/src/snowflake/connector/antlr/sep_gen.sh
@@ -1,0 +1,6 @@
+!/usr/bin/bash
+CURRENT_PATH=$(pwd)
+wget https://www.antlr.org/download/antlr-4.9.2-complete.jar
+MYCLASSPATH=$CURRENT_PATH/antlr-4.9.2-complete.jar:$CLASSPATH
+ANTLR4CMD="java -Xmx500M -cp $MYCLASSPATH org.antlr.v4.Tool"
+$ANTLR4CMD -Dlanguage=Python3 querySeparator.g

--- a/src/snowflake/connector/antlr/sep_gen.sh
+++ b/src/snowflake/connector/antlr/sep_gen.sh
@@ -1,4 +1,4 @@
-!/usr/bin/bash
+#!/usr/bin/bash
 CURRENT_PATH=$(pwd)
 wget https://www.antlr.org/download/antlr-4.9.2-complete.jar
 MYCLASSPATH=$CURRENT_PATH/antlr-4.9.2-complete.jar:$CLASSPATH

--- a/src/snowflake/connector/antlr/sql_separator.py
+++ b/src/snowflake/connector/antlr/sql_separator.py
@@ -8,9 +8,9 @@
 
 from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
 
-from snowflake.connector.antlr.querySeparatorLexer import querySeparatorLexer
-from snowflake.connector.antlr.querySeparatorListener import querySeparatorListener
-from snowflake.connector.antlr.querySeparatorParser import querySeparatorParser
+from .querySeparatorLexer import querySeparatorLexer
+from .querySeparatorListener import querySeparatorListener
+from .querySeparatorParser import querySeparatorParser
 
 COMMENT_CHANNEL: int = 9
 
@@ -144,6 +144,8 @@ def sep_sqls(
                 # hit one comment inside statement, add the statement string before this comment.
                 trimed_stmt += sqltext[cur : comment_toks[cur_idx].start]
                 cur = comment_toks[cur_idx].stop + 1
+                if cur < len(sqltext) and sqltext[cur - 1] == "\n":
+                    cur -= 1
                 cur_idx += 1
 
             if cur < stmt_stop:

--- a/src/snowflake/connector/antlr/sql_separator.py
+++ b/src/snowflake/connector/antlr/sql_separator.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+
+from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
+
+from snowflake.connector.antlr.querySeparatorLexer import querySeparatorLexer
+from snowflake.connector.antlr.querySeparatorListener import querySeparatorListener
+from snowflake.connector.antlr.querySeparatorParser import querySeparatorParser
+
+
+class sfcliSeparatorParser(querySeparatorParser):
+    def anonymousBlock(self):
+        querySeparatorParser.anonymousBlock(self)
+
+    def createFunctionStatement(self):
+        querySeparatorParser.createFunctionStatement(self)
+
+    def normalStatements(self):
+        querySeparatorParser.normalStatements(self)
+
+
+class sfSqlSeparatorListener(querySeparatorListener):
+    """use client side mini parser querySeparatorParser to split statements."""
+
+    def __init__(self):
+        self.result = []
+        self.result_str = []
+        self.level = 0
+        self.blockLevel = 0
+        self.result_blocks = []
+
+    def enterStatement(self, ctx: querySeparatorParser.StatementContext):
+        self.level += 1
+
+    # Exit a parse tree produced by querySeparatorParser#statement.
+    def exitStatement(self, ctx: querySeparatorParser.StatementContext):
+        self.level -= 1
+        if self.level == 0:
+            self.result.append(
+                [
+                    -1 if ctx.start is None else ctx.start.start,
+                    -1 if ctx.stop is None else ctx.stop.stop,
+                ]
+            )
+            self.result_str.append(ctx.getText())
+
+    # Enter a parse tree produced by querySeparatorParser#anonymousBlock.
+    def enterAnonymousBlock(self, ctx: querySeparatorParser.AnonymousBlockContext):
+        self.blockLevel += 1
+
+    # Exit a parse tree produced by querySeparatorParser#anonymousBlock.
+    def exitAnonymousBlock(self, ctx: querySeparatorParser.AnonymousBlockContext):
+        self.blockLevel -= 1
+        if self.blockLevel == 0:
+            self.result_blocks.append([ctx.start.start, ctx.stop.stop])
+
+
+def sep_sqls(sqltext: str):
+    sqltext = sqltext.strip()
+    sqlstream = InputStream(sqltext)
+
+    lexer = querySeparatorLexer(sqlstream)
+    tokens = CommonTokenStream(lexer)
+    parser = sfcliSeparatorParser(tokens)
+    tree = parser.queriesText()
+
+    listener = sfSqlSeparatorListener()
+    ParseTreeWalker.DEFAULT.walk(listener, tree)
+
+    stmt_list = []
+    for stmtpos in listener.result:
+        stmt_list.append(sqltext[stmtpos[0] : stmtpos[1] + 1])
+
+    return stmt_list

--- a/src/snowflake/connector/antlr/sql_separator.py
+++ b/src/snowflake/connector/antlr/sql_separator.py
@@ -12,6 +12,19 @@ from snowflake.connector.antlr.querySeparatorLexer import querySeparatorLexer
 from snowflake.connector.antlr.querySeparatorListener import querySeparatorListener
 from snowflake.connector.antlr.querySeparatorParser import querySeparatorParser
 
+COMMENT_CHANNEL: int = 9
+
+
+def is_put_or_get(stmt):
+    return stmt.strip()[:3].upper() in ("PUT", "GET")
+
+
+def is_comment_rest_line(comment: str):
+    compact = comment.strip()
+    if compact.startswith("--") or compact.startswith("//"):
+        return True
+    return False
+
 
 class sfcliSeparatorParser(querySeparatorParser):
     def anonymousBlock(self):
@@ -41,12 +54,17 @@ class sfSqlSeparatorListener(querySeparatorListener):
     def exitStatement(self, ctx: querySeparatorParser.StatementContext):
         self.level -= 1
         if self.level == 0:
+            last_tok = ctx.stop
             self.result.append(
                 [
                     -1 if ctx.start is None else ctx.start.start,
                     -1 if ctx.stop is None else ctx.stop.stop,
+                    -1
+                    if last_tok is None
+                    else last_tok.line,  # for same line comment attaching backward compatibility
                 ]
             )
+
             self.result_str.append(ctx.getText())
 
     # Enter a parse tree produced by querySeparatorParser#anonymousBlock.
@@ -60,20 +78,110 @@ class sfSqlSeparatorListener(querySeparatorListener):
             self.result_blocks.append([ctx.start.start, ctx.stop.stop])
 
 
-def sep_sqls(sqltext: str):
+def sep_sqls(
+    sqltext: str,
+    remove_comments: bool = False,
+):
+    """separate sql scripts
+    input:
+      sqltext - the sql script string
+      remove_comments - whether to remove comments in sql script
+     return:
+       stmt_list: list of statements
+       is_put_get: list of boolean. About if stmt_list[i] is PUT/GET command
+    """
     sqltext = sqltext.strip()
     sqlstream = InputStream(sqltext)
 
     lexer = querySeparatorLexer(sqlstream)
-    tokens = CommonTokenStream(lexer)
-    parser = sfcliSeparatorParser(tokens)
+    token_stream = CommonTokenStream(lexer)
+
+    parser = sfcliSeparatorParser(token_stream)
     tree = parser.queriesText()
 
     listener = sfSqlSeparatorListener()
     ParseTreeWalker.DEFAULT.walk(listener, tree)
 
     stmt_list = []
-    for stmtpos in listener.result:
-        stmt_list.append(sqltext[stmtpos[0] : stmtpos[1] + 1])
+    is_put_get = []
 
-    return stmt_list
+    line_comment_map = {}
+
+    comment_num = 0
+    comment_toks = []
+    for tok in token_stream.tokens:
+        if tok.channel == COMMENT_CHANNEL:
+            comment_num += 1
+            comment_toks.append(tok)
+            if line_comment_map.get(tok.line) is None:
+                line_comment_map[tok.line] = []
+            line_comment_map[tok.line].append(tok)
+    # the trivial case when there is no comment at all. No extra code/logic is needed
+    if comment_num == 0:
+        for stmtpos in listener.result:
+            trimed_stmt = sqltext[stmtpos[0] : stmtpos[1] + 1]
+            stmt_list.append(trimed_stmt)
+            is_put_get.append(is_put_or_get(trimed_stmt))
+
+        return stmt_list, is_put_get
+
+    if remove_comments:
+        # we have the begin and end positions of statements,
+        # now remove the comments inside statements.
+        sorted(comment_toks, key=lambda tok: tok.start)
+
+        cur_idx = 0
+        for stmtpos in listener.result:
+            cur = stmtpos[0]
+            stmt_stop = stmtpos[1]
+            trimed_stmt = ""
+
+            while cur_idx < comment_num and comment_toks[cur_idx].start < stmt_stop:
+                # skip comments that starts before current statement.
+                if comment_toks[cur_idx].stop < stmtpos[0]:
+                    cur_idx += 1
+                    continue
+                # hit one comment inside statement, add the statement string before this comment.
+                trimed_stmt += sqltext[cur : comment_toks[cur_idx].start]
+                cur = comment_toks[cur_idx].stop + 1
+                cur_idx += 1
+
+            if cur < stmt_stop:
+                trimed_stmt += sqltext[cur : stmt_stop + 1]
+
+            stmt_list.append(trimed_stmt)
+            is_put_get.append(is_put_or_get(trimed_stmt))
+    else:
+        # when we don't need to remove comments.
+        # here is to simulate how the old way of splitting
+        # attach comments with last or next statement:
+        #   we already have begin and end positions of a statement,
+        #    -- only the comment begins with '--' and '//' on the same line
+        #      that immediately follows the statement will go with this (prev) statement,
+        #    -- other comments go with next statement, unless it is the last statement.
+        # TODO: To be simplified once we don't have to keep identical output with old code
+
+        result_num = len(listener.result)
+        start = 0
+        for idx in range(result_num):
+            stmtpos = listener.result[idx]
+            end = stmtpos[1]
+            # there are comments on the same line of last token of the statement.
+            if line_comment_map.get(stmtpos[2]) is not None:
+                for line_comm in line_comment_map.get(stmtpos[2]):
+                    # Handle the first comment After the statement then break.
+                    if line_comm.start > end:
+                        if is_comment_rest_line(line_comm.text):
+                            end = line_comm.stop
+                        break
+            elif idx == (result_num - 1):
+                end = len(sqltext)
+
+            stmt_list.append(sqltext[start : end + 1])
+            start = end + 1
+
+        assert len(stmt_list) == len(listener.result)
+        for stmtpos in listener.result:
+            is_put_get.append(is_put_or_get(sqltext[stmtpos[0] : stmtpos[1]]))
+
+    return stmt_list, is_put_get

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -624,9 +624,7 @@ class SnowflakeConnection(object):
         **kwargs,
     ) -> Generator["SnowflakeCursor", None, None]:
         """Executes a stream of SQL statements. This is a non-standard convenient method."""
-        split_statements_list = split_statements(
-            stream, remove_comments=remove_comments
-        )
+        split_statements_list = split_statements(stream)
         # Note: split_statements_list is a list of tuples of sql statements and whether they are put/get
         non_empty_statements = [e for e in split_statements_list if e[0]]
         for sql, is_put_or_get in non_empty_statements:

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -7,8 +7,9 @@
 import logging
 import re
 from io import StringIO
+from typing import Optional
 
-from .antlr.sql_separator import sep_sqls
+from .antlr.sql_separator import is_put_or_get, sep_sqls
 
 _logger = logging.getLogger(__name__)
 
@@ -16,16 +17,40 @@ _logger = logging.getLogger(__name__)
 sf_comment_cmd_pattern = re.compile(r"(\n|\r)+\s*--sf:.+(\n|\r)+")
 
 
-def is_put_or_get(stmt):
-    return stmt.strip()[:3].upper() in ("PUT", "GET")
+class SQLDelimiter(object):
+    """Class that wraps a SQL delimiter string.
+
+    Since split_statements is a generator this mutable object will allow it change while executing.
+    """
+
+    def __str__(self):
+        return self.sql_delimiter
+
+    def __init__(self, sql_delimiter: str = ";"):
+        """Initializes SQLDelimiter with a string."""
+        self.sql_delimiter = sql_delimiter
 
 
 def split_statements(
     buf: StringIO,
+    remove_comments: bool = False,
+    delimiter: Optional[SQLDelimiter] = None,
 ):
-    """For automatic split, sep_sqls(sql) will detect the boundaries of sql statement blocks
-    using a simplified ANTLR4 parser. Or users could use manual way to guide the splitting
-    by using special comment. A pure comment line '--SF:<snowflake splitting hints>'
+    if delimiter is None or str(delimiter) == ";":
+        return split_statements_new(buf, remove_comments)
+    else:
+        return split_statements_old(buf, remove_comments, delimiter)
+
+
+def split_statements_new(
+    buf: StringIO,
+    remove_comments: bool = False,
+):
+    """split_statements_new is not taking delimiter.
+    This new method tries to use a mini ANTLR parser to recognize SQL statement blocks, especially
+    'create procedure...begin .. end'
+    In this method, users could also use manual way to guide the splitting
+    by using special comments. A pure comment line '--SF:<snowflake splitting hints>'
     All these commands should not be nested
       (1) '--SF:auto_split off': disable auto split. This should be first cmd in a script file
       (2) to disable split the sql texts between these two hints
@@ -41,7 +66,7 @@ def split_statements(
 
     # stmts to store the split result to return
     stmts = []
-
+    is_put_get = []
     is_auto_split = True
 
     for cmd in sfcmds:
@@ -52,7 +77,11 @@ def split_statements(
             is_auto_split = False
     starting_pos_of_block = -1  # not in block yet
     last_pos = 0  # last pos of ending blocks
+
+    # pieces contains tuples [(0|1, str)].
+    # 0 means the string could be split, 1 means it is a whole block
     pieces = []
+
     for cmd in sfcmds:
         if starting_pos_of_block < 0 and re.match(
             r"(\n|\r)+\s*--sf:\s*<<\s*(\n|\r)+", sqltext[cmd[0] : cmd[1]].lower()
@@ -76,17 +105,230 @@ def split_statements(
 
     if not is_auto_split:
         stmts = [p[1].strip() for p in pieces]
+        is_put_get = [is_put_or_get(stmt) for stmt in stmts]
     else:  # now apply auto-split to the pieces that were not wrapped by << and >> (piece[0]==1)
         for piece in pieces:
             if piece[0] == 0:
-                new_stmts = sep_sqls(piece[1])
-                for stmt in new_stmts:
-                    stmts.append(stmt.strip())
-            elif piece[0] == 1:
-                stmts.append(piece[1].strip())
+                new_stmts, ret_is_put_get = sep_sqls(piece[1], remove_comments)
+                for idx in range(len(new_stmts)):
+                    stmts.append(new_stmts[idx].strip())
+                    is_put_get.append(ret_is_put_get[idx])
 
-    for stmt in stmts:
-        yield stmt, is_put_or_get(stmt)
+            elif piece[0] == 1:
+                stmt = piece[1].strip()
+                stmts.append(stmt)
+                is_put_get.append(is_put_or_get(stmt))
+
+    for i in range(len(stmts)):
+        yield stmts[i], is_put_get[i]
+
+
+#
+# Below is the old way of splitting statements which allows delimiter
+# and does not support blocks(begin..end) and 'create procedure'
+#
+
+COMMENT_PATTERN_RE = re.compile(r"^\s*\-\-")
+EMPTY_LINE_RE = re.compile(r"^\s*$")
+
+_logger = logging.getLogger(__name__)
+
+
+def split_statements_old(
+    buf: StringIO,
+    remove_comments: bool = False,
+    delimiter: Optional[SQLDelimiter] = None,
+):
+    """Splits a stream into SQL statements (ends with a semicolon) or commands (!...).
+
+    Args:
+        buf: Unicode data stream.
+        remove_comments: Whether or not to remove all comments (Default value = False).
+        delimiter: The delimiter string that separates SQL commands from each other.
+
+    Yields:
+        A SQL statement or a command.
+    """
+    if delimiter is None:
+        delimiter = SQLDelimiter()  # Use default delimiter if none was given.
+    in_quote = False
+    ch_quote = None
+    in_comment = False
+    in_double_dollars = False
+    previous_delimiter = None
+
+    line = buf.readline()
+    if isinstance(line, bytes):
+        raise TypeError("Input data must not be binary type.")
+
+    statement = []
+    while line != "":
+        col = 0
+        col0 = 0
+        len_line = len(line)
+        sql_delimiter = delimiter.sql_delimiter
+        if not previous_delimiter or sql_delimiter != previous_delimiter:
+            # Only (re)compile new Regexes if they should be
+            escaped_delim = re.escape(sql_delimiter)
+            # Special characters possible in the sql delimiter are '_', '/' and ';'. If a delimiter does not end, or
+            # start with a special character then look for word separation with \b regex.
+            if re.match(r"\w", sql_delimiter[0]):
+                RE_START = re.compile(r"^[^\w$]?{}".format(escaped_delim))
+            else:
+                RE_START = re.compile(r"^.?{}".format(escaped_delim))
+            if re.match(r"\w", sql_delimiter[-1]):
+                RE_END = re.compile(r"{}[^\w$]?$".format(escaped_delim))
+            else:
+                RE_END = re.compile(r"{}.?$".format(escaped_delim))
+            previous_delimiter = sql_delimiter
+        while True:
+            if col >= len_line:
+                if col0 < col:
+                    if not in_comment and not in_quote and not in_double_dollars:
+                        statement.append((line[col0:col], True))
+                        if len(statement) == 1 and statement[0][0] == "":
+                            statement = []
+                        break
+                    elif not in_comment and (in_quote or in_double_dollars):
+                        statement.append((line[col0:col], True))
+                    elif not remove_comments:
+                        statement.append((line[col0:col], False))
+                break
+            elif in_comment:
+                if line[col:].startswith("*/"):
+                    in_comment = False
+                    if not remove_comments:
+                        statement.append((line[col0 : col + 2], False))
+                    col += 2
+                    col0 = col
+                else:
+                    col += 1
+            elif in_double_dollars:
+                if line[col:].startswith("$$"):
+                    in_double_dollars = False
+                    statement.append((line[col0 : col + 2], False))
+                    col += 2
+                    col0 = col
+                else:
+                    col += 1
+            elif in_quote:
+                if (
+                    line[col] == "\\"
+                    and col < len_line - 1
+                    and line[col + 1] in (ch_quote, "\\")
+                ):
+                    col += 2
+                elif line[col] == ch_quote:
+                    if (
+                        col < len_line - 1
+                        and line[col + 1] != ch_quote
+                        or col == len_line - 1
+                    ):
+                        # exits quote
+                        in_quote = False
+                        statement.append((line[col0 : col + 1], True))
+                        col += 1
+                        col0 = col
+                    else:
+                        # escaped quote and still in quote
+                        col += 2
+                else:
+                    col += 1
+            else:
+                if line[col] in ("'", '"'):
+                    in_quote = True
+                    ch_quote = line[col]
+                    col += 1
+                elif line[col] in (" ", "\t"):
+                    statement.append((line[col0 : col + 1], True))
+                    col += 1
+                    col0 = col
+                elif line[col:].startswith("--"):
+                    statement.append((line[col0:col], True))
+                    if not remove_comments:
+                        # keep the comment
+                        statement.append((line[col:], False))
+                    col = len_line + 1
+                    col0 = col
+                elif line[col:].startswith("/*") and not line[col0:].startswith(
+                    "file://"
+                ):
+                    if not remove_comments:
+                        statement.append((line[col0 : col + 2], False))
+                    else:
+                        statement.append((line[col0:col], False))
+                    col += 2
+                    col0 = col
+                    in_comment = True
+                elif line[col:].startswith("$$"):
+                    statement.append((line[col0 : col + 2], True))
+                    col += 2
+                    col0 = col
+                    in_double_dollars = True
+                elif (
+                    RE_START.match(line[col - 1 : col + len(sql_delimiter)])
+                    if col > 0
+                    else (RE_START.match(line[col : col + len(sql_delimiter)]))
+                ) and (RE_END.match(line[col : col + len(sql_delimiter) + 1])):
+                    statement.append((line[col0:col] + ";", True))
+                    col += len(sql_delimiter)
+                    try:
+                        if line[col] == ">":
+                            col += 1
+                            statement[-1] = (statement[-1][0] + ">", statement[-1][1])
+                    except IndexError:
+                        pass
+                    if COMMENT_PATTERN_RE.match(line[col:]) or EMPTY_LINE_RE.match(
+                        line[col:]
+                    ):
+                        if not remove_comments:
+                            # keep the comment
+                            statement.append((line[col:], False))
+                        col = len_line
+                    while col < len_line and line[col] in (" ", "\t"):
+                        col += 1
+                    yield _concatenate_statements(statement)
+                    col0 = col
+                    statement = []
+                elif col == 0 and line[col] == "!":  # command
+                    if len(statement) > 0:
+                        yield _concatenate_statements(statement)
+                        statement = []
+                    yield (
+                        line.strip()[: -len(sql_delimiter)]
+                        if line.strip().endswith(sql_delimiter)
+                        else line.strip()
+                    ).strip(), False
+                    break
+                else:
+                    col += 1
+        line = buf.readline()
+
+    if len(statement) > 0:
+        yield _concatenate_statements(statement)
+
+
+def _concatenate_statements(statement_list):
+    """Concatenate statements.
+
+    Each statement should be a tuple of statement and is_put_get.
+
+    The is_put_get is set to True if the statement is PUT or GET otherwise False for valid statement.
+    None is set if the statement is empty or comment only.
+
+    Args:
+        statement_list: List of statement parts.
+
+    Returns:
+        Tuple of statements and whether they are PUT or GET.
+    """
+    valid_statement_list = []
+    is_put_get = None
+    for text, is_statement in statement_list:
+        valid_statement_list.append(text)
+        if is_put_get is None and is_statement and len(text.strip()) >= 3:
+            is_put_get = text[:3].upper() in ("PUT", "GET")
+    return "".join(valid_statement_list).strip(), is_put_get
 
 
 def construct_hostname(region, account):

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -5,225 +5,24 @@
 #
 
 import logging
-import re
 from io import StringIO
-from typing import Optional
 
-COMMENT_PATTERN_RE = re.compile(r"^\s*\-\-")
-EMPTY_LINE_RE = re.compile(r"^\s*$")
+from .antlr.sql_separator import sep_sqls
 
 _logger = logging.getLogger(__name__)
 
 
-class SQLDelimiter(object):
-    """Class that wraps a SQL delimiter string.
-
-    Since split_statements is a generator this mutable object will allow it change while executing.
-    """
-
-    def __str__(self):
-        return self.sql_delimiter
-
-    def __init__(self, sql_delimiter: str = ";"):
-        """Initializes SQLDelimiter with a string."""
-        self.sql_delimiter = sql_delimiter
+def is_put_or_get(stmt):
+    return stmt[:3].upper() in ("PUT", "GET")
 
 
 def split_statements(
     buf: StringIO,
-    remove_comments: bool = False,
-    delimiter: Optional[SQLDelimiter] = None,
 ):
-    """Splits a stream into SQL statements (ends with a semicolon) or commands (!...).
-
-    Args:
-        buf: Unicode data stream.
-        remove_comments: Whether or not to remove all comments (Default value = False).
-        delimiter: The delimiter string that separates SQL commands from each other.
-
-    Yields:
-        A SQL statement or a command.
-    """
-    if delimiter is None:
-        delimiter = SQLDelimiter()  # Use default delimiter if none was given.
-    in_quote = False
-    ch_quote = None
-    in_comment = False
-    in_double_dollars = False
-    previous_delimiter = None
-
-    line = buf.readline()
-    if isinstance(line, bytes):
-        raise TypeError("Input data must not be binary type.")
-
-    statement = []
-    while line != "":
-        col = 0
-        col0 = 0
-        len_line = len(line)
-        sql_delimiter = delimiter.sql_delimiter
-        if not previous_delimiter or sql_delimiter != previous_delimiter:
-            # Only (re)compile new Regexes if they should be
-            escaped_delim = re.escape(sql_delimiter)
-            # Special characters possible in the sql delimiter are '_', '/' and ';'. If a delimiter does not end, or
-            # start with a special character then look for word separation with \b regex.
-            if re.match(r"\w", sql_delimiter[0]):
-                RE_START = re.compile(r"^[^\w$]?{}".format(escaped_delim))
-            else:
-                RE_START = re.compile(r"^.?{}".format(escaped_delim))
-            if re.match(r"\w", sql_delimiter[-1]):
-                RE_END = re.compile(r"{}[^\w$]?$".format(escaped_delim))
-            else:
-                RE_END = re.compile(r"{}.?$".format(escaped_delim))
-            previous_delimiter = sql_delimiter
-        while True:
-            if col >= len_line:
-                if col0 < col:
-                    if not in_comment and not in_quote and not in_double_dollars:
-                        statement.append((line[col0:col], True))
-                        if len(statement) == 1 and statement[0][0] == "":
-                            statement = []
-                        break
-                    elif not in_comment and (in_quote or in_double_dollars):
-                        statement.append((line[col0:col], True))
-                    elif not remove_comments:
-                        statement.append((line[col0:col], False))
-                break
-            elif in_comment:
-                if line[col:].startswith("*/"):
-                    in_comment = False
-                    if not remove_comments:
-                        statement.append((line[col0 : col + 2], False))
-                    col += 2
-                    col0 = col
-                else:
-                    col += 1
-            elif in_double_dollars:
-                if line[col:].startswith("$$"):
-                    in_double_dollars = False
-                    statement.append((line[col0 : col + 2], False))
-                    col += 2
-                    col0 = col
-                else:
-                    col += 1
-            elif in_quote:
-                if (
-                    line[col] == "\\"
-                    and col < len_line - 1
-                    and line[col + 1] in (ch_quote, "\\")
-                ):
-                    col += 2
-                elif line[col] == ch_quote:
-                    if (
-                        col < len_line - 1
-                        and line[col + 1] != ch_quote
-                        or col == len_line - 1
-                    ):
-                        # exits quote
-                        in_quote = False
-                        statement.append((line[col0 : col + 1], True))
-                        col += 1
-                        col0 = col
-                    else:
-                        # escaped quote and still in quote
-                        col += 2
-                else:
-                    col += 1
-            else:
-                if line[col] in ("'", '"'):
-                    in_quote = True
-                    ch_quote = line[col]
-                    col += 1
-                elif line[col] in (" ", "\t"):
-                    statement.append((line[col0 : col + 1], True))
-                    col += 1
-                    col0 = col
-                elif line[col:].startswith("--"):
-                    statement.append((line[col0:col], True))
-                    if not remove_comments:
-                        # keep the comment
-                        statement.append((line[col:], False))
-                    col = len_line + 1
-                    col0 = col
-                elif line[col:].startswith("/*") and not line[col0:].startswith(
-                    "file://"
-                ):
-                    if not remove_comments:
-                        statement.append((line[col0 : col + 2], False))
-                    else:
-                        statement.append((line[col0:col], False))
-                    col += 2
-                    col0 = col
-                    in_comment = True
-                elif line[col:].startswith("$$"):
-                    statement.append((line[col0 : col + 2], True))
-                    col += 2
-                    col0 = col
-                    in_double_dollars = True
-                elif (
-                    RE_START.match(line[col - 1 : col + len(sql_delimiter)])
-                    if col > 0
-                    else (RE_START.match(line[col : col + len(sql_delimiter)]))
-                ) and (RE_END.match(line[col : col + len(sql_delimiter) + 1])):
-                    statement.append((line[col0:col] + ";", True))
-                    col += len(sql_delimiter)
-                    try:
-                        if line[col] == ">":
-                            col += 1
-                            statement[-1] = (statement[-1][0] + ">", statement[-1][1])
-                    except IndexError:
-                        pass
-                    if COMMENT_PATTERN_RE.match(line[col:]) or EMPTY_LINE_RE.match(
-                        line[col:]
-                    ):
-                        if not remove_comments:
-                            # keep the comment
-                            statement.append((line[col:], False))
-                        col = len_line
-                    while col < len_line and line[col] in (" ", "\t"):
-                        col += 1
-                    yield _concatenate_statements(statement)
-                    col0 = col
-                    statement = []
-                elif col == 0 and line[col] == "!":  # command
-                    if len(statement) > 0:
-                        yield _concatenate_statements(statement)
-                        statement = []
-                    yield (
-                        line.strip()[: -len(sql_delimiter)]
-                        if line.strip().endswith(sql_delimiter)
-                        else line.strip()
-                    ).strip(), False
-                    break
-                else:
-                    col += 1
-        line = buf.readline()
-
-    if len(statement) > 0:
-        yield _concatenate_statements(statement)
-
-
-def _concatenate_statements(statement_list):
-    """Concatenate statements.
-
-    Each statement should be a tuple of statement and is_put_or_get.
-
-    The is_put_or_get is set to True if the statement is PUT or GET otherwise False for valid statement.
-    None is set if the statement is empty or comment only.
-
-    Args:
-        statement_list: List of statement parts.
-
-    Returns:
-        Tuple of statements and whether they are PUT or GET.
-    """
-    valid_statement_list = []
-    is_put_or_get = None
-    for text, is_statement in statement_list:
-        valid_statement_list.append(text)
-        if is_put_or_get is None and is_statement and len(text.strip()) >= 3:
-            is_put_or_get = text[:3].upper() in ("PUT", "GET")
-    return "".join(valid_statement_list).strip(), is_put_or_get
+    sqltext = buf.read()
+    stmts = sep_sqls(sqltext)
+    for stmt in stmts:
+        yield stmt, is_put_or_get(stmt)
 
 
 def construct_hostname(region, account):

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -5,22 +5,86 @@
 #
 
 import logging
+import re
 from io import StringIO
 
 from .antlr.sql_separator import sep_sqls
 
 _logger = logging.getLogger(__name__)
 
+# the pattern match a full line of comment
+sf_comment_cmd_pattern = re.compile(r"(\n|\r)+\s*--sf:.+(\n|\r)+")
+
 
 def is_put_or_get(stmt):
-    return stmt[:3].upper() in ("PUT", "GET")
+    return stmt.strip()[:3].upper() in ("PUT", "GET")
 
 
 def split_statements(
     buf: StringIO,
 ):
+    """For automatic split, sep_sqls(sql) will detect the boundaries of sql statement blocks
+    using a simplified ANTLR4 parser. Or users could use manual way to guide the splitting
+    by using special comment. A pure comment line '--SF:<snowflake splitting hints>'
+    All these commands should not be nested
+      (1) '--SF:auto_split off': disable auto split. This should be first cmd in a script file
+      (2) to disable split the sql texts between these two hints
+      '--SF:<<'
+         ...
+      '--SF:>>'
+      (3) to split the blocks before and after this comment '--SF:<<>>'
+    """
     sqltext = buf.read()
-    stmts = sep_sqls(sqltext)
+    sfcmds = []
+    for m in sf_comment_cmd_pattern.finditer(sqltext.lower()):
+        sfcmds.append([m.start(), m.end()])
+
+    # stmts to store the split result to return
+    stmts = []
+
+    is_auto_split = True
+
+    for cmd in sfcmds:
+        if is_auto_split and re.match(
+            r"(\n|\r)+\s*--sf:\s*auto_split\s+off", sqltext[cmd[0] : cmd[1]].lower()
+        ):
+            _logger.info("auto_split off")
+            is_auto_split = False
+    starting_pos_of_block = -1  # not in block yet
+    last_pos = 0  # last pos of ending blocks
+    pieces = []
+    for cmd in sfcmds:
+        if starting_pos_of_block < 0 and re.match(
+            r"(\n|\r)+\s*--sf:\s*<<\s*(\n|\r)+", sqltext[cmd[0] : cmd[1]].lower()
+        ):
+            starting_pos_of_block = cmd[1]
+            pieces.append([0, sqltext[last_pos : (cmd[0])]])
+        elif starting_pos_of_block > 0 and re.match(
+            r"(\n|\r)+\s*--sf:\s*>>\s*(\n|\r)+", sqltext[cmd[0] : cmd[1]].lower()
+        ):
+            pieces.append([1, sqltext[starting_pos_of_block : (cmd[0])]])
+            last_pos = cmd[1]
+            starting_pos_of_block = -1
+        elif starting_pos_of_block < 0 and re.match(
+            r"(\n|\r)+\s*--sf:\s*<<>>\s*(\n|\r)+", sqltext[cmd[0] : cmd[1]].lower()
+        ):
+            pieces.append([0, sqltext[last_pos : (cmd[0])]])
+            last_pos = cmd[1]
+
+    if last_pos < len(sqltext):
+        pieces.append([0, sqltext[last_pos:]])
+
+    if not is_auto_split:
+        stmts = [p[1].strip() for p in pieces]
+    else:  # now apply auto-split to the pieces that were not wrapped by << and >> (piece[0]==1)
+        for piece in pieces:
+            if piece[0] == 0:
+                new_stmts = sep_sqls(piece[1])
+                for stmt in new_stmts:
+                    stmts.append(stmt.strip())
+            elif piece[0] == 1:
+                stmts.append(piece[1].strip())
+
     for stmt in stmts:
         yield stmt, is_put_or_get(stmt)
 

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -36,6 +36,7 @@ def split_statements(
     remove_comments: bool = False,
     delimiter: Optional[SQLDelimiter] = None,
 ):
+    """Entry function to split statements."""
     if delimiter is None or str(delimiter) == ";":
         return split_statements_new(buf, remove_comments)
     else:

--- a/test/unit/test_split_statement.py
+++ b/test/unit/test_split_statement.py
@@ -433,7 +433,7 @@ def test_space_before_put():
         """
 -- sample data uploads
     PUT file:///tmp/data.txt @%ab;
-SELECT 1; /* 134 */ select /* 567*/ 345;
+SELECT 1; /* 134 */ select /* 567*/ 345;>
 GET @%bcd file:///tmp/aaa.txt;
 """
     ) as f:
@@ -444,7 +444,7 @@ GET @%bcd file:///tmp/aaa.txt;
             True,
         )
         assert next(itr) == ("""SELECT 1;""", False)
-        assert next(itr) == ("""/* 134 */ select /* 567*/ 345;""", False)
+        assert next(itr) == ("""/* 134 */ select /* 567*/ 345;>""", False)
         assert next(itr) == ("""GET @%bcd file:///tmp/aaa.txt;""", True)
         with pytest.raises(StopIteration):
             next(itr)

--- a/test/unit/test_split_statement.py
+++ b/test/unit/test_split_statement.py
@@ -734,6 +734,95 @@ def test_sql_createproc_sql():
             next(itr)
 
 
+def test_sql_createproc_with_comments():
+    sqltxt = """
+    CREATE TABLE T(a INTERVAL DAY(5));
+    select a from b;
+    create or replace procedure/*no mix with open_table()!*/ create_tables() as-- code below
+    begin
+    create table emp_us (deptno number, name variant);
+    create table emp_uk (deptno number, name variant);
+    end;
+    call create_tables();
+    put file:///a.txt @stage1;
+    """
+    with StringIO(sqltxt) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("CREATE TABLE T(a INTERVAL DAY(5));", False)
+        assert next(itr) == ("select a from b;", False)
+        assert next(itr) == (
+            """create or replace procedure/*no mix with open_table()!*/ create_tables() as-- code below
+    begin
+    create table emp_us (deptno number, name variant);
+    create table emp_uk (deptno number, name variant);
+    end;""",
+            False,
+        )
+        assert next(itr) == ("call create_tables();", False)
+        assert next(itr) == ("put file:///a.txt @stage1;", True)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    with StringIO(sqltxt) as f:
+        itr = split_statements(f, True)
+        assert next(itr) == ("CREATE TABLE T(a INTERVAL DAY(5));", False)
+        assert next(itr) == ("select a from b;", False)
+        assert next(itr) == (
+            """create or replace procedure create_tables() as
+    begin
+    create table emp_us (deptno number, name variant);
+    create table emp_uk (deptno number, name variant);
+    end;""",
+            False,
+        )
+        assert next(itr) == ("call create_tables();", False)
+        assert next(itr) == ("put file:///a.txt @stage1;", True)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+def test_sql_createproc_with_ext():
+    ext_in_create_proc = [
+        "temp",
+        "temporary",
+        "volatile",
+        "external",
+        "newkeyword1 kw2",
+    ]
+
+    sqltxt_ext_template = """
+    CREATE TABLE T(a INTERVAL DAY(5));
+    select a from b;
+    create or replace {0} procedure/*new keyword*/ create_tables() as-- code below
+    begin
+    select replace_procedure from table emp_us;
+    create table emp_uk (deptno number, name variant);
+    end;
+    call create_tables();
+    put file:///a.txt @stage1;
+    """
+    for ext in ext_in_create_proc:
+        sqltxt_ext = sqltxt_ext_template.format(ext)
+        with StringIO(sqltxt_ext) as f:
+            itr = split_statements(f, True)
+            assert next(itr) == ("CREATE TABLE T(a INTERVAL DAY(5));", False)
+            assert next(itr) == ("select a from b;", False)
+            expected_template = """create or replace {0} procedure create_tables() as
+    begin
+    select replace_procedure from table emp_us;
+    create table emp_uk (deptno number, name variant);
+    end;"""
+            expected_createproc = expected_template.format(ext)
+            assert next(itr) == (
+                expected_createproc,
+                False,
+            )
+        assert next(itr) == ("call create_tables();", False)
+        assert next(itr) == ("put file:///a.txt @stage1;", True)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
 def test_sql_nested_anonymous_block():
     sqltxt = """            select a from b where c=3;
             DECLARE
@@ -814,7 +903,6 @@ end;""",
             next(itr)
 
     with StringIO(sqltxt) as f:
-
         itr = split_statements(f, False)
         expect_outputs[5] = (
             """insert into table1 (i) values ('This is not a valid integer.');    -- FAILS!""",
@@ -835,7 +923,7 @@ def test_sql_creatproc_declare_stmt():
             BEGIN/*block1*/
               DECLARE
                 Z NUMBER DEFAULT X+Y;
-              BEGIN /*block 2*/
+              BEGIN/* block 2 */
                 SET X := 5;
                 RETURN Z;
               END;
@@ -853,6 +941,27 @@ def test_sql_creatproc_declare_stmt():
               DECLARE
                 Z NUMBER DEFAULT X+Y;
               BEGIN
+                SET X := 5;
+                RETURN Z;
+              END;
+            END;""",
+            False,
+        )
+        assert next(itr) == ("""GET file:///a.txt @stage1;""", True)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    with StringIO(sqltxt) as f:
+        itr = split_statements(f, False)
+        assert next(itr) == ("select a from b;", False)
+        assert next(itr) == (
+            """create or replace procedure create_tables() as             DECLARE
+              X NUMBER DEFAULT 0;
+              Y NUMBER DEFAULT X;
+            BEGIN/*block1*/
+              DECLARE
+                Z NUMBER DEFAULT X+Y;
+              BEGIN/* block 2 */
                 SET X := 5;
                 RETURN Z;
               END;

--- a/test/unit/test_split_statement.py
+++ b/test/unit/test_split_statement.py
@@ -50,11 +50,6 @@ def test_simple_sql():
     s = "select 1; -- test"
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 1; -- test", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 1;", False)
         with pytest.raises(StopIteration):
             next(itr)
@@ -62,12 +57,7 @@ def test_simple_sql():
     s = "select /* test */ 1; -- test comment select 1;"
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select /* test */ 1; -- test comment select 1;", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select /* test */ 1;", False)
         with pytest.raises(StopIteration):
             next(itr)
 
@@ -78,13 +68,7 @@ def test_multiple_line_sql():
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == (("select /* test */ 1; -- test comment", False))
-        assert next(itr) == ("select 23;", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
+        assert next(itr) == (("select /* test */ 1;", False))
         assert next(itr) == ("select 23;", False)
         with pytest.raises(StopIteration):
             next(itr)
@@ -94,13 +78,7 @@ select 23; -- test comment 2"""
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select /* test */ 1; -- test comment", False)
-        assert next(itr) == ("select 23; -- test comment 2", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select /* test */ 1;", False)
         assert next(itr) == ("select 23;", False)
         with pytest.raises(StopIteration):
             next(itr)
@@ -110,14 +88,7 @@ select 23; /* test comment 2 */ select 3"""
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select /* test */ 1; -- test comment", False)
-        assert next(itr) == ("select 23;", False)
-        assert next(itr) == ("/* test comment 2 */ select 3", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select /* test */ 1;", False)
         assert next(itr) == ("select 23;", False)
         assert next(itr) == ("select 3", False)
         with pytest.raises(StopIteration):
@@ -129,14 +100,7 @@ select 23; /* test comment 2
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select /* test */ 1; -- test comment", False)
-        assert next(itr) == ("select 23;", False)
-        assert next(itr) == ("/* test comment 2\n*/ select 3;", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select /* test */ 1;", False)
         assert next(itr) == ("select 23;", False)
         assert next(itr) == ("select 3;", False)
         with pytest.raises(StopIteration):
@@ -155,16 +119,9 @@ select 23; /* test comment 2
             "select /* test\n"
             "    continued comments 1\n"
             "    continued comments 2\n"
-            "    */ 1; -- test comment",
+            "    */ 1;",
             False,
         )
-        assert next(itr) == ("select 23;", False)
-        assert next(itr) == ("/* test comment 2\n*/ select 3;", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("select  1;", False)
         assert next(itr) == ("select 23;", False)
         assert next(itr) == ("select 3;", False)
         with pytest.raises(StopIteration):
@@ -177,12 +134,6 @@ def test_quotes():
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 'hello', 1; -- test comment", False)
-        assert next(itr) == ("select 23,'hello", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 'hello', 1;", False)
         assert next(itr) == ("select 23,'hello", False)
         with pytest.raises(StopIteration):
@@ -193,12 +144,6 @@ select "23,'hello" """
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 'he\"llo', 1; -- test comment", False)
-        assert next(itr) == ('select "23,\'hello"', False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 'he\"llo', 1;", False)
         assert next(itr) == ('select "23,\'hello"', False)
         with pytest.raises(StopIteration):
@@ -210,12 +155,6 @@ select "23,'hello" """
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 'hello\n', 1; -- test comment", False)
-        assert next(itr) == ('select "23,\'hello"', False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 'hello\n', 1;", False)
         assert next(itr) == ('select "23,\'hello"', False)
         with pytest.raises(StopIteration):
@@ -227,12 +166,6 @@ select "23,'','hello" """
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 'hello''\n', 1; -- test comment", False)
-        assert next(itr) == ("select \"23,'','hello\"", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 'hello''\n', 1;", False)
         assert next(itr) == ("select \"23,'','hello\"", False)
         with pytest.raises(StopIteration):
@@ -245,10 +178,10 @@ def test_quotes_in_comments():
     with StringIO(s) as f:
         itr = split_statements(f)
         assert next(itr) == (
-            "select 'hello'; -- test comment 'hello2' in comment",
+            "select 'hello';",
             False,
         )
-        assert next(itr) == ("/* comment 'quote'*/ select true", False)
+        assert next(itr) == ("select true", False)
         with pytest.raises(StopIteration):
             next(itr)
 
@@ -265,12 +198,6 @@ def test_backslash():
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("select 'hello\\\\', 1; -- test comment", False)
-        assert next(itr) == ("select 23,'\nhello", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("select 'hello\\\\', 1;", False)
         assert next(itr) == ("select 23,'\nhello", False)
         with pytest.raises(StopIteration):
@@ -283,12 +210,6 @@ def test_file_with_slash_star():
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("put file:///tmp/* @%tmp;", True)
-        assert next(itr) == ("ls @%tmp;", False)
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("put file:///tmp/* @%tmp;", True)
         assert next(itr) == ("ls @%tmp;", False)
         with pytest.raises(StopIteration):
@@ -310,39 +231,6 @@ list @~;
 
     with StringIO(s) as f:
         itr = split_statements(f)
-        assert next(itr) == ("list @~;", False)
-        # no comment line is returned
-        assert next(itr) == (
-            "-- first half\n" "put file://$SELF_DIR/staging-test-data/*.csv.gz @~;",
-            True,
-        )
-        assert next(itr) == (
-            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~;",
-            True,
-        )
-        assert next(itr) == (
-            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~ " "overwrite=true;",
-            True,
-        )
-        # no comment line is returned
-        assert next(itr) == (
-            "-- second half\n"
-            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~/foo;",
-            True,
-        )
-        assert next(itr) == (
-            "put file://$SELF_DIR/staging-test-data/bar.csv.gz @~/bar;",
-            True,
-        )
-        # no empty line is returned
-        assert next(itr) == ("list @~;", False)
-        assert next(itr) == ("remove @~ pattern='.*.csv.gz';", False)
-        assert next(itr) == ("list @~;", False)
-        # last raises StopIteration
-        with pytest.raises(StopIteration):
-            next(itr)
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
         assert next(itr) == ("list @~;", False)
         # no comment line is returned
         assert next(itr) == (
@@ -395,9 +283,9 @@ show tables"""
             False,
         )
 
-        assert next(itr) == ("""!spool $outfile""", False)
+        assert next(itr) == ("""!spool $outfile\n""", False)
         assert next(itr) == ("show views like 'AAA';", False)
-        assert next(itr) == ("!spool off", False)
+        assert next(itr) == ("!spool off\n", False)
         assert next(itr) == ("drop view if exists aaa;", False)
         assert next(itr) == ("show tables", False)
         with pytest.raises(StopIteration):
@@ -433,18 +321,17 @@ def test_space_before_put():
         """
 -- sample data uploads
     PUT file:///tmp/data.txt @%ab;
-SELECT 1; /* 134 */ select /* 567*/ 345;>
+SELECT 1; /* 134 */ select /* 567*/ 345;
 GET @%bcd file:///tmp/aaa.txt;
 """
     ) as f:
         itr = split_statements(f)
         assert next(itr) == (
-            """-- sample data uploads
-    PUT file:///tmp/data.txt @%ab;""",
+            """PUT file:///tmp/data.txt @%ab;""",
             True,
         )
         assert next(itr) == ("""SELECT 1;""", False)
-        assert next(itr) == ("""/* 134 */ select /* 567*/ 345;>""", False)
+        assert next(itr) == ("""select /* 567*/ 345;""", False)
         assert next(itr) == ("""GET @%bcd file:///tmp/aaa.txt;""", True)
         with pytest.raises(StopIteration):
             next(itr)
@@ -460,11 +347,6 @@ def test_empty_statement():
     ) as f:
         itr = split_statements(f)
         assert next(itr) == ("""select 1;""", False)
-        assert next(itr) == (
-            """-- tail comment1
--- tail comment2""",
-            None,
-        )
         with pytest.raises(StopIteration):
             next(itr)
 
@@ -477,13 +359,12 @@ select /*another test comments*/ 1; -- test comment 2
 select 2;
 """
     with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=False)
+        itr = split_statements(f)
         assert next(itr) == (
-            "--- test comment 1\n"
-            "select /*another test comments*/ 1; -- test comment 2",
+            "select /*another test comments*/ 1;",
             False,
         )
-        assert next(itr) == ("-- test comment 3\nselect 2;", False)
+        assert next(itr) == ("select 2;", False)
 
 
 @pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
@@ -492,60 +373,10 @@ def test_comments_with_semicolon():
 select 1;
 """
     with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=False)
-        assert next(itr) == ("--test ;\n" "select 1;", False)
+        itr = split_statements(f)
+        assert next(itr) == ("select 1;", False)
         with pytest.raises(StopIteration):
             next(itr)
-
-
-@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
-def test_comment_in_values():
-    """SNOW-51297: SnowSQL -o remove_comments=True breaks the query."""
-    # no space before a comment
-    s = """INSERT INTO foo
-VALUES (/*TIMEOUT*/ 10);"""
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("INSERT INTO foo\nVALUES ( 10);", False)
-
-    # no space before and after a comment
-    s = """INSERT INTO foo
-VALUES (/*TIMEOUT*/10);"""
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("INSERT INTO foo\nVALUES (10);", False)
-
-    # workaround
-    s = """INSERT INTO foo
-VALUES ( /*TIMEOUT*/ 10);"""
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("INSERT INTO foo\nVALUES (  10);", False)
-
-    # a comment start from the beginning of the line
-    s = """INSERT INTO foo VALUES (
-/*TIMEOUT*/
-10);"""
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == ("INSERT INTO foo VALUES (\n\n10);", False)
-
-
-@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
-def test_multiline_double_dollar_experssion_with_removed_comments():
-    s = """CREATE FUNCTION mean(a FLOAT, b FLOAT)
-  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$
-  var c = a + b;
-  return(c / 2);
-  $$;"""
-    with StringIO(s) as f:
-        itr = split_statements(f, remove_comments=True)
-        assert next(itr) == (
-            "CREATE FUNCTION mean(a FLOAT, b FLOAT)\n"
-            "  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$\n"
-            "  var c = a + b;\n  return(c / 2);\n  $$;",
-            False,
-        )
 
 
 @pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
@@ -571,7 +402,7 @@ def test_sql_delimiter():
     during execution, so the SnowSQL's cli class is passed in by SnowSQL. This function makes sure that this
     behaviour is not broken by mistake.
     """
-    delimiter = SQLDelimiter("imi")
+    delimiter = ";"
     with StringIO(
         (
             "create or replace view aaa\n"
@@ -582,9 +413,9 @@ def test_sql_delimiter():
             "!spool off\n"
             "drop view if exists aaa {delimiter}\n"
             "show tables"
-        ).format(delimiter=delimiter.sql_delimiter)
+        ).format(delimiter=delimiter)
     ) as f:
-        itr = split_statements(f, delimiter=delimiter)
+        itr = split_statements(f)
         assert next(itr) == (
             """create or replace view aaa
         as select * from
@@ -599,18 +430,6 @@ def test_sql_delimiter():
         assert next(itr) == ("show tables", False)
     with pytest.raises(StopIteration):
         next(itr)
-
-
-@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
-def test_sql_splitting_tokenization():
-    """This tests that sql_delimiter is token sensitive."""
-    raw_sql = "select 123 as asd"
-    for c in set(raw_sql.replace(" ", "")):
-        sql = raw_sql + " " + c + " " + raw_sql
-        with StringIO(sql) as sqlio:
-            s = split_statements(sqlio, delimiter=SQLDelimiter(c))
-            assert next(s)[0] == raw_sql + " ;"
-            assert next(s)[0] == raw_sql
 
 
 @pytest.mark.skipif(
@@ -637,3 +456,208 @@ def test_sql_splitting_various(sql, delimiter, split_stmnts):
             s[0] for s in split_statements(sqlio, delimiter=SQLDelimiter(delimiter))
         )
     assert statements == split_stmnts
+
+
+def test_sql_createproc_js():
+    with StringIO(
+        """
+    CREATE ROW ACCESS POLICY nullary_policy AS () RETURNS BOOLEAN -> true;
+    create or replace procedure stproc1(FLOAT_PARAM1 FLOAT)
+    returns string
+    language javascript
+    strict
+    execute as owner
+    as
+    $$
+    var sql_command =
+     "INSERT INTO stproc_test_table1 (num_col1) VALUES (" + FLOAT_PARAM1 + ")";
+    try {
+        snowflake.execute (
+            {sqlText: sql_command}
+            );
+        return "Succeeded.";   // Return a success/error indicator.
+        }
+    catch (err)  {
+        return "Failed: " + err;   // Return a success/error indicator.
+        }
+    $$
+    begin
+    /* test comment 3 */
+    NULL;
+    RETURN 3;
+    end;
+
+    """
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == (
+            """CREATE ROW ACCESS POLICY nullary_policy AS () RETURNS BOOLEAN -> true;""",
+            False,
+        )
+        assert next(itr) == (
+            """create or replace procedure stproc1(FLOAT_PARAM1 FLOAT)
+    returns string
+    language javascript
+    strict
+    execute as owner
+    as
+    $$
+    var sql_command =
+     "INSERT INTO stproc_test_table1 (num_col1) VALUES (" + FLOAT_PARAM1 + ")";
+    try {
+        snowflake.execute (
+            {sqlText: sql_command}
+            );
+        return "Succeeded.";   // Return a success/error indicator.
+        }
+    catch (err)  {
+        return "Failed: " + err;   // Return a success/error indicator.
+        }
+    $$""",
+            False,
+        )
+        assert next(itr) == (
+            """begin
+    /* test comment 3 */
+    NULL;
+    RETURN 3;
+    end;""",
+            False,
+        )
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+def test_sql_createproc_sql():
+    with StringIO(
+        """
+    CREATE TABLE T(a INTERVAL DAY(5));
+    select a from b;
+    create or replace procedure create_tables() as
+    begin
+    create table emp_us (deptno number, name variant);
+    create table emp_uk (deptno number, name variant);
+    end;
+    call create_tables();
+    put file:///a.txt @stage1;
+    """
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("CREATE TABLE T(a INTERVAL DAY(5));", False)
+        assert next(itr) == ("select a from b;", False)
+        assert next(itr) == (
+            """create or replace procedure create_tables() as
+    begin
+    create table emp_us (deptno number, name variant);
+    create table emp_uk (deptno number, name variant);
+    end;""",
+            False,
+        )
+        assert next(itr) == ("call create_tables();", False)
+        assert next(itr) == ("put file:///a.txt @stage1;", True)
+
+
+def test_sql_nested_anonymous_block():
+    with StringIO(
+        """            select a from b where c=3;
+            DECLARE
+              X NUMBER DEFAULT 0;
+              Y NUMBER DEFAULT X;
+            BEGIN
+              DECLARE
+                Z NUMBER DEFAULT X+Y;
+              BEGIN
+                SET X := 5;
+                RETURN Z;
+              END;
+            END;
+            put a to @b;
+begin transaction;
+insert into table1 (i) values (1);
+insert into table1 (i) values ('This is not a valid integer.');    -- FAILS!
+insert into table1 (i) values (2);
+commit;
+select case collate('m', 'upper')
+    when 'M' then true
+    else false
+end;
+            begin;
+insert into table2 ...;
+commit;
+
+"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("""select a from b where c=3;""", False)
+        assert next(itr) == (
+            """DECLARE
+              X NUMBER DEFAULT 0;
+              Y NUMBER DEFAULT X;
+            BEGIN
+              DECLARE
+                Z NUMBER DEFAULT X+Y;
+              BEGIN
+                SET X := 5;
+                RETURN Z;
+              END;
+            END;""",
+            False,
+        )
+        assert next(itr) == ("""put a to @b;""", True)
+        assert next(itr) == ("""begin transaction;""", False)
+        assert next(itr) == ("""insert into table1 (i) values (1);""", False)
+        assert next(itr) == (
+            """insert into table1 (i) values ('This is not a valid integer.');""",
+            False,
+        )
+        assert next(itr) == ("""insert into table1 (i) values (2);""", False)
+        assert next(itr) == ("""commit;""", False)
+        assert next(itr) == (
+            """select case collate('m', 'upper')
+    when 'M' then true
+    else false
+end;""",
+            False,
+        )
+        assert next(itr) == ("""begin;""", False)
+        assert next(itr) == ("""insert into table2 ...;""", False)
+        assert next(itr) == ("""commit;""", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+def test_sql_creatproc_declare_stmt():
+    with StringIO(
+        """    select a from b;
+    create or replace procedure create_tables() as             DECLARE
+              X NUMBER DEFAULT 0;
+              Y NUMBER DEFAULT X;
+            BEGIN
+              DECLARE
+                Z NUMBER DEFAULT X+Y;
+              BEGIN
+                SET X := 5;
+                RETURN Z;
+              END;
+            END;
+            GET file:///a.txt @stage1;"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select a from b;", False)
+        assert next(itr) == (
+            """create or replace procedure create_tables() as             DECLARE
+              X NUMBER DEFAULT 0;
+              Y NUMBER DEFAULT X;
+            BEGIN
+              DECLARE
+                Z NUMBER DEFAULT X+Y;
+              BEGIN
+                SET X := 5;
+                RETURN Z;
+              END;
+            END;""",
+            False,
+        )
+        assert next(itr) == ("""GET file:///a.txt @stage1;""", True)
+        with pytest.raises(StopIteration):
+            next(itr)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ parallel = true
 omit = */snowflake/connector/tool/*
        */snowflake/connector/vendored/*
        src/snowflake/connector/incident.py
+       */snowflake/connector/antlr/*
 [coverage:paths]
 source = src/snowflake/connector
          */.tox/*/lib/python*/site-packages/snowflake/connector


### PR DESCRIPTION
… scripts

What to detect with ANTLR4:
  -- create function/procedure anonymousBlock (label)?
      anonymousBlock support beginEndBlock and StringLiteral
  -- anonymousBlock in regular context: (declare..)? (begin ... end)
  -- KW_END in CASE statement should not mess with beginEndBlock
  -- BEGIN; BEGIN TRANSACTION | WORK should be treated as single statement (being split)

Changes vs old implementation:
  -- no more include comments between statements
  -- no more support 'removing comment' and 'sql_delimiter' parameter in new approach
  -- with this change, we want to claim we are deprecating 'sql_delimiter' and 'remove_comments' options since with a custom sql_delimiter, the sql statements are actually not standard, and 'remove_comments' could be conflict with hints.

Controls for splitting and/or delimiter:
  -- ANTLR4 split can be disabled if the first line is '-- SPLIT DISABLED --'
  -- A single comment line '-- <<>>' to separate statement before and after this comment
  -- A pair of comment line '--<<' and '-->>' to wrap a statement block that no split is needed


Setup.py changes:
   -- Add customized build step to download antlr-4.9.2-complete.jar to generate python3 stub files for querySeparator.g

Github workflow:
  -- Add steps to install Java if Java is not in the github environment, then run ANTLR codegen.