### PR TITLE
SNOW-361357 Provide interface exposing `schema` info to `ResultBatches`

### DIFF
--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,6 +4,7 @@
 
 # distutils: language = c++
 # cython: language_level=3
+from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -4,7 +4,6 @@
 
 # distutils: language = c++
 # cython: language_level=3
-from typing import Iterator
 
 from cpython.ref cimport PyObject
 from libc.stdint cimport *

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -121,7 +121,7 @@ class ResultMetadata(NamedTuple):
 
     @classmethod
     def from_column(cls, col: Dict[str, Any]):
-        """Initializes a ResultMetadata object from the column description in the query response"""
+        """Initializes a ResultMetadata object from the column description in the query response."""
         return cls(
             col["name"],
             FIELD_NAME_TO_ID[col["type"].upper()],

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -15,6 +15,7 @@ from threading import Lock, Timer
 from typing import (
     IO,
     TYPE_CHECKING,
+    Any,
     Dict,
     Iterator,
     List,
@@ -119,11 +120,11 @@ class ResultMetadata(NamedTuple):
     is_nullable: bool
 
     @classmethod
-    def from_column(cls, col):
-        type_value = FIELD_NAME_TO_ID[col["type"].upper()]
+    def from_column(cls, col: Dict[str, Any]):
+        """Initializes a ResultMetadata object from the column description in the query response"""
         return cls(
             col["name"],
-            type_value,
+            FIELD_NAME_TO_ID[col["type"].upper()],
             None,
             col["length"],
             col["precision"],

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -776,7 +776,6 @@ class SnowflakeCursor(object):
             for column in data["rowtype"]
         ]
 
-        # could copy description here
         result_chunks = create_batches_from_response(
             self, self._query_result_format, data, self._description
         )

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -776,10 +776,9 @@ class SnowflakeCursor(object):
             for column in data["rowtype"]
         ]
 
+        # could copy description here
         result_chunks = create_batches_from_response(
-            self,
-            self._query_result_format,
-            data,
+            self, self._query_result_format, data, self._description
         )
 
         self._result_set = ResultSet(

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -37,7 +37,7 @@ DOWNLOAD_TIMEOUT = 7  # seconds
 
 if TYPE_CHECKING:  # pragma: no cover
     from .converter import SnowflakeConverterType
-    from .cursor import SnowflakeCursor
+    from .cursor import ResultMetadata, SnowflakeCursor
     from .vendored.requests import Response
 
 if installed_pandas:
@@ -72,7 +72,7 @@ def create_batches_from_response(
     cursor: "SnowflakeCursor",
     _format: str,
     data: Dict[str, Any],
-    schema: List[Tuple[str, int, int, int, int, bool]],
+    schema: List["ResultMetadata"],
 ) -> List["ResultBatch"]:
     column_converters: List[Tuple[str, "SnowflakeConverterType"]] = []
     arrow_context: Optional["ArrowConverterContext"] = None
@@ -214,7 +214,7 @@ class ResultBatch(abc.ABC):
         chunk_headers: Optional[Dict[str, str]],
         remote_chunk_info: Optional["RemoteChunkInfo"],
         column_names: Sequence[str],
-        schema: List[Tuple[str, int, int, int, int, bool]],
+        schema: List["ResultMetadata"],
         use_dict_result: bool,
     ):
         self.rowcount = rowcount
@@ -345,7 +345,7 @@ class JSONResultBatch(ResultBatch):
         chunk_headers: Optional[Dict[str, str]],
         remote_chunk_info: Optional["RemoteChunkInfo"],
         column_names: Sequence[str],
-        schema: List[Tuple[str, int, int, int, int, bool]],
+        schema: List["ResultMetadata"],
         column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
         use_dict_result: bool,
     ):
@@ -365,7 +365,7 @@ class JSONResultBatch(ResultBatch):
         data: Sequence[Sequence[Any]],
         data_len: int,
         column_names: Sequence[str],
-        schema: List[Tuple[str, int, int, int, int, bool]],
+        schema: List["ResultMetadata"],
         column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
         use_dict_result: bool,
     ):
