### PR TITLE
SNOW-349276 fix rownumber

### DIFF
--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -8,6 +8,7 @@ import decimal
 import time
 from datetime import datetime, timedelta
 from logging import getLogger
+from typing import Dict, Optional, Union
 
 import pytz
 
@@ -31,7 +32,10 @@ logger = getLogger(__name__)
 
 
 class ArrowConverterContext(object):
-    def __init__(self, session_parameters=None):
+    def __init__(
+        self,
+        session_parameters: Optional[Dict[str, Union[str, int, bool]]] = None,
+    ):
         if session_parameters is None:
             session_parameters = {}
         self._timezone = (

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,6 +4,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *
@@ -29,7 +30,7 @@ EMPTY_UNIT: default
 ROW_UNIT: fetch row by row if the user call `fetchone()`
 TABLE_UNIT: fetch one arrow table if the user call `fetch_pandas()`
 '''
-ROW_UNIT, TABLE_UNIT, EMPTY_UNIT = 'row', 'table', ''
+ROW_UNIT, TABLE_UNIT = 'row', 'table'
 
 
 cdef extern from "cpp/ArrowIterator/CArrowIterator.hpp" namespace "sf":
@@ -157,6 +158,9 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
 
 cdef class EmptyPyArrowIterator:
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
        raise StopIteration
 
@@ -179,6 +183,7 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
     # still be converted into native python types.
     # https://docs.snowflake.com/en/user-guide/sqlalchemy.html#numpy-data-type-support
     cdef object use_numpy
+    cdef object number_to_decimal
 
     def __cinit__(
             self,
@@ -187,6 +192,7 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
             object arrow_context,
             object use_dict_result,
             object numpy,
+            object number_to_decimal,
     ):
         cdef shared_ptr[InputStream] input_stream
         cdef shared_ptr[CRecordBatch] record_batch
@@ -195,11 +201,11 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
         cdef CResult[shared_ptr[CRecordBatchReader]] readerRet = CRecordBatchStreamReader.Open(input_stream.get())
         if not readerRet.ok():
             Error.errorhandler_wrapper(
-                cursor.connection,
+                cursor.connection if cursor is not None else None,
                 cursor,
                 OperationalError,
                 {
-                    'msg': 'Failed to open arrow stream: ' + str(readerRet.status().message()),
+                    'msg': f'Failed to open arrow stream: {readerRet.status().message()}',
                     'errno': ER_FAILED_TO_READ_ARROW_STREAM
                 })
 
@@ -209,20 +215,21 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
             ret = reader.get().ReadNext(&record_batch)
             if not ret.ok():
                 Error.errorhandler_wrapper(
-                    cursor.connection,
+                    cursor.connection if cursor is not None else None,
                     cursor,
                     OperationalError,
                     {
-                        'msg': 'Failed to read next arrow batch: ' + str(ret.message()),
+                        'msg': f'Failed to read next arrow batch: {ret.message()}',
                         'errno': ER_FAILED_TO_READ_ARROW_STREAM
-                    })
+                    }
+                )
 
             if record_batch.get() is NULL:
                 break
 
             self.batches.push_back(record_batch)
 
-        snow_logger.debug(msg="Batches read: {}".format(self.batches.size()), path_name=__file__, func_name="__cinit__")
+        snow_logger.debug(msg=f"Batches read: {self.batches.size()}", path_name=__file__, func_name="__cinit__")
 
         self.context = arrow_context
         self.cIterator = NULL
@@ -230,20 +237,29 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
         self.use_dict_result = use_dict_result
         self.cursor = cursor
         self.use_numpy = numpy
+        self.number_to_decimal = number_to_decimal
 
     def __dealloc__(self):
         del self.cIterator
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
+        if self.cIterator is NULL:
+            self.init_row_unit()
         self.cret = self.cIterator.next()
 
         if not self.cret.get().successObj:
-            msg = 'Failed to convert current row, cause: ' + str(<object>self.cret.get().exception)
-            Error.errorhandler_wrapper(self.cursor.connection, self.cursor, InterfaceError,
-                                       {
-                                           'msg': msg,
-                                           'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE
-                                       })
+            Error.errorhandler_wrapper(
+                self.cursor.connection if self.cursor is not None else None,
+                self.cursor,
+                InterfaceError,
+                {
+                    'msg': f'Failed to convert current row, cause: {<object>self.cret.get().exception}',
+                    'errno': ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE
+                }
+            )
             # it looks like this line can help us get into python and detect the global variable immediately
             # however, this log will not show up for unclear reason
         ret = <object>self.cret.get().successObj
@@ -253,25 +269,29 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
         else:
             return ret
 
-    def init(self, str iter_unit, bint number_to_decimal):
-        # init chunk (row) iterator or table iterator
-        if iter_unit != ROW_UNIT and iter_unit != TABLE_UNIT:
-            raise NotImplementedError
-        elif iter_unit == ROW_UNIT:
-            self.cIterator = new CArrowChunkIterator(
-                <PyObject*>self.context,
-                &self.batches,
-                <PyObject *>self.use_numpy,
-            ) if not self.use_dict_result else new DictCArrowChunkIterator(
-                <PyObject*>self.context,
-                &self.batches,
-                <PyObject *>self.use_numpy
+    def init(self, str iter_unit):
+        if iter_unit == ROW_UNIT:
+            self.init_row_unit()
+        elif iter_unit == TABLE_UNIT:
+            self.init_table_unit()
+        self.unit = iter_unit
+
+    def init_row_unit(self) -> None:
+        self.cIterator = new CArrowChunkIterator(
+            <PyObject *> self.context,
+            &self.batches,
+            <PyObject *> self.use_numpy
+        ) \
+            if not self.use_dict_result \
+            else new DictCArrowChunkIterator(
+            <PyObject *> self.context,
+            &self.batches,
+            <PyObject *> self.use_numpy
             )
 
-        elif iter_unit == TABLE_UNIT:
-            self.cIterator = new CArrowTableIterator(
-                <PyObject*>self.context,
-                &self.batches,
-                number_to_decimal,
-            )
-        self.unit = iter_unit
+    def init_table_unit(self) -> None:
+        self.cIterator = new CArrowTableIterator(
+            <PyObject *> self.context,
+            &self.batches,
+            self.number_to_decimal,
+        )

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -6,6 +6,7 @@
 
 import json
 import time
+from abc import ABC
 from collections import namedtuple
 from concurrent.futures.thread import ThreadPoolExecutor
 from gzip import GzipFile
@@ -271,7 +272,7 @@ class ResultIterWithTimings:
         return self._timings
 
 
-class RawBinaryDataHandler:
+class RawBinaryDataHandler(ABC):
     """Abstract class being passed to network.py to handle raw binary data."""
 
     def to_iterator(self, raw_data_fd, download_time):

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -316,11 +316,10 @@ class ArrowBinaryHandler(RawBinaryDataHandler):
         from .arrow_iterator import PyArrowIterator
 
         gzip_decoder = GzipFile(fileobj=raw_data_fd, mode="r")
-        it = PyArrowIterator(
+        return PyArrowIterator(
             self._cursor,
             gzip_decoder,
             self._arrow_context,
             self._cursor._use_dict_result,
             self._cursor.connection._numpy,
         )
-        return it

--- a/src/snowflake/connector/chunk_downloader.py
+++ b/src/snowflake/connector/chunk_downloader.py
@@ -48,15 +48,15 @@ logger = getLogger(__name__)
 class SnowflakeChunkDownloader(object):
     """Large Result set chunk downloader class."""
 
-    def _pre_init(
-        self,
-        chunks,
-        connection,
-        cursor,
-        qrmk,
-        chunk_headers,
-        query_result_format="JSON",
-        prefetch_threads=DEFAULT_CLIENT_PREFETCH_THREADS,
+    def __init__(
+            self,
+            chunks,
+            connection,
+            cursor,
+            qrmk,
+            chunk_headers,
+            query_result_format: str = "JSON",
+            prefetch_threads=DEFAULT_CLIENT_PREFETCH_THREADS,
     ):
         self._query_result_format = query_result_format
 
@@ -74,7 +74,6 @@ class SnowflakeChunkDownloader(object):
         self._effective_threads = min(prefetch_threads, self._chunk_size)
         if self._effective_threads < 1:
             self._effective_threads = 1
-
         for idx, chunk in enumerate(chunks):
             logger.debug("queued chunk %d: rowCount=%s", idx, chunk["rowCount"])
             self._chunks[idx] = SnowflakeChunk(
@@ -98,27 +97,6 @@ class SnowflakeChunkDownloader(object):
         self._total_millis_parsing_chunks = 0
 
         self._next_chunk_to_consume = 0
-
-    def __init__(
-        self,
-        chunks,
-        connection,
-        cursor,
-        qrmk,
-        chunk_headers,
-        query_result_format="JSON",
-        prefetch_threads=DEFAULT_CLIENT_PREFETCH_THREADS,
-    ):
-        self._pre_init(
-            chunks,
-            connection,
-            cursor,
-            qrmk,
-            chunk_headers,
-            query_result_format=query_result_format,
-            prefetch_threads=prefetch_threads,
-        )
-        logger.debug("Chunk Downloader in memory")
         for idx in range(self._effective_threads):
             self._pool.submit(self._download_chunk, idx)
         self._next_chunk_to_download = self._effective_threads

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -25,6 +25,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
     Union,
 )
 
@@ -566,7 +567,7 @@ class SnowflakeConnection(object):
         """Rolls back the current transaction."""
         self.cursor().execute("ROLLBACK")
 
-    def cursor(self, cursor_class: SnowflakeCursor = SnowflakeCursor):
+    def cursor(self, cursor_class: Type["SnowflakeCursor"] = SnowflakeCursor):
         """Creates a cursor object. Each statement will be executed in a new cursor object."""
         logger.debug("cursor")
         if not self.rest:

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -11,7 +11,7 @@ from datetime import date, datetime
 from datetime import time as dt_t
 from datetime import timedelta
 from logging import getLogger
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import pytz
 
@@ -72,6 +72,9 @@ PYTHON_TO_SNOWFLAKE_TYPE = {
     "datetime64": "TIMESTAMP_NTZ",
     "quoted_name": "TEXT",
 }
+
+# Type alias
+SnowflakeConverterType = Callable[[Any], Any]
 
 
 def convert_datetime_to_epoch(dt: datetime) -> float:
@@ -150,10 +153,8 @@ class SnowflakeConverter(object):
     def get_parameter(self, param: str) -> Optional[Union[str, int, bool]]:
         return self._parameters.get(param)
 
-    #
-    # FROM Snowflake to Python Objects
-    #
-    def to_python_method(self, type_name, column):
+    def to_python_method(self, type_name, column) -> "SnowflakeConverterType":
+        """FROM Snowflake to Python Objects"""
         ctx = column.copy()
         if ctx.get("scale") is not None:
             ctx["max_fraction"] = int(10 ** ctx["scale"])

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -14,7 +14,7 @@ from logging import getLogger
 from threading import Lock, Timer
 from typing import IO, TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Union
 
-from snowflake.connector.result_chunk import create_chunks_from_response
+from snowflake.connector.result_batch import create_chunks_from_response
 from snowflake.connector.result_set import ResultSet
 
 from .bind_upload_agent import BindUploadAgent, BindUploadError
@@ -49,7 +49,7 @@ from .time_util import get_time_millis
 if TYPE_CHECKING:  # pragma: no cover
     from .connection import SnowflakeConnection
     from .file_transfer_agent import SnowflakeProgressPercentage
-    from .result_chunk import ResultChunk
+    from .result_batch import ResultBatch
 
 
 logger = getLogger(__name__)
@@ -1121,8 +1121,7 @@ class SnowflakeCursor(object):
         self._sfqid = sfqid
         self._prefetch_hook = wait_until_ready
 
-    # TODO: final name? get_paritions? get_batches? get_chunks?
-    def get_result_partitions(self) -> Optional[List["ResultChunk"]]:
+    def get_result_batches(self) -> Optional[List["ResultBatch"]]:
         if self._result_set is None:
             return None
         self._log_telemetry_job_data(TelemetryField.GET_PARTITIONS_USED, 1)

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -49,6 +49,8 @@ from .time_util import get_time_millis
 if TYPE_CHECKING:  # pragma: no cover
     from .connection import SnowflakeConnection
     from .file_transfer_agent import SnowflakeProgressPercentage
+    from .result_chunk import ResultChunk
+
 
 logger = getLogger(__name__)
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -191,7 +191,7 @@ class SnowflakeCursor(object):
         self._log_max_query_length = connection.log_max_query_length
         self._inner_cursor: Optional["SnowflakeCursor"] = None
         self._prefetch_hook = None
-        self.rownumber: Optional[int] = None
+        self._rownumber: Optional[int] = None
 
         self.reset()
 
@@ -209,6 +209,10 @@ class SnowflakeCursor(object):
     @property
     def rowcount(self):
         return self._total_rowcount if self._total_rowcount >= 0 else None
+
+    @property
+    def rownumber(self):
+        return self._rownumber if self._rownumber >= 0 else None
 
     @property
     def sfqid(self):
@@ -743,7 +747,7 @@ class SnowflakeCursor(object):
             self,
             result_chunks,
         )
-        self.rownumber = 0
+        self._rownumber = -1
 
         if is_dml:
             updated_rows = 0
@@ -960,7 +964,7 @@ class SnowflakeCursor(object):
                     self,
                     _next,
                 )
-            self.rownumber += 1
+            self._rownumber += 1
             return _next
         except StopIteration:
             return None
@@ -1105,7 +1109,7 @@ class SnowflakeCursor(object):
             )
             self._result = self._inner_cursor._result
             self._result_set = self._inner_cursor._result_set
-            self.rownumber = 0
+            self._rownumber = 0
             # Unset this function, so that we don't block anymore
             self._prefetch_hook = None
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1125,7 +1125,7 @@ class SnowflakeCursor(object):
         if self._result_set is None:
             return None
         self._log_telemetry_job_data(TelemetryField.GET_PARTITIONS_USED, 1)
-        return self._result_set.partitions
+        return self._result_set.batches
 
 
 class DictCursor(SnowflakeCursor):

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -191,7 +191,7 @@ class SnowflakeCursor(object):
         self._log_max_query_length = connection.log_max_query_length
         self._inner_cursor: Optional["SnowflakeCursor"] = None
         self._prefetch_hook = None
-        self._rownumber: Optional[int] = None
+        self.rownumber: Optional[int] = None
 
         self.reset()
 
@@ -209,10 +209,6 @@ class SnowflakeCursor(object):
     @property
     def rowcount(self):
         return self._total_rowcount if self._total_rowcount >= 0 else None
-
-    @property
-    def rownumber(self):
-        return self._rownumber if self._rownumber >= 0 else None
 
     @property
     def sfqid(self):
@@ -747,7 +743,7 @@ class SnowflakeCursor(object):
             self,
             result_chunks,
         )
-        self._rownumber = -1
+        self.rownumber = 0
 
         if is_dml:
             updated_rows = 0
@@ -964,7 +960,7 @@ class SnowflakeCursor(object):
                     self,
                     _next,
                 )
-            self._rownumber += 1
+            self.rownumber += 1
             return _next
         except StopIteration:
             return None
@@ -1109,7 +1105,7 @@ class SnowflakeCursor(object):
             )
             self._result = self._inner_cursor._result
             self._result_set = self._inner_cursor._result_set
-            self._rownumber = 0
+            self.rownumber = 0
             # Unset this function, so that we don't block anymore
             self._prefetch_hook = None
 

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -230,7 +230,7 @@ class Error(BASE_EXCEPTION_CLASS):
 
     @staticmethod
     def errorhandler_wrapper(
-        connection: "SnowflakeConnection",
+        connection: Optional["SnowflakeConnection"],
         cursor: Optional["SnowflakeCursor"],
         error_class: Union[Type["Error"], Type[Exception]],
         error_value: Dict[str, Union[str, bool]],

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -247,29 +247,87 @@ class Error(BASE_EXCEPTION_CLASS):
             None if no exceptions are raised by the connection's and cursor's error handlers.
 
         Raises:
-            A Snowflake error if connection and cursor are None.
+            A Snowflake error if connection, or cursor are None. Otherwise it gives the
+            exception to the first handler in that order.
         """
-        error_value.setdefault("done_format_msg", False)
 
+        handed_over = Error.hand_to_other_handler(
+            connection,
+            cursor,
+            error_class,
+            error_value,
+        )
+        if not handed_over:
+            raise Error.errorhandler_make_exception(
+                error_class,
+                error_value,
+            )
+
+    @staticmethod
+    def errorhandler_wrapper_from_ready_exception(
+        connection: Optional["SnowflakeConnection"],
+        cursor: Optional["SnowflakeCursor"],
+        error_exc: Union["Error", Exception],
+    ) -> None:
+        """Like errorhandler_wrapper, but it takes a ready to go Exception."""
+        if isinstance(error_exc, Error):
+            error_value = {
+                "msg": error_exc.msg,
+                "errno": error_exc.errno,
+                "sqlstate": error_exc.sqlstate,
+                "sfqid": error_exc.sfqid,
+            }
+        else:
+            error_value = error_exc.args
+
+        handed_over = Error.hand_to_other_handler(
+            connection,
+            cursor,
+            type(error_exc),
+            error_value,
+        )
+        if not handed_over:
+            raise error_exc
+
+    @staticmethod
+    def hand_to_other_handler(
+        connection: Optional["SnowflakeConnection"],
+        cursor: Optional["SnowflakeCursor"],
+        error_class: Union[Type["Error"], Type[Exception]],
+        error_value: Dict[str, Union[str, bool]],
+    ) -> bool:
+        """If possible give error to a higher error handler in connection, or cursor.
+
+        Returns:
+            Whether it error was successfully given to a handler.
+        """
         if connection is not None:
             connection.messages.append((error_class, error_value))
         if cursor is not None:
             cursor.messages.append((error_class, error_value))
             cursor.errorhandler(connection, cursor, error_class, error_value)
-            return
+            return True
         elif connection is not None:
             connection.errorhandler(connection, cursor, error_class, error_value)
-            return
+            return True
+        return False
+
+    @staticmethod
+    def errorhandler_make_exception(
+        error_class: Union[Type["Error"], Type[Exception]],
+        error_value: Dict[str, Union[str, bool]],
+    ) -> Union["Error", Exception]:
+        """Helper function to errorhandler_wrapper that creates the exception."""
+        error_value.setdefault("done_format_msg", False)
 
         if issubclass(error_class, Error):
-            raise error_class(
+            return error_class(
                 msg=error_value["msg"],
                 errno=error_value.get("errno"),
                 sqlstate=error_value.get("sqlstate"),
                 sfqid=error_value.get("sfqid"),
             )
-        else:
-            raise error_class(error_value)
+        return error_class(error_value)
 
 
 class _Warning(BASE_EXCEPTION_CLASS):

--- a/src/snowflake/connector/json_result.py
+++ b/src/snowflake/connector/json_result.py
@@ -16,13 +16,10 @@ logger = getLogger(__name__)
 
 
 class JsonResult:
-    def __init__(self, raw_response, cursor):
+    def __init__(self, data, cursor):
         self._reset()
         self._cursor = cursor
         self._connection = cursor.connection
-        self._init_from_meta(raw_response)
-
-    def _init_from_meta(self, data):
         self._total_row_index = -1  # last fetched number of rows
         self._chunk_index = 0
         self._chunk_count = 0

--- a/src/snowflake/connector/json_result.py
+++ b/src/snowflake/connector/json_result.py
@@ -5,15 +5,16 @@
 #
 
 from logging import getLogger
-from typing import List
-
-from snowflake.connector.converter import SnowflakeConverter
+from typing import TYPE_CHECKING, List
 
 from .constants import FIELD_ID_TO_NAME
 from .errorcode import ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE
 from .errors import Error, InterfaceError
 from .telemetry import TelemetryField
 from .time_util import get_time_millis
+
+if TYPE_CHECKING:  # pragma: no cover
+    from snowflake.connector.converter import SnowflakeConverterType
 
 logger = getLogger(__name__)
 
@@ -33,7 +34,7 @@ class JsonResult:
 
         rowtypes = data["rowtype"]
         self._column_names: List[str] = [c["name"] for c in rowtypes]
-        self._column_converters: List["SnowflakeConverter"] = [
+        self._column_converters: List["SnowflakeConverterType"] = [
             self._connection.converter.to_python_method(c["type"].upper(), c)
             for c in rowtypes
         ]

--- a/src/snowflake/connector/result_chunk.py
+++ b/src/snowflake/connector/result_chunk.py
@@ -1,0 +1,163 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+
+import json
+import time
+from enum import Enum, unique
+from gzip import GzipFile
+from logging import getLogger
+from typing import Dict, List, NamedTuple, Optional, Union
+
+from snowflake.connector.chunk_downloader import JsonBinaryHandler
+from snowflake.connector.converter import SnowflakeConverter
+from snowflake.connector.time_util import DecorrelateJitterBackoff, TimeCNM
+from snowflake.connector.vendored import requests
+from snowflake.connector.vendored.urllib3.util import parse_url
+
+logger = getLogger(__name__)
+
+MAX_DOWNLOAD_RETRY = 10
+DOWNLOAD_TIMEOUT = 7  # seconds
+AVAILABLE_RESULT_CHUNK_FORMATS = {"json", "arrow"}
+
+
+@unique
+class DownloadMetrics(Enum):
+    """Defines the keywords by which to store metrics for chunks."""
+
+    download = "download"  # Download time in milliseconds
+    parse = "parse"  # Parsing time to final data types
+    load = "load"  # Parsing time from initial type to intermediate types
+
+
+class RemoteChunkInfo(NamedTuple):
+    """Small class that holds information about chunks that are in phase 1."""
+
+    url: str
+    rowCount: int
+    uncompressedSize: int
+    compressedSize: int
+
+
+class ResultChunk:
+    """A chunk of a resultset.
+
+    A ResultChunk can exist in 2 different states:
+        1. It has all the information necessary to download its own data
+        2. It either has it's data downloaded and parsed
+    Most result chunks should start in state 1 and then when necessary transition themselves into state 2.
+    """
+
+    def __init__(
+        self,
+        chunk_headers: Optional[Dict[str, str]],
+        remote_chunk_info: Optional[List["SnowflakeConverter"]],
+        converters: Optional[Dict[str, Union[int, str]]],
+        _format: str = "json",
+    ):
+        """Initialize ResultChunk with necessary state for state 1."""
+        # Sanitize input
+        if _format not in AVAILABLE_RESULT_CHUNK_FORMATS:
+            raise AttributeError(f"Unavailable result chunk format: {_format}")
+        # Set up class for state 1
+        self._chunk_headers = chunk_headers
+        self._remote_chunk_info = remote_chunk_info
+        self._converters = converters
+        self._data: Optional[List[List]] = None
+        self._format = _format
+        self._metrics: Dict[str, int] = {}
+
+    @classmethod
+    def from_data(
+        cls,
+        data: List[List],
+    ):
+        """Initialize ResultChunk straight in state 2."""
+        new_chunk = cls(None, None, None)
+        new_chunk._data = data
+        return new_chunk
+
+    def __repr__(self):
+        """Make devs' lives easier. If not downloaded yet display file's basename and if downloaded display length."""
+        if not self._downloaded:
+            path = parse_url(self._remote_chunk_info.url).path
+            return f"ResultChunk({path.rsplit('/', 1)[1]})"
+        else:
+            return f"ResultChunk({len(self)})"
+
+    def __len__(self):
+        if self._downloaded:
+            return len(self._data)
+        else:
+            return 0
+
+    @property
+    def _downloaded(self) -> bool:
+        """Whether this chunk has been transitioned to state 2."""
+        return self._data is not None
+
+    def __iter__(self):
+        if not self._downloaded:
+            self._download()
+        return iter(self._data)
+
+    def _download(self) -> None:
+        """Transition from phase 1 to 2 by downloading the data from blob storage.
+
+        Note that this is a synchronous method. If parallelism is necessary caller should take care of that.
+        """
+        if self._downloaded:
+            return
+        sleep_timer = 1
+        backoff = DecorrelateJitterBackoff(1, 16)
+        binary_data_handler = (  # NOQA
+            JsonBinaryHandler(is_raw_binary_iterator=True)
+            if self._format == "json"
+            else None
+        )
+        # TODO ArrowBinaryHandler(self._cursor, self._connection)
+        for retry in range(MAX_DOWNLOAD_RETRY):
+            try:
+                with TimeCNM() as download_metric:
+                    response = requests.get(
+                        self._remote_chunk_info.url,
+                        headers=self._chunk_headers,
+                        timeout=DOWNLOAD_TIMEOUT,
+                        stream=True,  # Default to non-streaming unless arrow
+                    )
+                    if response.ok:
+                        break
+            except Exception:
+                if retry == MAX_DOWNLOAD_RETRY - 1:
+                    # Re-throw if we failed on the last retry
+                    raise
+                sleep_timer = backoff.next_sleep(1, sleep_timer)
+                logger.exception(
+                    f"Failed to fetch the large result set chunk {self._remote_chunk_info.url} "
+                    f"for the {retry + 1} th time, backing off for {sleep_timer}s"
+                )
+                time.sleep(sleep_timer)
+
+        self._metrics[DownloadMetrics.download.value] = int(download_metric)
+        # Load data to a intermediate form
+        with TimeCNM() as load_metric:
+            with GzipFile(fileobj=response.raw, mode="r") as gfd:
+                if self._format == "json":
+                    # Read in decompressed data
+                    read_data: str = gfd.read().decode("utf-8", "replace")
+                    downloaded_data = json.loads("".join(["[", read_data, "]"]))
+                elif self._format == "arrow":
+                    # TODO
+                    downloaded_data = None
+        self._metrics[DownloadMetrics.load.value] = int(load_metric)
+        # Process downloaded data
+        with TimeCNM() as parse_metric:
+            self._data = [
+                [c(d) for c, d in zip(self._converters, r)] for r in downloaded_data
+            ]
+        self._metrics[DownloadMetrics.parse.value] = int(parse_metric)
+        # After we transitioned out of state 1 remove now unnecessary info
+        self._chunk_headers = None
+        self._chunk_info = None
+        self._converters = None

--- a/src/snowflake/connector/result_chunk.py
+++ b/src/snowflake/connector/result_chunk.py
@@ -1,9 +1,11 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 #
-
+import abc
+import io
 import json
 import time
+from base64 import b64decode
 from enum import Enum, unique
 from gzip import GzipFile
 from logging import getLogger
@@ -16,21 +18,30 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Tuple,
+    Union,
 )
 
-from snowflake.connector.chunk_downloader import JsonBinaryHandler
-from snowflake.connector.time_util import DecorrelateJitterBackoff, TimeCNM
-from snowflake.connector.vendored import requests
-from snowflake.connector.vendored.urllib3.util import parse_url
+from .arrow_context import ArrowConverterContext
+from .arrow_iterator import ROW_UNIT, TABLE_UNIT
+from .errorcode import ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE
+from .errors import Error, InterfaceError
+from .time_util import DecorrelateJitterBackoff, TimerContextManager
+from .vendored import requests
 
 logger = getLogger(__name__)
 
 MAX_DOWNLOAD_RETRY = 10
 DOWNLOAD_TIMEOUT = 7  # seconds
-AVAILABLE_RESULT_CHUNK_FORMATS = {"json", "arrow"}
 
 if TYPE_CHECKING:  # pragma: no cover
-    from snowflake.connector.converter import SnowflakeConverterType
+    from .converter import SnowflakeConverterType
+    from .cursor import SnowflakeCursor
+
+# qrmk related constants
+SSE_C_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm"
+SSE_C_KEY = "x-amz-server-side-encryption-customer-key"
+SSE_C_AES = "AES256"
 
 
 @unique
@@ -50,54 +61,128 @@ class RemoteChunkInfo(NamedTuple):
     compressedSize: int
 
 
-class ResultChunk:
-    """A chunk of a result set.
+def create_chunks_from_response(
+    cursor: "SnowflakeCursor",
+    _format: str,
+    data: Dict[str, Any],
+) -> List["ResultChunk"]:
+    column_converters: List[Tuple[str, "SnowflakeConverterType"]] = []
+    arrow_context: Optional["ArrowConverterContext"] = None
+    rowtypes = data["rowtype"]
+    column_names: List[str] = [c["name"] for c in rowtypes]
+    if _format == "json":
+        column_converters: List[Tuple[str, "SnowflakeConverterType"]] = [
+            (
+                c["type"],
+                cursor._connection.converter.to_python_method(c["type"].upper(), c),
+            )
+            for c in rowtypes
+        ]
+        first_chunk = JSONResultChunk.from_data(
+            data.get("rowset"),
+            column_names,
+            column_converters,
+            cursor._use_dict_result,
+        )
+    else:
+        rowset_b64 = data.get("rowsetBase64")
+        arrow_context = ArrowConverterContext(cursor._connection._session_parameters)
 
-    TODO redo doc-string
+        if rowset_b64:
+            first_chunk = ArrowResultChunk.from_data(
+                rowset_b64,
+                arrow_context,
+                cursor._use_dict_result,
+                cursor._connection._numpy,
+                column_names,
+                cursor._connection._arrow_number_to_decimal,
+            )
+        else:
+            # Log
+            first_chunk = ArrowResultChunk.from_data(
+                [],
+                arrow_context,
+                cursor._use_dict_result,
+                cursor._connection._numpy,
+                column_names,
+                cursor._connection._arrow_number_to_decimal,
+            )
 
-    A ResultChunk can exist in 2 different states:
-        1. It has all the information necessary to download its own data
-        2. It either has it's data downloaded and parsed
-    Most result chunks should start in state 1 and then when necessary transition
-    themselves into state 2.
-    """
+    if "chunks" not in data:
+        return [first_chunk]
+    else:
+        chunks = data["chunks"]
+        logger.debug("chunk size=%s", len(chunks))
+        # prepare the downloader for further fetch
+        qrmk = data.get("qrmk")
+        chunk_headers: Dict[str, Any] = {}
+        if "chunkHeaders" in data:
+            chunk_headers = {}
+            for header_key, header_value in data["chunkHeaders"].items():
+                chunk_headers[header_key] = header_value
+                if "encryption" not in header_key:
+                    logger.debug(
+                        "added chunk header: key=%s, value=%s",
+                        header_key,
+                        header_value,
+                    )
+        elif qrmk is not None:
+            logger.debug(f"qrmk={qrmk}")
+            chunk_headers[SSE_C_ALGORITHM] = SSE_C_AES
+            chunk_headers[SSE_C_KEY] = qrmk
 
+        if _format == "json":
+            return [first_chunk] + [
+                JSONResultChunk(
+                    c["rowCount"],
+                    chunk_headers,
+                    RemoteChunkInfo(
+                        url=c["url"],
+                        uncompressedSize=c["uncompressedSize"],
+                        compressedSize=c["compressedSize"],
+                    ),
+                    column_names,
+                    column_converters,
+                    cursor._use_dict_result,
+                )
+                for c in chunks
+            ]
+        else:
+            return [first_chunk] + [
+                ArrowResultChunk(
+                    c["rowCount"],
+                    chunk_headers,
+                    RemoteChunkInfo(
+                        url=c["url"],
+                        uncompressedSize=c["uncompressedSize"],
+                        compressedSize=c["compressedSize"],
+                    ),
+                    arrow_context,
+                    cursor._use_dict_result,
+                    cursor._connection._numpy,
+                    column_names,
+                    cursor._connection._arrow_number_to_decimal,
+                )
+                for c in chunks
+            ]
+
+
+class ResultChunk(abc.ABC):
     def __init__(
         self,
         rowcount: int,
         chunk_headers: Optional[Dict[str, str]],
         remote_chunk_info: Optional["RemoteChunkInfo"],
-        converters: Optional[Sequence["SnowflakeConverterType"]],
-        _format: str = "json",
+        column_names: Sequence[str],
+        use_dict_result: bool,
     ):
-        """Initialize ResultChunk with necessary state for state 1."""
-        # Sanitize input
-        if _format not in AVAILABLE_RESULT_CHUNK_FORMATS:
-            raise AttributeError(f"Unavailable result chunk format: {_format}")
         self.rowcount = rowcount
         self._chunk_headers = chunk_headers
         self._remote_chunk_info = remote_chunk_info
-        self._converters = converters
-        self._data: Optional[List[List[Any, ...]]] = None
-        self._format = _format
+        self._column_names = column_names
+        self._use_dict_result = use_dict_result
         self._metrics: Dict[str, int] = {}
-
-    @classmethod
-    def from_data(
-        cls,
-        data: Sequence[Sequence[Any]],
-    ):
-        """Initialize ResultChunk straight in state 2."""
-        new_chunk = cls(len(data), None, None, None)
-        new_chunk._data = data
-        return new_chunk
-
-    def __repr__(self) -> str:
-        if self._local:
-            return f"ResultChunk({self.rowcount})"
-        else:
-            path = parse_url(self._remote_chunk_info.url).path
-            return f"ResultChunk({path.rsplit('/', 1)[1]})"
+        self._data: Optional[List[List[Any, ...]]] = None
 
     @property
     def _local(self) -> bool:
@@ -124,34 +209,129 @@ class ResultChunk:
             return self._remote_chunk_info.uncompressedSize
         return None
 
-    def __iter__(self) -> Iterator[List[Any]]:
+    def __iter__(
+        self,
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
         """Returns an iterator through the data this chunk holds.
 
         In case of this being a local chunk it iterates through the local already parsed
         data and if it's a remote chunk it will download, parse its data and return an
         iterator for it.
         """
-        return iter(self._download())
+        return self._download()
 
-    def _download(self) -> List[List[Any]]:
-        """Transition from phase 1 to 2 by downloading the data from blob storage.
+    @abc.abstractmethod
+    def _download(
+        self, **kwargs
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
+        raise NotImplementedError()
 
-        Note that this is a synchronous method. If parallelism is necessary caller
-        should take care of that.
-        """
+
+class JSONResultChunk(ResultChunk):
+    def __init__(
+        self,
+        rowcount: int,
+        chunk_headers: Optional[Dict[str, str]],
+        remote_chunk_info: Optional["RemoteChunkInfo"],
+        column_names: Sequence[str],
+        column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
+        use_dict_result: bool,
+    ):
+        super().__init__(
+            rowcount,
+            chunk_headers,
+            remote_chunk_info,
+            column_names,
+            use_dict_result,
+        )
+        self.column_converters = column_converters
+
+    @classmethod
+    def from_data(
+        cls,
+        data: Sequence[Sequence[Any]],
+        column_names: Sequence[str],
+        column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
+        use_dict_result: bool,
+    ):
+        new_chunk = cls(
+            len(data),
+            None,
+            None,
+            column_names,
+            column_converters,
+            use_dict_result,
+        )
+        new_chunk._data = list(new_chunk._parse(data))
+        return new_chunk
+
+    def _load(self, response):  # TODO types
+        with GzipFile(fileobj=response.raw, mode="r") as gfd:
+            # Read in decompressed data
+            read_data: str = gfd.read().decode("utf-8", "replace")
+            return json.loads("".join(["[", read_data, "]"]))
+
+    def _parse(
+        self, downloaded_data
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
+        if self._use_dict_result:
+            for row in downloaded_data:
+                row_result = {}
+                try:
+                    for (_t, c), v, n in zip(
+                        self.column_converters,
+                        row,
+                        self._column_names,
+                    ):
+                        row_result[n] = v if c is None or v is None else c(v)
+                except Exception as error:
+                    msg = f"Failed to convert: field {n}: {_t}::{v}, Error: {error}"
+                    logger.exception(msg)
+                    yield Error.errorhandler_make_exception(
+                        InterfaceError,
+                        {
+                            "msg": msg,
+                            "errno": ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
+                        },
+                    )
+                yield row_result
+        else:
+            for row in downloaded_data:
+                row_result = [None] * len(self._column_names)
+                try:
+                    idx = 0
+                    for (_t, c), v, _n in zip(
+                        self.column_converters,
+                        row,
+                        self._column_names,
+                    ):
+                        row_result[idx] = v if c is None or v is None else c(v)
+                        idx += 1
+                except Exception as error:
+                    msg = f"Failed to convert: field {_n}: {_t}::{v}, Error: {error}"
+                    logger.exception(msg)
+                    yield Error.errorhandler_make_exception(
+                        InterfaceError,
+                        {
+                            "msg": msg,
+                            "errno": ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
+                        },
+                    )
+                yield tuple(row_result)
+
+    def __repr__(self) -> str:
+        return f"JSONResultChunk({self.rowcount})"
+
+    def _download(
+        self, **kwargs
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
         if self._local:
-            return self._data
+            return iter(self._data)
         sleep_timer = 1
         backoff = DecorrelateJitterBackoff(1, 16)
-        binary_data_handler = (  # NOQA
-            JsonBinaryHandler(is_raw_binary_iterator=True)
-            if self._format == "json"
-            else None
-        )
-        # TODO ArrowBinaryHandler(self._cursor, self._connection)
         for retry in range(MAX_DOWNLOAD_RETRY):
             try:
-                with TimeCNM() as download_metric:
+                with TimerContextManager() as download_metric:
                     response = requests.get(
                         self._remote_chunk_info.url,
                         headers=self._chunk_headers,
@@ -172,23 +352,142 @@ class ResultChunk:
                 )
                 time.sleep(sleep_timer)
 
-        self._metrics[DownloadMetrics.download.value] = int(download_metric)
+        self._metrics[
+            DownloadMetrics.download.value
+        ] = download_metric.get_timing_millis()
         # Load data to a intermediate form
-        with TimeCNM() as load_metric:
-            with GzipFile(fileobj=response.raw, mode="r") as gfd:
-                if self._format == "json":
-                    # Read in decompressed data
-                    read_data: str = gfd.read().decode("utf-8", "replace")
-                    downloaded_data = json.loads("".join(["[", read_data, "]"]))
-                elif self._format == "arrow":
-                    # TODO
-                    downloaded_data = None
-        self._metrics[DownloadMetrics.load.value] = int(load_metric)
+        with TimerContextManager() as load_metric:
+            downloaded_data = self._load(response)
+        self._metrics[DownloadMetrics.load.value] = load_metric.get_timing_millis()
         # Process downloaded data
-        # TODO do we still parse for Arrow
-        with TimeCNM() as parse_metric:
-            parsed_data = [
-                [c(d) for c, d in zip(self._converters, r)] for r in downloaded_data
-            ]
-        self._metrics[DownloadMetrics.parse.value] = int(parse_metric)
-        return parsed_data
+        with TimerContextManager() as parse_metric:
+            parsed_data = self._parse(downloaded_data)
+        self._metrics[DownloadMetrics.parse.value] = parse_metric.get_timing_millis()
+        return iter(parsed_data)
+
+
+class ArrowResultChunk(ResultChunk):
+    def __init__(
+        self,
+        rowcount: int,
+        chunk_headers: Optional[Dict[str, str]],
+        remote_chunk_info: Optional["RemoteChunkInfo"],
+        context: "ArrowConverterContext",
+        use_dict_result: bool,
+        numpy: bool,
+        column_names: Sequence[str],
+        number_to_decimal: bool,
+    ):
+        super().__init__(
+            rowcount, chunk_headers, remote_chunk_info, column_names, use_dict_result
+        )
+        self._context = context
+        self._numpy = numpy
+        self._number_to_decimal = number_to_decimal
+
+    def __repr__(self) -> str:
+        return f"ArrowResultChunk({self.rowcount})"
+
+    def _load(
+        self, response, row_unit: str
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
+        from .arrow_iterator import PyArrowIterator
+
+        gfd = GzipFile(fileobj=response.raw, mode="r")
+
+        iter = PyArrowIterator(
+            None,
+            gfd,
+            self._context,
+            self._use_dict_result,
+            self._numpy,
+            self._number_to_decimal,
+        )
+        if row_unit == TABLE_UNIT:
+            iter.init_table_unit()
+        return iter
+
+    def parse(self, downloaded_data):
+        return downloaded_data
+
+    def _from_data(self, data: str, iter_unit: int):
+        from .arrow_iterator import PyArrowIterator
+
+        if len(data) == 0:
+            return iter([])
+
+        _iter = PyArrowIterator(
+            None,
+            io.BytesIO(b64decode(data)),
+            self._context,
+            self._use_dict_result,
+            self._numpy,
+            self._number_to_decimal,
+        )
+        if iter_unit == TABLE_UNIT:
+            _iter.init_table_unit()
+        else:
+            _iter.init_row_unit()
+        return _iter
+
+    @classmethod
+    def from_data(
+        cls,
+        data: Sequence[Sequence[Any]],
+        context: "ArrowConverterContext",
+        use_dict_result: bool,
+        numpy: bool,
+        column_names: Sequence[str],
+        number_to_decimal: bool,
+    ):
+        new_chunk = cls(
+            len(data),
+            None,
+            None,
+            context,
+            use_dict_result,
+            numpy,
+            column_names,
+            number_to_decimal,
+        )
+        new_chunk._data = data
+        return new_chunk
+
+    def _download(
+        self, **kwargs
+    ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:
+        iter_unit = kwargs.pop("iter_unit", ROW_UNIT)
+        if self._local:
+            return self._from_data(self._data, iter_unit)
+        sleep_timer = 1
+        backoff = DecorrelateJitterBackoff(1, 16)
+        for retry in range(MAX_DOWNLOAD_RETRY):
+            try:
+                with TimerContextManager() as download_metric:
+                    response = requests.get(
+                        self._remote_chunk_info.url,
+                        headers=self._chunk_headers,
+                        timeout=DOWNLOAD_TIMEOUT,
+                        stream=True,
+                    )
+                    if response.ok:
+                        break
+            except Exception:
+                if retry == MAX_DOWNLOAD_RETRY - 1:
+                    # Re-throw if we failed on the last retry
+                    raise
+                sleep_timer = backoff.next_sleep(1, sleep_timer)
+                logger.exception(
+                    f"Failed to fetch the large result set chunk "
+                    f"{self._remote_chunk_info.url} for the {retry + 1} th time, "
+                    f"backing off for {sleep_timer}s"
+                )
+                time.sleep(sleep_timer)
+
+        self._metrics[
+            DownloadMetrics.download.value
+        ] = download_metric.get_timing_millis()
+        with TimerContextManager() as load_metric:
+            loaded_data = self._load(response, iter_unit)
+        self._metrics[DownloadMetrics.load.value] = load_metric.get_timing_millis()
+        return loaded_data

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+from abc import ABC, abstractmethod
+from concurrent.futures.thread import ThreadPoolExecutor
+from itertools import chain
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional
+
+from snowflake.connector.result_chunk import DownloadMetrics, ResultChunk
+from snowflake.connector.telemetry import TelemetryField
+
+if TYPE_CHECKING:  # pragma: no cover
+    from snowflake.connector.cursor import SnowflakeCursor
+
+logger = getLogger(__name__)
+
+
+class ResultSetInterface(ABC, Iterable[List[Any]]):
+    def __init__(
+        self,
+        cursor: "SnowflakeCursor",
+        result_chunks: List["ResultChunk"],
+    ):
+        """Initialize a ResultSet with a connection and a list of ResultChunks."""
+        self.partitions = result_chunks
+        self._cursor = cursor
+        self._iter: Optional[Iterator[List[Any]]] = None
+
+    def _report_metrics(self) -> None:
+        """Report all metrics totalled up."""
+        # TODO report first chunk telemetry and maybe there's a few other kinds
+        #  of telemetry missing still
+        self._cursor._log_telemetry_job_data(
+            TelemetryField.TIME_DOWNLOADING_CHUNKS,
+            self._metrics[DownloadMetrics.download.value],
+        )
+        self._cursor._log_telemetry_job_data(
+            TelemetryField.TIME_PARSING_CHUNKS,
+            self._metrics[DownloadMetrics.parse.value],
+        )
+
+    def _pre_download(self) -> None:
+        """Pre-download some chunks at creation time."""
+
+    @property
+    def _metrics(self):
+        """Sum up all the chunks' metrics and show them together."""
+        overall_metrics: Dict[str, int] = {}
+        for c in self.partitions:
+            for n, v in c._metrics.items():
+                overall_metrics[n] = overall_metrics.get(n, 0) + v
+        return overall_metrics
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[List[Any]]:
+        """Returns a new iterator through all partitions."""
+        raise NotImplementedError
+
+    def __next__(self) -> List[Any]:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            self._report_metrics()
+
+
+class ResultSet(ResultSetInterface):
+    """This class retrieves the results of a query with the historical strategy.
+
+    It pre-downloads the first up to 4 ResultChunks (this doesn't include the 1st chunk
+    as that is embedded in the response JSON from Snowflake).
+    """
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[List[Any]]:
+        """Set up a new iterator through all partitions with first 5 chunks ready."""
+        with ThreadPoolExecutor(4) as pool:
+            results = pool.map(iter, self.partitions[1:5])
+        pre_downloaded_iters: List[Iterator[List[Any]]] = list(results)
+
+        # TODO find a better way than keeping an internal iterator
+        self._iter = chain(
+            self.partitions[0],  # Embedded by Snowflake chunk
+            *pre_downloaded_iters,  # Pre-downloaded chunks
+            *self.partitions[5:],  # On-demand downloaded chunks
+        )
+        return self
+
+
+class NoPrefetchResultSet(ResultSetInterface):
+    """This class retrieves the results of a query with the on-demand strategy.
+
+    It pre-downloads none of the chunks at creation time.
+    """
+
+    def _pre_download(self) -> None:
+        pass

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -19,7 +19,7 @@ from typing import (
 from .arrow_iterator import TABLE_UNIT
 from .errors import NotSupportedError
 from .options import installed_pandas, pandas
-from .result_chunk import ArrowResultChunk, DownloadMetrics, ResultChunk
+from .result_batch import ArrowResultBatch, DownloadMetrics, ResultBatch
 from .telemetry import TelemetryField
 from .time_util import get_time_millis
 
@@ -36,7 +36,7 @@ logger = getLogger(__name__)
 
 def result_set_iterator(
     pre_iter: Iterator[Iterator[Tuple]],
-    post_iter: Iterable["ResultChunk"],
+    post_iter: Iterable["ResultBatch"],
     final: Callable[[], None],
     **kw: Any,
 ) -> Iterator[Tuple]:
@@ -67,7 +67,7 @@ class ResultSet(Iterable[List[Any]]):
     def __init__(
         self,
         cursor: "SnowflakeCursor",
-        result_chunks: List["ResultChunk"],
+        result_chunks: List["ResultBatch"],
     ):
         """Initialize a ResultSet with a connection and a list of ResultChunks."""
         self.partitions = result_chunks
@@ -103,7 +103,7 @@ class ResultSet(Iterable[List[Any]]):
         # For now we don't support mixed ResultSets, so assume first partition's type
         #  represents them all
         head_type = type(self.partitions[0])
-        if head_type != ArrowResultChunk:
+        if head_type != ArrowResultBatch:
             raise NotSupportedError(
                 f"Trying to use arrow fetching on {head_type} which "
                 f"is not ArrowResultChunk"

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -1,22 +1,69 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 #
-from abc import ABC, abstractmethod
+from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
-from itertools import chain
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+)
 
-from snowflake.connector.result_chunk import DownloadMetrics, ResultChunk
-from snowflake.connector.telemetry import TelemetryField
+from .arrow_iterator import TABLE_UNIT
+from .errors import NotSupportedError
+from .options import installed_pandas, pandas
+from .result_chunk import ArrowResultChunk, DownloadMetrics, ResultChunk
+from .telemetry import TelemetryField
+from .time_util import get_time_millis
 
 if TYPE_CHECKING:  # pragma: no cover
     from snowflake.connector.cursor import SnowflakeCursor
 
+if installed_pandas:
+    from pyarrow import Table, concat_tables
+else:
+    Table = None
+
 logger = getLogger(__name__)
 
 
-class ResultSetInterface(ABC, Iterable[List[Any]]):
+def result_set_iterator(
+    pre_iter: Iterator[Iterator[Tuple]],
+    post_iter: Iterable["ResultChunk"],
+    final: Callable[[], None],
+    **kw: Any,
+) -> Iterator[Tuple]:
+    """Creates an iterator over some other iterators.
+
+    Very similar to itertools.chain but we need some keywords to be propagated to
+    _download functions later.
+
+    We need this to have ResultChunks fall out of usage so that they can be garbage
+    collected.
+    """
+    for it in pre_iter:
+        for element in it:
+            yield element
+    for it in post_iter:
+        for element in it._download(**kw):
+            yield element
+    final()
+
+
+class ResultSet(Iterable[List[Any]]):
+    """This class retrieves the results of a query with the historical strategy.
+
+    It pre-downloads the first up to 4 ResultChunks (this doesn't include the 1st chunk
+    as that is embedded in the response JSON from Snowflake).
+    """
+
     def __init__(
         self,
         cursor: "SnowflakeCursor",
@@ -25,26 +72,67 @@ class ResultSetInterface(ABC, Iterable[List[Any]]):
         """Initialize a ResultSet with a connection and a list of ResultChunks."""
         self.partitions = result_chunks
         self._cursor = cursor
-        self._iter: Optional[Iterator[List[Any]]] = None
+        self._iter: Optional[Iterator[Tuple]] = None
 
     def _report_metrics(self) -> None:
-        """Report all metrics totalled up."""
-        # TODO report first chunk telemetry and maybe there's a few other kinds
-        #  of telemetry missing still
-        self._cursor._log_telemetry_job_data(
-            TelemetryField.TIME_DOWNLOADING_CHUNKS,
-            self._metrics[DownloadMetrics.download.value],
-        )
-        self._cursor._log_telemetry_job_data(
-            TelemetryField.TIME_PARSING_CHUNKS,
-            self._metrics[DownloadMetrics.parse.value],
-        )
+        """Report all metrics totalled up.
 
-    def _pre_download(self) -> None:
-        """Pre-download some chunks at creation time."""
+        This includes TIME_CONSUME_LAST_RESULT, TIME_DOWNLOADING_CHUNKS and
+        TIME_PARSING_CHUNKS in that order.
+        """
+        time_consume_last_result = get_time_millis() - self._cursor._first_chunk_time
+        self._cursor._log_telemetry_job_data(
+            TelemetryField.TIME_CONSUME_LAST_RESULT, time_consume_last_result
+        )
+        metrics = self._get_metrics()
+        if DownloadMetrics.download.value in metrics:
+            self._cursor._log_telemetry_job_data(
+                TelemetryField.TIME_DOWNLOADING_CHUNKS,
+                metrics.get(DownloadMetrics.download.value),
+            )
+        if DownloadMetrics.parse.value in metrics:
+            self._cursor._log_telemetry_job_data(
+                TelemetryField.TIME_PARSING_CHUNKS,
+                metrics.get(DownloadMetrics.parse.value),
+            )
 
-    @property
-    def _metrics(self):
+    def _fetch_arrow_batches(
+        self,
+    ) -> Iterator[Table]:
+        """Fetches a all the results as Arrow Tables, chunked by Snowflake back-end."""
+        # For now we don't support mixed ResultSets, so assume first partition's type
+        #  represents them all
+        head_type = type(self.partitions[0])
+        if head_type != ArrowResultChunk:
+            raise NotSupportedError(
+                f"Trying to use arrow fetching on {head_type} which "
+                f"is not ArrowResultChunk"
+            )
+        return self._create_iter(iter_unit=TABLE_UNIT)
+
+    def _fetch_arrow_all(self):
+        """Fetches a single Arrow Table."""
+        tables = list(self._fetch_arrow_batches())
+        if tables:
+            return concat_tables(tables)
+        else:
+            return None
+
+    def _fetch_pandas_batches(self, **kwargs):
+        """Fetches Pandas dataframes in batch, where 'batch' refers to Snowflake Chunk. Thus, the batch size (the
+        number of rows in dataframe) is optimized by Snowflake Python Connector."""
+        for table in self._fetch_arrow_batches():
+            yield table.to_pandas(**kwargs)
+
+    def _fetch_pandas_all(self, **kwargs):
+        """Fetches a single Pandas dataframe."""
+        table = self._fetch_arrow_all()
+        if table:
+            return table.to_pandas(**kwargs)
+        else:
+            return pandas.DataFrame(columns=self.partitions[0]._column_names)
+
+    def _get_metrics(self) -> Dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""
         overall_metrics: Dict[str, int] = {}
         for c in self.partitions:
@@ -52,46 +140,31 @@ class ResultSetInterface(ABC, Iterable[List[Any]]):
                 overall_metrics[n] = overall_metrics.get(n, 0) + v
         return overall_metrics
 
-    @abstractmethod
-    def __iter__(self) -> Iterator[List[Any]]:
-        """Returns a new iterator through all partitions."""
-        raise NotImplementedError
+    def __iter__(self) -> Iterator[Tuple]:
+        """Returns a new iterator through all partitions with default values."""
+        return self._create_iter()
 
-    def __next__(self) -> List[Any]:
-        try:
-            return next(self._iter)
-        except StopIteration:
-            self._report_metrics()
-
-
-class ResultSet(ResultSetInterface):
-    """This class retrieves the results of a query with the historical strategy.
-
-    It pre-downloads the first up to 4 ResultChunks (this doesn't include the 1st chunk
-    as that is embedded in the response JSON from Snowflake).
-    """
-
-    @abstractmethod
-    def __iter__(self) -> Iterator[List[Any]]:
+    def _create_iter(self, **kwargs) -> Iterator[Tuple]:
         """Set up a new iterator through all partitions with first 5 chunks ready."""
+        futures: List[Future[Iterator[Tuple]]] = []
         with ThreadPoolExecutor(4) as pool:
-            results = pool.map(iter, self.partitions[1:5])
-        pre_downloaded_iters: List[Iterator[List[Any]]] = list(results)
+            for p in self.partitions[1:5]:
+                futures.append(pool.submit(p._download, **kwargs))
+        pre_downloaded_iters: List[Iterator[Tuple]] = [
+            self.partitions[0]._download(**kwargs)
+        ] + [r.result() for r in futures]
+        post_download_iters = self.partitions[5:]
 
-        # TODO find a better way than keeping an internal iterator
-        self._iter = chain(
-            self.partitions[0],  # Embedded by Snowflake chunk
-            *pre_downloaded_iters,  # Pre-downloaded chunks
-            *self.partitions[5:],  # On-demand downloaded chunks
+        return result_set_iterator(
+            iter(pre_downloaded_iters),
+            iter(post_download_iters),
+            self._report_metrics,
+            **kwargs,
         )
-        return self
 
-
-class NoPrefetchResultSet(ResultSetInterface):
-    """This class retrieves the results of a query with the on-demand strategy.
-
-    It pre-downloads none of the chunks at creation time.
-    """
-
-    def _pre_download(self) -> None:
-        pass
+    @property
+    def total_row_index(self) -> int:
+        total = 0
+        for p in self.partitions:
+            total += p.rowcount
+        return total

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -20,6 +20,7 @@ class TelemetryField(object):
     TIME_DOWNLOADING_CHUNKS = "client_time_downloading_chunks"
     TIME_PARSING_CHUNKS = "client_time_parsing_chunks"
     SQL_EXCEPTION = "client_sql_exception"
+    GET_PARTITIONS_USED = "client_get_partitions_used"
 
     # Keys for telemetry data sent through either in-band or out-of-band telemetry
     KEY_TYPE = "type"

--- a/src/snowflake/connector/time_util.py
+++ b/src/snowflake/connector/time_util.py
@@ -52,7 +52,7 @@ class DecorrelateJitterBackoff(object):
         return min(self._cap, random.randint(self._base, sleep * 3))
 
 
-class TimeCNM:
+class TimerContextManager:
     """Context manager class to easily measure execution of a code block.
 
     Once the context manager finishes, the class should be cast into an int to retrieve
@@ -60,23 +60,26 @@ class TimeCNM:
 
     Example:
 
-        with TimeCNM() as measured_time:
+        with TimerContextManager() as measured_time:
             pass
-        download_metric = int(measured_time)
+        download_metric = measured_time.get_timing_millis()
     """
 
     def __init__(self):
         self._start: Optional[int] = None
         self._end: Optional[int] = None
 
-    def __enter__(self) -> "TimeCNM":
+    def __enter__(self) -> "TimerContextManager":
         self._start = get_time_millis()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self._end = get_time_millis()
 
-    def __int__(self) -> int:
+    def get_timing_millis(self) -> int:
+        """Get measured timing in milliseconds."""
         if self._start is None or self._end is None:
-            raise Exception("Trying to get timing before TimeCNM has finished")
+            raise Exception(
+                "Trying to get timing before TimerContextManager has finished"
+            )
         return self._end - self._start

--- a/test/integ/pandas/test_logging.py
+++ b/test/integ/pandas/test_logging.py
@@ -20,9 +20,7 @@ def test_rand_table_log(caplog, conn_cnx, db_parameters):
             ).fetchall()
 
         # make assertions
-        has_batch_read = (
-            has_batch_size
-        ) = has_chunk_info = has_batch_index = has_done = False
+        has_batch_read = has_batch_size = has_chunk_info = has_batch_index = False
         for record in caplog.records:
             if "Batches read:" in record.msg:
                 has_batch_read = True
@@ -44,15 +42,5 @@ def test_rand_table_log(caplog, conn_cnx, db_parameters):
                 assert "CArrowChunkIterator.cpp" in record.filename
                 assert "next" in record.funcName
 
-            if "fetching data done" in record.msg:
-                has_done = True
-                assert "arrow_result" in record.filename  # using arrow result
-
         # each of these records appear at least once in records
-        assert (
-            has_batch_read
-            and has_batch_size
-            and has_chunk_info
-            and has_batch_index
-            and has_done
-        )
+        assert has_batch_read and has_batch_size and has_chunk_info and has_batch_index

--- a/test/integ/pandas/test_unit_arrow_chunk_iterator.py
+++ b/test/integ/pandas/test_unit_arrow_chunk_iterator.py
@@ -663,8 +663,8 @@ def iterate_over_test_chunk(
     # seek stream to begnning so that we can read from stream
     stream.seek(0)
     context = ArrowConverterContext()
-    it = PyArrowIterator(None, stream, context, False, False)
-    it.init(ROW_UNIT, False)
+    it = PyArrowIterator(None, stream, context, False, False, False)
+    it.init(ROW_UNIT)
 
     count = 0
     while True:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -32,7 +32,6 @@ from snowflake.connector.errorcode import (
     ER_INVALID_VALUE,
     ER_NOT_POSITIVE_SIZE,
 )
-from snowflake.connector.result_chunk import ArrowResultChunk, JSONResultChunk
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 from snowflake.connector.telemetry import TelemetryField
 
@@ -47,11 +46,13 @@ try:
         ER_NO_PYARROW,
         ER_NO_PYARROW_SNOWSQL,
     )
+    from snowflake.connector.result_chunk import ArrowResultChunk, JSONResultChunk
 except ImportError:
     PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = None
     ER_NO_ARROW_RESULT = None
     ER_NO_PYARROW = None
     ER_NO_PYARROW_SNOWSQL = None
+    ArrowResultChunk = JSONResultChunk = None
 
 if TYPE_CHECKING:  # pragma: no cover
     from snowflake.connector.result_chunk import ResultChunk

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -931,15 +931,16 @@ def test_empty_execution(conn):
                 cur.fetchall()
 
 
-@pytest.mark.skipolddriver(reason="There was a bug about rownumber in older versions")
 def test_rownumber(conn):
     """Checks whether rownumber is returned as expected."""
     with conn() as cnx:
         with cnx.cursor() as cur:
-            assert cur.execute("select * from values (1), (2)").fetchone() == (1,)
-            assert cur.rownumber == 1
+            assert cur.execute("select * from values (1), (2)")
+            assert cur.rownumber is None
+            assert cur.fetchone() == (1,)
+            assert cur.rownumber == 0
             assert cur.fetchone() == (2,)
-            assert cur.rownumber == 2
+            assert cur.rownumber == 1
 
 
 def test_values_set(conn):

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -923,8 +923,7 @@ def test_empty_execution(conn):
                 cur.fetchall()
 
 
-# There was a bug about rownumber in older versions
-@pytest.mark.skipolddriver
+@pytest.mark.skipolddriver(reason="There was a bug about rownumber in older versions")
 def test_rownumber(conn):
     """Checks whether rownumber is returned as expected."""
     with conn() as cnx:
@@ -1195,3 +1194,6 @@ def test__log_telemetry_job_data(conn_cnx, caplog):
         logging.WARNING,
         "Cursor failed to log to telemetry. Connection object may be None.",
     ) in caplog.record_tuples
+
+
+# def test_

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1213,7 +1213,7 @@ def test__log_telemetry_job_data(conn_cnx, caplog):
         ("arrow", ArrowResultBatch),
     ),
 )
-def test_resultbatch_pickling(
+def test_resultbatch(
     conn_cnx,
     result_format,
     expected_chunk_type,
@@ -1250,7 +1250,7 @@ def test_resultbatch_pickling(
             )
     post_pickle_partitions: List["ResultBatch"] = pickle.loads(pickle_str)
     total_rows = 0
-    # Make sure the partitions can be iterated over individually
+    # Make sure the batches can be iterated over individually
     for partition in post_pickle_partitions:
         for row in partition:
             col1 = row[0]
@@ -1258,7 +1258,7 @@ def test_resultbatch_pickling(
             total_rows += 1
     assert total_rows == rowcount
     total_rows = 0
-    # Make sure the partitions can be iterated over again
+    # Make sure the batches can be iterated over again
     for partition in post_pickle_partitions:
         for row in partition:
             col1 = row[0]

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -931,16 +931,18 @@ def test_empty_execution(conn):
                 cur.fetchall()
 
 
+@pytest.mark.skipolddriver(reason="There was a bug about rownumber in older versions")
 def test_rownumber(conn):
     """Checks whether rownumber is returned as expected."""
     with conn() as cnx:
         with cnx.cursor() as cur:
-            assert cur.execute("select * from values (1), (2)")
             assert cur.rownumber is None
-            assert cur.fetchone() == (1,)
+            assert cur.execute("select * from values (1), (2)")
             assert cur.rownumber == 0
-            assert cur.fetchone() == (2,)
+            assert cur.fetchone() == (1,)
             assert cur.rownumber == 1
+            assert cur.fetchone() == (2,)
+            assert cur.rownumber == 2
 
 
 def test_values_set(conn):

--- a/test/integ/test_large_result_set.py
+++ b/test/integ/test_large_result_set.py
@@ -115,11 +115,7 @@ def test_query_large_result_set_n_threads(
 def test_query_large_result_set(conn_cnx, db_parameters, ingest_data):
     """[s3] Gets Large Result set."""
     sql = "select * from {name} order by 1".format(name=db_parameters["name"])
-    with conn_cnx(
-        user=db_parameters["user"],
-        account=db_parameters["account"],
-        password=db_parameters["password"],
-    ) as cnx:
+    with conn_cnx() as cnx:
         telemetry_data = []
         add_log_mock = Mock()
         add_log_mock.side_effect = lambda datum: telemetry_data.append(datum)
@@ -151,7 +147,9 @@ def test_query_large_result_set(conn_cnx, db_parameters, ingest_data):
         expected = [
             TelemetryField.TIME_CONSUME_FIRST_RESULT,
             TelemetryField.TIME_CONSUME_LAST_RESULT,
-            TelemetryField.TIME_PARSING_CHUNKS,
+            # NOTE: Arrow doesn't do parsing like how JSON does, so depending on what
+            #  way this is executed only look for JSON result sets
+            # TelemetryField.TIME_PARSING_CHUNKS,
             TelemetryField.TIME_DOWNLOADING_CHUNKS,
         ]
         for field in expected:

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -78,7 +78,7 @@ def test_put_copy0(conn_cnx, db_parameters, from_path, file_src):
         run(
             cnx,
             """
-create table {name} (
+create or replace table {name} (
 aa int,
 dt date,
 ts timestamp,

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -14,6 +14,7 @@ from typing import Optional
 import pytest
 
 from snowflake.connector.cursor import SnowflakeCursor
+
 from ..generate_test_files import generate_k_lines_of_n_files
 from ..integ_helpers import put
 
@@ -83,10 +84,8 @@ def test_put_small_data_use_s3_regional_url(
         number_of_lines=number_of_lines,
         from_path=from_path,
     )
-    assert (
-        put_cursor._connection._session_parameters.get(
-            "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1"
-        )
+    assert put_cursor._connection._session_parameters.get(
+        "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1"
     )
 
 
@@ -99,7 +98,9 @@ def _put_get_user_stage_s3_regional_url(
     from_path=True,
 ) -> Optional[SnowflakeCursor]:
     put_cursor: Optional[SnowflakeCursor] = None
-    with conn_cnx(role="accountadmin",) as cnx:
+    with conn_cnx(
+        role="accountadmin",
+    ) as cnx:
         cnx.cursor().execute(
             "alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;"
         )
@@ -108,7 +109,9 @@ def _put_get_user_stage_s3_regional_url(
             tmpdir, conn_cnx, db_parameters, number_of_files, number_of_lines, from_path
         )
     finally:
-        with conn_cnx(role="accountadmin",) as cnx:
+        with conn_cnx(
+            role="accountadmin",
+        ) as cnx:
             cnx.cursor().execute(
                 "alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;"
             )


### PR DESCRIPTION
SNOW-34276
Fixing bug in `rownumber`.

As per https://www.python.org/dev/peps/pep-0249/#rownumber

> The next fetch operation will fetch the row indexed by .rownumber in that sequence.

So now if you take a look at: https://github.com/snowflakedb/snowflake-connector-python/blob/e6137a05d184ec095bd6be50ff1bbd4e131064f4/test/integ/test_cursor.py#L933

You can see that `rownumber` returns what we fetched in the previous fetch operation.

To be merged after #688 