### PR TITLE
SNOW-296993 fixing a ResultBatch telemetry bug

### DIFF
--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -99,10 +99,13 @@ class ResultSet(Iterable[List[Any]]):
         This includes TIME_CONSUME_LAST_RESULT, TIME_DOWNLOADING_CHUNKS and
         TIME_PARSING_CHUNKS in that order.
         """
-        time_consume_last_result = get_time_millis() - self._cursor._first_chunk_time
-        self._cursor._log_telemetry_job_data(
-            TelemetryField.TIME_CONSUME_LAST_RESULT, time_consume_last_result
-        )
+        if self._cursor._first_chunk_time is not None:
+            time_consume_last_result = (
+                get_time_millis() - self._cursor._first_chunk_time
+            )
+            self._cursor._log_telemetry_job_data(
+                TelemetryField.TIME_CONSUME_LAST_RESULT, time_consume_last_result
+            )
         metrics = self._get_metrics()
         if DownloadMetrics.download.value in metrics:
             self._cursor._log_telemetry_job_data(

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -63,7 +63,7 @@ class TelemetryClient(object):
         self._lock = Lock()
         self._enabled = True
 
-    def add_log_to_batch(self, telemetry_data):
+    def add_log_to_batch(self, telemetry_data: "TelemetryData") -> None:
         if self._is_closed:
             raise Exception("Attempted to add log when TelemetryClient is closed")
         elif not self._enabled:
@@ -76,7 +76,7 @@ class TelemetryClient(object):
         if len(self._log_batch) >= self._flush_size:
             self.send_batch()
 
-    def try_add_log_to_batch(self, telemetry_data):
+    def try_add_log_to_batch(self, telemetry_data: "TelemetryData") -> None:
         try:
             self.add_log_to_batch(telemetry_data)
         except Exception:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1225,6 +1225,7 @@ def test_resultbatch(
     conn_cnx,
     result_format,
     expected_chunk_type,
+    capture_sf_telemetry,
 ):
     """This test checks the following things:
     1. After executing a query can we pickle the result batches
@@ -1239,25 +1240,23 @@ def test_resultbatch(
             "python_connector_query_result_format": result_format,
         }
     ) as con:
-        # TODO: add a fixture to easily capture telemetry data
-        telemetry_data = []
-        add_log_mock = mock.Mock()
-        add_log_mock.side_effect = lambda datum: telemetry_data.append(datum)
-        con._telemetry.add_log_to_batch = add_log_mock
-        with con.cursor() as cur:
-            cur.execute(f"select seq4() from table(generator(rowcount => {rowcount}));")
-            assert cur._result_set.total_row_index() == rowcount
-            pre_pickle_partitions = cur.get_result_batches()
-            assert len(pre_pickle_partitions) > 1
-            assert pre_pickle_partitions is not None
-            assert all(
-                isinstance(p, expected_chunk_type) for p in pre_pickle_partitions
-            )
-            pickle_str = pickle.dumps(pre_pickle_partitions)
-            assert any(
-                t.message["type"] == TelemetryField.GET_PARTITIONS_USED
-                for t in telemetry_data
-            )
+        with capture_sf_telemetry.patch_connection(con) as telemetry_data:
+            with con.cursor() as cur:
+                cur.execute(
+                    f"select seq4() from table(generator(rowcount => {rowcount}));"
+                )
+                assert cur._result_set.total_row_index() == rowcount
+                pre_pickle_partitions = cur.get_result_batches()
+                assert len(pre_pickle_partitions) > 1
+                assert pre_pickle_partitions is not None
+                assert all(
+                    isinstance(p, expected_chunk_type) for p in pre_pickle_partitions
+                )
+                pickle_str = pickle.dumps(pre_pickle_partitions)
+                assert any(
+                    t.message["type"] == TelemetryField.GET_PARTITIONS_USED
+                    for t in telemetry_data.records
+                )
     post_pickle_partitions: List["ResultBatch"] = pickle.loads(pickle_str)
     total_rows = 0
     # Make sure the batches can be iterated over individually


### PR DESCRIPTION
SNOW-296993

SnowSQL builds have been broken since Friday because the telemetry `_first_chunk_time` is not always recorded.
This PR skips reporting that Telemetry when it needs to and it also introduces a fixture that we can use to easily capture Telemetry messages during testing (it can also be used to disable telemetry by not propagating the messages to the real telemetry objects).