### PR TITLE
SNOW-365904 Intialize UniqueRefs without move operator

### DIFF
--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -442,7 +442,7 @@ void DictCArrowChunkIterator::createRowPyObject()
   m_latestReturnedRow.reset(PyDict_New());
   for (int i = 0; i < m_currentSchema->num_fields(); i++)
   {
-    py::UniqueRef value = py::UniqueRef(m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch));
+    py::UniqueRef value(m_currentBatchConverters[i]->toPyObject(m_rowIndexInBatch));
     if (!value.empty())
     {
       // PyDict_SetItemString doesn't steal a reference to value.get().

--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -168,7 +168,7 @@ m_context(context),
 m_pyTableObjRef(nullptr),
 m_convert_number_to_decimal(number_to_decimal)
 {
-  py::UniqueRef tz = py::UniqueRef(PyObject_GetAttrString(m_context, "_timezone"));
+  py::UniqueRef tz(PyObject_GetAttrString(m_context, "_timezone"));
   PyArg_Parse(tz.get(), "s", &m_timezone);
 }
 


### PR DESCRIPTION
Address changes in: https://snowflakecomputing.atlassian.net/browse/SNOW-365904

Old code was implicitly using `UniqueRef(UniqueRef&& other)` which was made to be `explicit`