### PR TITLE
SNOW-365900 Test key/pair authentication with regionless URL

### DIFF
--- a/src/snowflake/connector/auth_keypair.py
+++ b/src/snowflake/connector/auth_keypair.py
@@ -61,7 +61,8 @@ class AuthByKeyPair(AuthByPlugin):
             account = account.partition("-")[0]
         else:
             account = account.partition(".")[0]
-        account = account.upper().replace("-", "_")
+        account = account.upper()
+
         user = user.upper()
 
         now = datetime.utcnow()

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -7,7 +7,6 @@
 import uuid
 from datetime import datetime, timedelta
 from os import path
-from test.integ.conftest import RUNNING_AGAINST_LOCAL_SNOWFLAKE
 
 import jwt
 import pytest
@@ -65,10 +64,8 @@ def test_get_token_from_private_key(input_account, expected_account):
     )
 
 
-@pytest.mark.internal
-@pytest.mark.skipif(
-    not RUNNING_AGAINST_LOCAL_SNOWFLAKE,
-    reason="connection timeouts occur when attempting to connect to this external account with automated testing",
+@pytest.mark.skip(
+    reason="Test is for running locally only. Credentials will fail on Jenkins and Github."
 )
 def test_regionless_url_JWT_token_validity():
 

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -7,6 +7,7 @@
 import uuid
 from datetime import datetime, timedelta
 from os import path
+from test.integ.conftest import RUNNING_AGAINST_LOCAL_SNOWFLAKE
 
 import jwt
 import pytest
@@ -65,6 +66,10 @@ def test_get_token_from_private_key(input_account, expected_account):
 
 
 @pytest.mark.internal
+@pytest.mark.skipif(
+    not RUNNING_AGAINST_LOCAL_SNOWFLAKE,
+    reason="connection timeouts occur when attempting to connect to this external account with automated testing",
+)
 def test_regionless_url_JWT_token_validity():
 
     test_user = "admin"

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -7,6 +7,7 @@
 import uuid
 from datetime import datetime, timedelta
 from os import path
+from test.integ.conftest import RUNNING_AGAINST_LOCAL_SNOWFLAKE
 
 import jwt
 import pytest
@@ -64,8 +65,12 @@ def test_get_token_from_private_key(input_account, expected_account):
     )
 
 
-@pytest.mark.skipolddriver
-def test_regionless_url_JWT_token_validity(request, db_parameters):
+@pytest.mark.internal
+@pytest.mark.skipif(
+    not RUNNING_AGAINST_LOCAL_SNOWFLAKE,
+    reason="connection timeouts occur when attempting to connect to this external account with automated testing",
+)
+def test_regionless_url_JWT_token_validity(db_parameters):
 
     test_user = "admin"
 

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -84,26 +84,16 @@ def test_regionless_url_JWT_token_validity(request, db_parameters):
         "timezone": "UTC",
     }
 
-    cnx = snowflake.connector.connect(**db_config_with_pw)
-    cursor = cnx.cursor()
-    cursor.execute(
-        """
-    use role accountadmin
-    """
-    )
-
-    private_key_der, public_key_der_encoded = generate_key_pair(2048)
-
-    cnx.cursor().execute(
-        """
-    alter user {user} set rsa_public_key='{public_key}'
-    """.format(
-            user=test_user, public_key=public_key_der_encoded
-        )
-    )
+    with snowflake.connector.connect(**db_config_with_pw) as cnx:
+        with cnx.cursor() as cursor:
+            cursor.execute("use role accountadmin")
+            private_key_der, public_key_der_encoded = generate_key_pair(2048)
+            cursor.execute(
+                f"alter user {test_user} set rsa_public_key='{public_key_der_encoded}'"
+            )
 
     db_config["private_key"] = private_key_der
-    with snowflake.connector.connect(**db_config) as _:
+    with snowflake.connector.connect(**db_config):
         pass
 
 

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -7,7 +7,6 @@
 import uuid
 from datetime import datetime, timedelta
 from os import path
-from test.integ.conftest import RUNNING_AGAINST_LOCAL_SNOWFLAKE
 
 import jwt
 import pytest
@@ -66,11 +65,7 @@ def test_get_token_from_private_key(input_account, expected_account):
 
 
 @pytest.mark.internal
-@pytest.mark.skipif(
-    not RUNNING_AGAINST_LOCAL_SNOWFLAKE,
-    reason="connection timeouts occur when attempting to connect to this external account with automated testing",
-)
-def test_regionless_url_JWT_token_validity(db_parameters):
+def test_regionless_url_JWT_token_validity():
 
     test_user = "admin"
 


### PR DESCRIPTION
SNOW-365900
This fixes the issue of JWT tokens being invalid for account aliases with dashes in them, and runs a test against one of these accounts with an org alias in QA. The current Jenkins credentials running against a dev deployment would require us to set up org/account creation with every Jenkins run, so it seems more feasible to test against an org that doesn't have to be re-created each run.