### PR TITLE
SNOW-169178 Replace pointers with UniqueRefs

### DIFF
--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -441,11 +441,13 @@ void DictCArrowChunkIterator::createRowPyObject()
   m_latestReturnedRow.reset(PyDict_New());
   for (int i = 0; i < m_currentSchema->num_fields(); i++)
   {
-    PyObject* value = m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch);
-    if (value != nullptr)
+    py::UniqueRef value = py::UniqueRef(m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch));
+    if (!value.empty())
     {
-      PyDict_SetItemString(m_latestReturnedRow.get(), m_currentSchema->field(i)->name().c_str(), value);
-      Py_DECREF(value);
+      PyDict_SetItemString(
+          m_latestReturnedRow.get(),
+          m_currentSchema->field(i)->name().c_str(),
+          value.get());
     }
   }
   return;

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -89,6 +89,7 @@ void CArrowChunkIterator::createRowPyObject()
   m_latestReturnedRow.reset(PyTuple_New(m_columnCount));
   for (int i = 0; i < m_columnCount; i++)
   {
+    // PyTuple_SET_ITEM steals a reference to the PyObject returned by toPyObject below
     PyTuple_SET_ITEM(
         m_latestReturnedRow.get(), i,
         m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch));
@@ -444,6 +445,7 @@ void DictCArrowChunkIterator::createRowPyObject()
     py::UniqueRef value = py::UniqueRef(m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch));
     if (!value.empty())
     {
+      // PyDict_SetItemString doesn't steal a reference to value.get().
       PyDict_SetItemString(
           m_latestReturnedRow.get(),
           m_currentSchema->field(i)->name().c_str(),

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -168,9 +168,8 @@ m_context(context),
 m_pyTableObjRef(nullptr),
 m_convert_number_to_decimal(number_to_decimal)
 {
-  PyObject* tz = PyObject_GetAttrString(m_context, "_timezone");
-  PyArg_Parse(tz, "s", &m_timezone);
-  Py_XDECREF(tz);
+  py::UniqueRef tz = py::UniqueRef(PyObject_GetAttrString(m_context, "_timezone"));
+  PyArg_Parse(tz.get(), "s", &m_timezone);
 }
 
 std::shared_ptr<ReturnVal> CArrowTableIterator::next()

--- a/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/IColumnConverter.hpp
@@ -17,6 +17,7 @@ class IColumnConverter
 public:
   IColumnConverter() = default;
   virtual ~IColumnConverter() = default;
+  // The caller is responsible for calling DECREF on the returned pointer
   virtual PyObject* toPyObject(int64_t rowIndex) const = 0;
 };
 }


### PR DESCRIPTION
This PR addresses changes requested in [SNOW-169178](https://snowflakecomputing.atlassian.net/browse/SNOW-169178).

Replaces raw PyObject*s with UniqueRefs (a wrapper for PyObject*). When the local variable goes out of scope, the destructor of UniqueRef is called, ultimately calling XDECREF on the pointer.

Verified that memory leaks are not happening using sample code: https://gist.github.com/schitlurharidas/25b66e6220923597fb019bffaf6749a5 
