### PR TITLE
add method to check if arrow is part of the current query result

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -808,6 +808,14 @@ class SnowflakeCursor(object):
                 },
             )
 
+    def arrow_avail(self):
+        """
+        Check to see if current query result is an arrow compatible and if pyarrow is installed.
+        Use to safely call fetch_pandas_X() methods
+        """
+        global pyarrow
+        return pyarrow is not None and self._query_result_format == "arrow"
+
     def query_result(self, qid):
         url = "/queries/{qid}/result".format(qid=qid)
         ret = self._connection.rest.request(url=url, method="get")


### PR DESCRIPTION
Currently `fetch_pandas_all()` fails if the query result isn't an arrow data. This new method allows a user to check if the data is available to be fetched using `fetch_pandas_all` without calling and failing. This allows a user to use `fetchall` if the result isn't arrow compatible.