@@ -479,7 +479,7 @@ class ArrowResultBatch(ResultBatch):
         use_dict_result: bool,
         numpy: bool,
         column_names: Sequence[str],
-        schema: List[Tuple[str, int, int, int, int, bool]],
+        schema: List["ResultMetadata"],
         number_to_decimal: bool,
     ):
         super().__init__(
@@ -557,7 +557,7 @@ class ArrowResultBatch(ResultBatch):
         use_dict_result: bool,
         numpy: bool,
         column_names: Sequence[str],
-        schema: List[Tuple[str, int, int, int, int, bool]],
+        schema: List["ResultMetadata"],
         number_to_decimal: bool,
     ):
         """Initializes an ``ArrowResultBatch`` from static, local data."""

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -599,7 +599,7 @@ class ArrowResultBatch(ResultBatch):
         table = self.to_arrow()
         if table:
             return table.to_pandas(**kwargs)
-        return pandas.DataFrame(columns=self._column_names)
+        return pandas.DataFrame(columns=self.column_names)
 
     def _get_pandas_iter(self, **kwargs) -> Iterator["pandas.DataFrame"]:
         """An iterator for this batch which yields a pandas DataFrame"""

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -248,6 +248,10 @@ class ResultBatch(abc.ABC):
             return None
         return self._remote_chunk_info.uncompressedSize
 
+    @property
+    def column_names(self) -> List[str]:
+        return [col.name for col in self.schema]
+
     def __iter__(
         self,
     ) -> Union[Iterator[Union[Dict, Exception]], Iterator[Union[Tuple, Exception]]]:

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -72,7 +72,7 @@ def create_batches_from_response(
     cursor: "SnowflakeCursor",
     _format: str,
     data: Dict[str, Any],
-    schema: List["ResultMetadata"],
+    schema: Sequence["ResultMetadata"],
 ) -> List["ResultBatch"]:
     column_converters: List[Tuple[str, "SnowflakeConverterType"]] = []
     arrow_context: Optional["ArrowConverterContext"] = None
@@ -82,7 +82,9 @@ def create_batches_from_response(
     rest_of_chunks: List["ResultBatch"] = []
     if _format == "json":
 
-        def col_to_converter(col):
+        def col_to_converter(
+            col: Dict[str, Any]
+        ) -> Tuple[str, "SnowflakeConverterType"]:
             type_name = col["type"].upper()
             python_method = cursor._connection.converter.to_python_method(
                 type_name, col
@@ -116,7 +118,7 @@ def create_batches_from_response(
             chunk_headers[SSE_C_ALGORITHM] = SSE_C_AES
             chunk_headers[SSE_C_KEY] = qrmk
 
-        def remote_chunk_info(c):
+        def remote_chunk_info(c: Dict[str, Any]) -> RemoteChunkInfo:
             return RemoteChunkInfo(
                 url=c["url"],
                 uncompressedSize=c["uncompressedSize"],
@@ -210,7 +212,7 @@ class ResultBatch(abc.ABC):
         rowcount: int,
         chunk_headers: Optional[Dict[str, str]],
         remote_chunk_info: Optional["RemoteChunkInfo"],
-        schema: List["ResultMetadata"],
+        schema: Sequence["ResultMetadata"],
         use_dict_result: bool,
     ):
         self.rowcount = rowcount
@@ -339,7 +341,7 @@ class JSONResultBatch(ResultBatch):
         rowcount: int,
         chunk_headers: Optional[Dict[str, str]],
         remote_chunk_info: Optional["RemoteChunkInfo"],
-        schema: List["ResultMetadata"],
+        schema: Sequence["ResultMetadata"],
         column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
         use_dict_result: bool,
     ):
@@ -357,7 +359,7 @@ class JSONResultBatch(ResultBatch):
         cls,
         data: Sequence[Sequence[Any]],
         data_len: int,
-        schema: List["ResultMetadata"],
+        schema: Sequence["ResultMetadata"],
         column_converters: Sequence[Tuple[str, "SnowflakeConverterType"]],
         use_dict_result: bool,
     ):
@@ -469,7 +471,7 @@ class ArrowResultBatch(ResultBatch):
         context: "ArrowConverterContext",
         use_dict_result: bool,
         numpy: bool,
-        schema: List["ResultMetadata"],
+        schema: Sequence["ResultMetadata"],
         number_to_decimal: bool,
     ):
         super().__init__(
@@ -545,7 +547,7 @@ class ArrowResultBatch(ResultBatch):
         context: "ArrowConverterContext",
         use_dict_result: bool,
         numpy: bool,
-        schema: List["ResultMetadata"],
+        schema: Sequence["ResultMetadata"],
         number_to_decimal: bool,
     ):
         """Initializes an ``ArrowResultBatch`` from static, local data."""

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -221,7 +221,7 @@ class ResultBatch(abc.ABC):
         self._chunk_headers = chunk_headers
         self._remote_chunk_info = remote_chunk_info
         self._column_names = column_names
