### PR TITLE
SNOW-364567 SNOW-303944 Remove substitution of dash for underscore in account names

### DIFF
--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -61,7 +61,7 @@ class AuthByKeyPair(AuthByPlugin):
             account = account.partition("-")[0]
         else:
             account = account.partition(".")[0]
-        account = account.upper().replace("-", "_")
+        account = account.upper()
         user = user.upper()
 
         now = datetime.utcnow()

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -22,7 +22,7 @@ import snowflake.connector
     "input_account,expected_account",
     [
         ("s3testaccount.global", "S3TESTACCOUNT.GLOBAL"),
-        ("acct-with-dashes", "ACCT_WITH_DASHES"),
+        ("acct-with-dashes", "ACCT-WITH-DASHES"),
         ("testaccount.extra", "TESTACCOUNT"),
         ("testaccount-user.global", "TESTACCOUNT"),
         ("normalaccount", "NORMALACCOUNT"),


### PR DESCRIPTION
Replacing '-' with '_' has led to a problem with certain accounts. Removing this logic so as to not break existing customers.