### PR TITLE
SNOW-296993 fixing import statement for SnowSQL

### DIFF
--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,7 +4,6 @@
 
 # distutils: language = c++
 # cython: language_level=3
-from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *
@@ -13,24 +12,15 @@ from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector
 
-from snowflake.connector.snow_logging import getSnowLogger
-
+from .constants import ROW_UNIT, TABLE_UNIT
 from .errorcode import (
     ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
     ER_FAILED_TO_READ_ARROW_STREAM,
 )
 from .errors import Error, InterfaceError, OperationalError
+from .snow_logging import getSnowLogger
 
 snow_logger = getSnowLogger(__name__)
-
-
-'''
-the unit in this iterator
-EMPTY_UNIT: default
-ROW_UNIT: fetch row by row if the user call `fetchone()`
-TABLE_UNIT: fetch one arrow table if the user call `fetch_pandas()`
-'''
-ROW_UNIT, TABLE_UNIT = 'row', 'table'
 
 
 cdef extern from "cpp/ArrowIterator/CArrowIterator.hpp" namespace "sf":

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -190,3 +190,10 @@ class QueryStatus(Enum):
     RESTARTED = 10
     BLOCKED = 11
     NO_DATA = 12
+
+
+# ArrowResultChunk constants the unit in this iterator
+# EMPTY_UNIT: default
+# ROW_UNIT: fetch row by row if the user call `fetchone()`
+# TABLE_UNIT: fetch one arrow table if the user call `fetch_pandas()`
+ROW_UNIT, TABLE_UNIT = "row", "table"

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -61,7 +61,7 @@ except ImportError:
     pyarrow = None
 
 try:
-    from .arrow_iterator import TABLE_UNIT, PyArrowIterator  # NOQA
+    from .arrow_iterator import PyArrowIterator  # NOQA
 
     CAN_USE_ARROW_RESULT_FORMAT = True
 except ImportError as e:  # pragma: no cover

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from .arrow_context import ArrowConverterContext
-from .arrow_iterator import ROW_UNIT, TABLE_UNIT
+from .constants import ROW_UNIT, TABLE_UNIT
 from .errorcode import ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE
 from .errors import Error, InterfaceError
 from .options import installed_pandas

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from .arrow_iterator import TABLE_UNIT
+from .constants import TABLE_UNIT
 from .errors import NotSupportedError
 from .options import installed_pandas, pandas
 from .result_batch import (

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -13,6 +13,8 @@ from decimal import Decimal
 import numpy
 import pytest
 
+from snowflake.connector.constants import TABLE_UNIT
+
 try:
     from snowflake.connector.options import installed_pandas, pandas, pyarrow  # NOQA
 except ImportError:
@@ -22,7 +24,7 @@ except ImportError:
 
 
 try:
-    from snowflake.connector.arrow_iterator import TABLE_UNIT, PyArrowIterator  # NOQA
+    from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
 
     no_arrow_iterator_ext = False
 except ImportError:

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -13,7 +13,11 @@ from decimal import Decimal
 import numpy
 import pytest
 
-from snowflake.connector.constants import TABLE_UNIT
+try:
+    from snowflake.connector.constants import TABLE_UNIT
+except ImportError:
+    # This is because of olddriver tests
+    TABLE_UNIT = "table"
 
 try:
     from snowflake.connector.options import installed_pandas, pandas, pyarrow  # NOQA


### PR DESCRIPTION
SNOW-296993
SnowSQL doesn't have access to our compiled code, so the following import statement broke SnowSQL build:
https://github.com/snowflakedb/snowflake-connector-python/blob/d7fd76a55b5b768f3e8113afb2574b3b843d5679/src/snowflake/connector/result_batch.py#L26

This PR fixes this issue. To observe the issue please see: http://172.16.20.10:8080/job/Snowsql-Mac64-Test/2605/console

I'll try to see if I could run this test before I flip the review to be ready on this branch