### PR TITLE
SNOW-372606 only create Jira if the issue is not made by whitesource

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'whitesource-for-github-com[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
SNOW-372606

As we are getting ready to deploy Whitesource in this repository we should make sure that we won't double create Jiras. Whitesource handles its own Jira creation.