### PR TITLE
SNOW-177082 Adds `to_arrow` and `to_pandas`, refactors `result_set` and `result_batch`

### DIFF
--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -13,7 +13,7 @@ from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector
 
-from .constants import ROW_UNIT, TABLE_UNIT
+from .constants import IterUnit
 from .errorcode import (
     ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE,
     ER_FAILED_TO_READ_ARROW_STREAM,
@@ -261,9 +261,9 @@ cdef class PyArrowIterator(EmptyPyArrowIterator):
             return ret
 
     def init(self, str iter_unit):
-        if iter_unit == ROW_UNIT:
+        if iter_unit == IterUnit.ROW_UNIT.value:
             self.init_row_unit()
-        elif iter_unit == TABLE_UNIT:
+        elif iter_unit == IterUnit.TABLE_UNIT.value:
             self.init_table_unit()
         self.unit = iter_unit
 

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,6 +4,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,7 +4,6 @@
 
 # distutils: language = c++
 # cython: language_level=3
-from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -196,4 +196,7 @@ class QueryStatus(Enum):
 # EMPTY_UNIT: default
 # ROW_UNIT: fetch row by row if the user call `fetchone()`
 # TABLE_UNIT: fetch one arrow table if the user call `fetch_pandas()`
-ROW_UNIT, TABLE_UNIT = "row", "table"
+@unique
+class IterUnit(Enum):
+    ROW_UNIT = "row"
+    TABLE_UNIT = "table"

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -845,7 +845,7 @@ class SnowflakeCursor(object):
 
     def fetch_arrow_batches(self) -> Iterator[Table]:
         self.check_can_use_arrow_resultset()
-        if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
+        if self._query_result_format != "arrow":
             raise NotSupportedError
         self._log_telemetry_job_data(
             TelemetryField.ARROW_FETCH_BATCHES, TelemetryData.TRUE
@@ -854,7 +854,7 @@ class SnowflakeCursor(object):
 
     def fetch_arrow_all(self) -> Optional[Table]:
         self.check_can_use_arrow_resultset()
-        if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
+        if self._query_result_format != "arrow":
             raise NotSupportedError
         self._log_telemetry_job_data(TelemetryField.ARROW_FETCH_ALL, TelemetryData.TRUE)
         return self._result_set._fetch_arrow_all()
@@ -862,7 +862,7 @@ class SnowflakeCursor(object):
     def fetch_pandas_batches(self, **kwargs) -> Iterator["pandas.DataFrame"]:
         """Fetches a single Arrow Table."""
         self.check_can_use_pandas()
-        if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
+        if self._query_result_format != "arrow":
             raise NotSupportedError
         self._log_telemetry_job_data(
             TelemetryField.PANDAS_FETCH_BATCHES, TelemetryData.TRUE

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -62,6 +62,7 @@ except ImportError:
 
 try:
     from .arrow_iterator import PyArrowIterator  # NOQA
+
     CAN_USE_ARROW_RESULT_FORMAT = True
 except ImportError as e:  # pragma: no cover
     logger.debug(

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -62,7 +62,6 @@ except ImportError:
 
 try:
     from .arrow_iterator import PyArrowIterator  # NOQA
-
     CAN_USE_ARROW_RESULT_FORMAT = True
 except ImportError as e:  # pragma: no cover
     logger.debug(

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -844,7 +844,7 @@ class SnowflakeCursor(object):
         return self
 
     def fetch_arrow_batches(self) -> Iterator[Table]:
-        self.check_can_use_pandas()
+        self.check_can_use_arrow_resultset()
         if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
             raise NotSupportedError
         self._log_telemetry_job_data(
@@ -853,7 +853,7 @@ class SnowflakeCursor(object):
         return self._result_set._fetch_arrow_batches()
 
     def fetch_arrow_all(self) -> Optional[Table]:
-        self.check_can_use_pandas()
+        self.check_can_use_arrow_resultset()
         if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
             raise NotSupportedError
         self._log_telemetry_job_data(TelemetryField.ARROW_FETCH_ALL, TelemetryData.TRUE)

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -42,6 +42,7 @@ from .errors import (
     ProgrammingError,
 )
 from .file_transfer_agent import SnowflakeFileTransferAgent
+from .options import installed_pandas, pandas
 from .sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 from .telemetry import TelemetryData, TelemetryField
 from .time_util import get_time_millis
@@ -54,9 +55,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = getLogger(__name__)
 
-try:
-    import pyarrow
-except ImportError:
+if installed_pandas:
+    from pyarrow import Table
+else:
     logger.debug("Failed to import pyarrow. Cannot use pandas fetch API")
     pyarrow = None
 
@@ -789,9 +790,7 @@ class SnowflakeCursor(object):
             )
 
     def check_can_use_pandas(self):
-        global pyarrow
-
-        if pyarrow is None:
+        if not installed_pandas:
             msg = (
                 "Optional dependency: 'pyarrow' is not installed, please see the following link for install "
                 "instructions: https://docs.snowflake.com/en/user-guide/python-connector-pandas.html#installation"
@@ -844,41 +843,39 @@ class SnowflakeCursor(object):
             )
         return self
 
-    def fetch_arrow_batches(self):
+    def fetch_arrow_batches(self) -> Iterator[Table]:
         self.check_can_use_pandas()
         if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
             raise NotSupportedError
         self._log_telemetry_job_data(
-            TelemetryField.ARROW_FETCH_BATCHES, TelemetryData.DUMMY_VALUE
+            TelemetryField.ARROW_FETCH_BATCHES, TelemetryData.TRUE
         )
         return self._result_set._fetch_arrow_batches()
 
-    def fetch_arrow_all(self):
+    def fetch_arrow_all(self) -> Optional[Table]:
         self.check_can_use_pandas()
         if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
             raise NotSupportedError
-        self._log_telemetry_job_data(
-            TelemetryField.ARROW_FETCH_ALL, TelemetryData.DUMMY_VALUE
-        )
+        self._log_telemetry_job_data(TelemetryField.ARROW_FETCH_ALL, TelemetryData.TRUE)
         return self._result_set._fetch_arrow_all()
 
-    def fetch_pandas_batches(self, **kwargs):
+    def fetch_pandas_batches(self, **kwargs) -> Iterator["pandas.DataFrame"]:
         """Fetches a single Arrow Table."""
         self.check_can_use_pandas()
         if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
             raise NotSupportedError
         self._log_telemetry_job_data(
-            TelemetryField.PANDAS_FETCH_BATCHES, TelemetryData.DUMMY_VALUE
+            TelemetryField.PANDAS_FETCH_BATCHES, TelemetryData.TRUE
         )
         return self._result_set._fetch_pandas_batches(**kwargs)
 
-    def fetch_pandas_all(self, **kwargs):
+    def fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":
         """Fetch Pandas dataframes in batches, where 'batch' refers to Snowflake Chunk."""
         self.check_can_use_pandas()
         if self._query_result_format != "arrow":
             raise NotSupportedError
         self._log_telemetry_job_data(
-            TelemetryField.PANDAS_FETCH_ALL, TelemetryData.DUMMY_VALUE
+            TelemetryField.PANDAS_FETCH_ALL, TelemetryData.TRUE
         )
         return self._result_set._fetch_pandas_all(**kwargs)
 
@@ -1160,7 +1157,7 @@ class SnowflakeCursor(object):
         if self._result_set is None:
             return None
         self._log_telemetry_job_data(
-            TelemetryField.GET_PARTITIONS_USED, TelemetryData.DUMMY_VALUE
+            TelemetryField.GET_PARTITIONS_USED, TelemetryData.TRUE
         )
         return self._result_set.batches
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -59,7 +59,7 @@ if installed_pandas:
     from pyarrow import Table
 else:
     logger.debug("Failed to import pyarrow. Cannot use pandas fetch API")
-    pyarrow = None
+    Table = None
 
 try:
     from .arrow_iterator import PyArrowIterator  # NOQA

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -843,6 +843,24 @@ class SnowflakeCursor(object):
             )
         return self
 
+    def fetch_arrow_batches(self):
+        self.check_can_use_pandas()
+        if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
+            raise NotSupportedError
+        self._log_telemetry_job_data(
+            TelemetryField.ARROW_FETCH_BATCHES, TelemetryData.DUMMY_VALUE
+        )
+        return self._result_set._fetch_arrow_batches()
+
+    def fetch_arrow_all(self):
+        self.check_can_use_pandas()
+        if self._query_result_format != "arrow":  # TODO: or pandas isn't imported
+            raise NotSupportedError
+        self._log_telemetry_job_data(
+            TelemetryField.ARROW_FETCH_ALL, TelemetryData.DUMMY_VALUE
+        )
+        return self._result_set._fetch_arrow_all()
+
     def fetch_pandas_batches(self, **kwargs):
         """Fetches a single Arrow Table."""
         self.check_can_use_pandas()
@@ -851,8 +869,7 @@ class SnowflakeCursor(object):
         self._log_telemetry_job_data(
             TelemetryField.PANDAS_FETCH_BATCHES, TelemetryData.DUMMY_VALUE
         )
-        for df in self._result_set._fetch_pandas_batches(**kwargs):
-            yield df
+        return self._result_set._fetch_pandas_batches(**kwargs)
 
     def fetch_pandas_all(self, **kwargs):
         """Fetch Pandas dataframes in batches, where 'batch' refers to Snowflake Chunk."""

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -592,13 +592,13 @@ class ArrowResultBatch(ResultBatch):
             return self._create_iter(iter_unit=iter_unit)
 
     def _get_pandas_iter(self, **kwargs) -> Iterator["pandas.DataFrame"]:
-        """Returns an iterator for this batch which yields a pandas DataFrame"""
+        """An iterator for this batch which yields a pandas DataFrame"""
         yield self.to_pandas(**kwargs)
 
     def to_pandas(self, **kwargs) -> "pandas.DataFrame":
         """Returns this batch as a pandas DataFrame"""
         self.check_can_use_pandas()
-        table = next(self._get_arrow_iter(), None)
+        table = next(self._get_arrow_iter())
         if table:
             return table.to_pandas(**kwargs)
         return pandas.DataFrame(columns=self._column_names)
@@ -609,4 +609,4 @@ class ArrowResultBatch(ResultBatch):
 
     def to_arrow(self) -> Optional[Table]:
         """Returns this batch as a pyarrow Table"""
-        return next(self.get_arrow_iter(), None)
+        return next(self._get_arrow_iter(), None)

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -583,14 +583,16 @@ class ArrowResultBatch(ResultBatch):
     def to_pandas(self, **kwargs) -> "pandas.DataFrame":
         """Returns this batch as a pandas DataFrame"""
         self._check_can_use_pandas()
-        table = next(self._get_arrow_iter())
+        table = self.to_arrow()
         if table:
             return table.to_pandas(**kwargs)
         return pandas.DataFrame(columns=self._column_names)
 
     def _get_pandas_iter(self, **kwargs) -> Iterator["pandas.DataFrame"]:
         """An iterator for this batch which yields a pandas DataFrame"""
-        yield self.to_pandas(**kwargs)
+        dataframe = self.to_pandas(**kwargs)
+        if not dataframe.empty:
+            yield dataframe
 
     def create_iter(
         self, **kwargs

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -118,7 +118,7 @@ class ResultSet(Iterable[List[Any]]):
                 metrics.get(DownloadMetrics.parse.value),
             )
 
-    def __can_create_arrow_iter(self) -> None:
+    def _can_create_arrow_iter(self) -> None:
         # For now we don't support mixed ResultSets, so assume first partition's type
         #  represents them all
         head_type = type(self.batches[0])
@@ -132,7 +132,7 @@ class ResultSet(Iterable[List[Any]]):
         self,
     ) -> Iterator[Table]:
         """Fetches all the results as Arrow Tables, chunked by Snowflake back-end."""
-        self.__can_create_arrow_iter()
+        self._can_create_arrow_iter()
         return self._create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="arrow")
 
     def _fetch_arrow_all(self) -> Optional[Table]:
@@ -149,7 +149,7 @@ class ResultSet(Iterable[List[Any]]):
         Thus, the batch size (the number of rows in dataframe) is determined by
         Snowflake's back-end.
         """
-        self.__can_create_arrow_iter()
+        self._can_create_arrow_iter()
         return self._create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="pandas")
 
     def _fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -155,7 +155,9 @@ class ResultSet(Iterable[List[Any]]):
     def _fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":
         """Fetches a single Pandas dataframe."""
         dataframes = list(self._fetch_pandas_batches())
-        return pandas.concat(dataframes, **kwargs)
+        if dataframes:
+            return pandas.concat(dataframes, **kwargs)
+        return pandas.DataFrame(columns=self.batches[0]._column_names)
 
     def _get_metrics(self) -> Dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -118,7 +118,7 @@ class ResultSet(Iterable[List[Any]]):
                 metrics.get(DownloadMetrics.parse.value),
             )
 
-    def __can_create_arrow_iter(self):
+    def __can_create_arrow_iter(self) -> None:
         # For now we don't support mixed ResultSets, so assume first partition's type
         #  represents them all
         head_type = type(self.batches[0])
@@ -135,7 +135,7 @@ class ResultSet(Iterable[List[Any]]):
         self.__can_create_arrow_iter()
         return self._create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="arrow")
 
-    def _fetch_arrow_all(self):
+    def _fetch_arrow_all(self) -> Optional[Table]:
         """Fetches a single Arrow Table from all of the ``ResultBatch``."""
         tables = list(self._fetch_arrow_batches())
         if tables:
@@ -143,7 +143,7 @@ class ResultSet(Iterable[List[Any]]):
         else:
             return None
 
-    def _fetch_pandas_batches(self, **kwargs):
+    def _fetch_pandas_batches(self, **kwargs) -> Iterator["pandas.DataFrame"]:
         """Fetches Pandas dataframes in batches, where batch refers to Snowflake Chunk.
 
         Thus, the batch size (the number of rows in dataframe) is determined by
@@ -152,7 +152,7 @@ class ResultSet(Iterable[List[Any]]):
         self.__can_create_arrow_iter()
         return self._create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="pandas")
 
-    def _fetch_pandas_all(self, **kwargs):
+    def _fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":
         """Fetches a single Pandas dataframe."""
         dataframes = list(self._fetch_pandas_batches())
         return pandas.concat(dataframes, **kwargs)
@@ -176,6 +176,7 @@ class ResultSet(Iterable[List[Any]]):
         Iterator[Union[Dict, Exception]],
         Iterator[Union[Tuple, Exception]],
         Iterator[Table],
+        Iterator["pandas.DataFrame"],
     ]:
         """Set up a new iterator through all batches with first 5 chunks downloaded.
 

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -24,6 +24,9 @@ class TelemetryField(object):
     # fetch_pandas_* usage
     PANDAS_FETCH_ALL = "client_fetch_pandas_all"
     PANDAS_FETCH_BATCHES = "client_fetch_pandas_batches"
+    # fetch_arrow_* usage
+    ARROW_FETCH_ALL = "client_fetch_arrow_all"
+    ARROW_FETCH_BATCHES = "client_fetch_arrow_batches"
     # Keys for telemetry data sent through either in-band or out-of-band telemetry
     KEY_TYPE = "type"
     KEY_SFQID = "QueryID"

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -43,7 +43,8 @@ class TelemetryField(object):
 class TelemetryData(object):
     """An instance of telemetry data which can be sent to the server."""
 
-    DUMMY_VALUE = 1
+    TRUE = 1
+    FALSE = 0
 
     def __init__(self, message, timestamp):
         self.message = message

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1059,13 +1059,13 @@ def test_batch_to_pandas_arrow(conn_cnx, result_format):
             # check that size, columns, and FOO column data is correct
             if result_format == "pandas":
                 df = batch.to_pandas()
-                assert type(df) is pandas.DataFrame
+                assert type(df) == pandas.DataFrame
                 assert df.shape == (10, 2)
                 assert all(df.columns == ["FOO", "BAR"])
                 assert list(df.FOO) == list(range(rowcount))
             elif result_format == "arrow":
                 arrow_table = batch.to_arrow()
-                assert type(arrow_table) is pyarrow.Table
+                assert type(arrow_table) == pyarrow.Table
                 assert arrow_table.shape == (10, 2)
                 assert arrow_table.column_names == ["FOO", "BAR"]
                 assert arrow_table.to_pydict()["FOO"] == list(range(rowcount))

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -9,6 +9,7 @@ import random
 import time
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 
 import numpy
 import pytest
@@ -17,7 +18,10 @@ try:
     from snowflake.connector.constants import IterUnit
 except ImportError:
     # This is because of olddriver tests
-    IterUnit.TABLE_UNIT = "table"
+    class IterUnit(Enum):
+        ROW_UNIT = "row"
+        TABLE_UNIT = "table"
+
 
 try:
     from snowflake.connector.options import installed_pandas, pandas, pyarrow  # NOQA

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -14,10 +14,10 @@ import numpy
 import pytest
 
 try:
-    from snowflake.connector.constants import TABLE_UNIT
+    from snowflake.connector.constants import IterUnit
 except ImportError:
     # This is because of olddriver tests
-    TABLE_UNIT = "table"
+    IterUnit.TABLE_UNIT = "table"
 
 try:
     from snowflake.connector.options import installed_pandas, pandas, pyarrow  # NOQA
@@ -25,7 +25,6 @@ except ImportError:
     installed_pandas = False
     pandas = None
     pyarrow = None
-
 
 try:
     from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
@@ -741,7 +740,8 @@ def test_empty(conn_cnx):
         df_count = 0
         for _ in cursor.fetch_pandas_batches():
             df_count += 1
-        assert df_count == 0
+        # an empty df is yielded
+        assert df_count == 1
 
 
 def get_random_seed():
@@ -988,7 +988,8 @@ def test_resultbatches_pandas_functionality(conn_cnx):
             result_batches = cur.get_result_batches()
             assert len(result_batches) > 1
     tables = itertools.chain.from_iterable(
-        list(b.create_iter(iter_unit=TABLE_UNIT)) for b in result_batches
+        list(b.create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="arrow"))
+        for b in result_batches
     )
     final_df = pyarrow.concat_tables(tables).to_pandas()
     assert numpy.array_equal(expected_df, final_df)
@@ -1036,3 +1037,29 @@ def test_pandas_telemetry(
         assert occurence == 1
 
         finish(conn, table)
+
+
+@pytest.mark.parametrize("result_format", ["pandas", "arrow"])
+def test_batch_to_pandas_arrow(conn_cnx, result_format):
+    rowcount = 10
+    with conn_cnx() as cnx:
+        cursor = cnx.cursor()
+        cursor.execute(SQL_ENABLE_ARROW)
+        cursor.execute(
+            f"select seq4() as foo, seq4() as bar from table(generator(rowcount=>{rowcount})) order by foo asc"
+        )
+        batches = cursor.get_result_batches()
+        assert len(batches) == 1
+        batch = batches[0]
+
+        # check that size, columns, and FOO column data is correct
+        if result_format == "pandas":
+            df = batch.to_pandas()
+            assert df.shape == (10, 2)
+            assert all(df.columns == ["FOO", "BAR"])
+            assert list(df.FOO) == list(range(rowcount))
+        elif result_format == "arrow":
+            arrow_table = batch.to_arrow()
+            assert arrow_table.shape == (10, 2)
+            assert arrow_table.column_names == ["FOO", "BAR"]
+            assert arrow_table.to_pydict()["FOO"] == list(range(rowcount))

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -28,6 +28,7 @@ except ImportError:
 
 try:
     from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
+
     no_arrow_iterator_ext = False
 except ImportError:
     no_arrow_iterator_ext = True

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -741,8 +741,7 @@ def test_empty(conn_cnx):
         df_count = 0
         for _ in cursor.fetch_pandas_batches():
             df_count += 1
-        # an empty df is yielded
-        assert df_count == 1
+        assert df_count == 0
 
 
 def get_random_seed():

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -29,7 +29,6 @@ except ImportError:
 
 try:
     from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
-
     no_arrow_iterator_ext = False
 except ImportError:
     no_arrow_iterator_ext = True

--- a/test/integ/pandas/test_unit_arrow_chunk_iterator.py
+++ b/test/integ/pandas/test_unit_arrow_chunk_iterator.py
@@ -36,7 +36,7 @@ except ImportError:
     pass
 
 try:
-    from snowflake.connector.arrow_iterator import ROW_UNIT  # NOQA
+    from snowflake.connector.arrow_iterator import IterUnit  # NOQA
     from snowflake.connector.arrow_iterator import PyArrowIterator  # NOQA
 
     no_arrow_iterator_ext = False
@@ -664,7 +664,7 @@ def iterate_over_test_chunk(
     stream.seek(0)
     context = ArrowConverterContext()
     it = PyArrowIterator(None, stream, context, False, False, False)
-    it.init(ROW_UNIT)
+    it.init(IterUnit.ROW_UNIT.value)
 
     count = 0
     while True:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1082,9 +1082,7 @@ def test_check_can_use_pandas(conn_cnx):
     """Tests check_can_use_arrow_resultset has no effect when we can import pandas."""
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
-            with mock.patch(
-                "snowflake.connector.cursor.pyarrow", "Something other than None"
-            ):
+            with mock.patch("snowflake.connector.cursor.installed_pandas", True):
                 cur.check_can_use_pandas()
 
 
@@ -1110,9 +1108,7 @@ def test_not_supported_pandas(conn_cnx):
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
             cur.execute("select 1", _statement_params=result_format)
-            with mock.patch(
-                "snowflake.connector.cursor.pyarrow", "Something other than None"
-            ):
+            with mock.patch("snowflake.connector.cursor.installed_pandas", True):
                 with pytest.raises(NotSupportedError):
                     cur.fetch_pandas_all()
                 with pytest.raises(NotSupportedError):

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1257,7 +1257,6 @@ def test_resultbatch(
                     t.message["type"] == TelemetryField.GET_PARTITIONS_USED
                     for t in telemetry_data.records
                 )
-        # TODO: add a fixture to easily capture telemetry data
         telemetry_data = []
         add_log_mock = mock.Mock()
         add_log_mock.side_effect = lambda datum: telemetry_data.append(datum)

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1093,7 +1093,7 @@ def test_check_cannot_use_pandas(conn_cnx):
     """Tests check_can_use_arrow_resultset has expected outcomes."""
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
-            with mock.patch("snowflake.connector.cursor.pyarrow", None):
+            with mock.patch("snowflake.connector.cursor.installed_pandas", False):
                 with pytest.raises(
                     ProgrammingError,
                     match=r"Optional dependency: 'pyarrow' is not installed, please see the "
@@ -1257,24 +1257,6 @@ def test_resultbatch(
                     t.message["type"] == TelemetryField.GET_PARTITIONS_USED
                     for t in telemetry_data.records
                 )
-        telemetry_data = []
-        add_log_mock = mock.Mock()
-        add_log_mock.side_effect = lambda datum: telemetry_data.append(datum)
-        con._telemetry.add_log_to_batch = add_log_mock
-        with con.cursor() as cur:
-            cur.execute(f"select seq4() from table(generator(rowcount => {rowcount}));")
-            assert cur._result_set.total_row_index() == rowcount
-            pre_pickle_partitions = cur.get_result_batches()
-            assert len(pre_pickle_partitions) > 1
-            assert pre_pickle_partitions is not None
-            assert all(
-                isinstance(p, expected_chunk_type) for p in pre_pickle_partitions
-            )
-            pickle_str = pickle.dumps(pre_pickle_partitions)
-            assert any(
-                t.message["type"] == TelemetryField.GET_PARTITIONS_USED
-                for t in telemetry_data
-            )
     post_pickle_partitions: List["ResultBatch"] = pickle.loads(pickle_str)
     total_rows = 0
     # Make sure the batches can be iterated over individually


### PR DESCRIPTION
This PR addresses changes requested in: SNOW-177082

To summarize the changes:
- the existing `ROW_UNIT` and `TABLE_UNIT` constants are replaced with an Enum. All usages of these constants are also replaced. In `arrow_iterator.pyx` I made sure to use the .value of the Enum to allow for string comparison
- `cursor.py` has 2 new functions, `fetch_arrow_batches()` and `fetch_arrow_all()`, which use the corresponding `result_set.py` function
- `result_set.py` no longer converts pyarrow.Tables to dataframes. Instead, `result_batch.py` will return a pyarrow.Table/dataframe where appropriate. This is specified by a keyword argument.
- `result_batch.py`:
    - added two new methods called `to_arrow` and `to_pandas`. These are implemented only by the `ArrowResultBatch`
    - moved the existing `create_iter()` in `ArrowResultBatch` to be a protected member called `_create_iter()`. Created a new function called `create_iter()` to be the interface that `result_set` uses.
    - created `get_pandas_iter()` and `get_arrow_iter()` which are both iterators as the name implies. `to_pandas()` and `to_arrow()` simply use these iterators