### PR TITLE
SNOW-351142 explicitly set python version to 3.6 for fix_lint

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.6'
       - name: Display Python version
         run: python -c "import sys; import os; print(\"\n\".join(os.environ[\"PATH\"].split(os.pathsep))); print(sys.version); print(sys.executable);"
       - name: Upgrade setuptools and pip

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -14,6 +14,7 @@ from typing import Optional
 import pytest
 
 from snowflake.connector.cursor import SnowflakeCursor
+
 from ..generate_test_files import generate_k_lines_of_n_files
 from ..integ_helpers import put
 
@@ -83,10 +84,8 @@ def test_put_small_data_use_s3_regional_url(
         number_of_lines=number_of_lines,
         from_path=from_path,
     )
-    assert (
-        put_cursor._connection._session_parameters.get(
-            "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1"
-        )
+    assert put_cursor._connection._session_parameters.get(
+        "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1"
     )
 
 
@@ -99,7 +98,9 @@ def _put_get_user_stage_s3_regional_url(
     from_path=True,
 ) -> Optional[SnowflakeCursor]:
     put_cursor: Optional[SnowflakeCursor] = None
-    with conn_cnx(role="accountadmin",) as cnx:
+    with conn_cnx(
+        role="accountadmin",
+    ) as cnx:
         cnx.cursor().execute(
             "alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = true;"
         )
@@ -108,7 +109,9 @@ def _put_get_user_stage_s3_regional_url(
             tmpdir, conn_cnx, db_parameters, number_of_files, number_of_lines, from_path
         )
     finally:
-        with conn_cnx(role="accountadmin",) as cnx:
+        with conn_cnx(
+            role="accountadmin",
+        ) as cnx:
             cnx.cursor().execute(
                 "alter account set ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1 = false;"
             )


### PR DESCRIPTION
SNOW-351142

Hotfixing `fix_lint` step for GH actions, it also fixes a linting issue in `master`, but to see it skipping beforehand see this example: https://github.com/snowflakedb/snowflake-connector-python/runs/2460860144?check_suite_focus=true and the run on this PR