### PR TITLE
[SNOW-344429] Adds make_pd_writer

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -217,6 +217,24 @@ def make_pd_writer(
     ],
     None,
 ]:
+    """This returns a pd_writer with the desired arguments
+
+        Example usage:
+            import pandas as pd
+            from snowflake.connector.pandas_tools import pd_writer
+
+            sf_connector_version_df = pd.DataFrame([('snowflake-connector-python', '1.0')], columns=['NAME', 'NEWEST_VERSION'])
+            sf_connector_version_df.to_sql('driver_versions', engine, index=False, method=make_pd_writer())
+
+            # to use quote_identifiers=False,
+            from functools import partial
+            sf_connector_version_df.to_sql(
+                'driver_versions', engine, index=False, method=make_pd_writer(quote_identifiers=False)))
+
+    Args:
+        quote_identifiers: if True (default), the pd_writer will pass quote identifiers to Snowflake.
+            If False, the created pd_writer will not quote identifiers (and typically coerced to uppercase by Snowflake)
+    """
     return partial(pd_writer, quote_identifiers=quote_identifiers)
 
 
@@ -236,10 +254,7 @@ def pd_writer(
             sf_connector_version_df = pd.DataFrame([('snowflake-connector-python', '1.0')], columns=['NAME', 'NEWEST_VERSION'])
             sf_connector_version_df.to_sql('driver_versions', engine, index=False, method=pd_writer)
 
-            # to use quote_identifiers=False
-            from functools import partial
-            sf_connector_version_df.to_sql(
-                'driver_versions', engine, index=False, method=partial(pd_writer, quote_identifiers=False))
+            # to use quote_identifiers=False, see `make_pd_writer`
 
     Args:
         table: Pandas package's table object.

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -217,7 +217,7 @@ def make_pd_writer(
     ],
     None,
 ]:
-    """This returns a pd_writer with the desired arguments
+    """This returns a pd_writer with the desired arguments.
 
         Example usage:
             import pandas as pd

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -17,9 +17,8 @@ from ...lazy_var import LazyVar
 
 try:
     from snowflake.connector.options import pandas  # NOQA
-    from snowflake.connector.pandas_tools import make_pd_writer, write_pandas  # NOQA
+    from snowflake.connector.pandas_tools import write_pandas  # NOQA
 except ImportError:
-    make_pd_writer = None
     pandas = None
     write_pandas = None
 


### PR DESCRIPTION
This PR addresses changes requested in https://snowflakecomputing.atlassian.net/browse/SNOW-344429.

I followed Mark's suggestion of adding a generator function that takes an argument - allowing the user to set `quote_identifiers` as they wish. The docstring in the PR shows an example of how to use the new generator function.

The generator function uses `partial` to create a function with `quote_identifiers` set.
The test for this function can be found at: https://github.com/snowflakedb/snowflake/pull/28037

The test written passes precommit, as can be seen here: https://ci75.int.snowflakecomputing.com/job/RT-Precommit/974/