### PR TITLE
SNOW-353595 updating build and test pipeline

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -244,11 +244,6 @@ jobs:
       - name: Show wheels downloaded
         run: ls -lh dist
         shell: bash
-      - name: Remove manylinux2010 wheel
-        run: |
-          rm dist/*manylinux2010*.whl
-          ls -lh dist
-        if: matrix.os.download_name == 'linux'
       - name: Upgrade setuptools, pip and wheel
         run: python -m pip install -U setuptools pip wheel
       - name: Install tox


### PR DESCRIPTION
SNOW-353595

It looks like `auditwheel` now tags the same wheel with multiple tags instead of creating multiple wheel files tagged for one specific `manylinux` version.