-        self._schema = schema
+        self.schema = schema
         self._use_dict_result = use_dict_result
         self._metrics: Dict[str, int] = {}
         self._data: Optional[Union[str, List[Tuple[Any, ...]]]] = None

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -158,8 +158,7 @@ class ResultSet(Iterable[List[Any]]):
         if table:
             return table.to_pandas(**kwargs)
         else:
-            column_names = [col.name for col in self.batches[0].schema]
-            return pandas.DataFrame(columns=column_names)
+            return pandas.DataFrame(columns=self.batches[0].column_names)
 
     def _get_metrics(self) -> Dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -154,11 +154,10 @@ class ResultSet(Iterable[List[Any]]):
 
     def _fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":
         """Fetches a single Pandas dataframe."""
-        table = self._fetch_arrow_all()
-        if table:
-            return table.to_pandas(**kwargs)
-        else:
-            return pandas.DataFrame(columns=self.batches[0].column_names)
+        dataframes = list(self._fetch_pandas_batches())
+        if dataframes:
+            return pandas.concat(dataframes, **kwargs)
+        return pandas.DataFrame(columns=self.batches[0].column_names)
 
     def _get_metrics(self) -> Dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -154,10 +154,12 @@ class ResultSet(Iterable[List[Any]]):
 
     def _fetch_pandas_all(self, **kwargs) -> "pandas.DataFrame":
         """Fetches a single Pandas dataframe."""
-        dataframes = list(self._fetch_pandas_batches())
-        if dataframes:
-            return pandas.concat(dataframes, **kwargs)
-        return pandas.DataFrame(columns=self.batches[0]._column_names)
+        table = self._fetch_arrow_all()
+        if table:
+            return table.to_pandas(**kwargs)
+        else:
+            column_names = [col.name for col in self.batches[0].schema]
+            return pandas.DataFrame(columns=column_names)
 
     def _get_metrics(self) -> Dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -11,7 +11,7 @@ import os
 import pickle
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, NamedTuple
 
 import mock
 import pytest
@@ -28,7 +28,22 @@ from snowflake.connector import (
     errors,
 )
 from snowflake.connector.compat import BASE_EXCEPTION_CLASS, IS_WINDOWS
-from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
+from snowflake.connector.cursor import SnowflakeCursor
+
+try:
+    from snowflake.connector.cursor import ResultMetadata
+except ImportError:
+
+    class ResultMetadata(NamedTuple):
+        name: str
+        type_code: int
+        display_size: int
+        internal_size: int
+        precision: int
+        scale: int
+        is_nullable: bool
+
+
 from snowflake.connector.errorcode import (
     ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
     ER_INVALID_VALUE,

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1368,13 +1368,7 @@ def test_resultbatch_schema_exists_when_zero_rows(conn_cnx, result_format, patch
             schema = result_batches[0].schema
             assert schema[0] == ResultMetadata("C1", 0, None, None, 10, 0, False)
             assert schema[1] == ResultMetadata(
-                "C2",
-                2,
-                None,
-                16777216,
-                None,
-                None,
-                False,
+                "C2", 2, None, 16777216, None, None, False
             )
 
 


### PR DESCRIPTION
This PR addresses changes requested in  https://snowflakecomputing.atlassian.net/browse/SNOW-361357

It passes the cursor's description list to each of the result batches, and can be accessed by each individual batch with `.schema`.

The added test has an example of the usage for this function