### PR TITLE
SNOW-361210 Adds Retry Logic and Tests

### DIFF
--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -210,7 +210,7 @@ def raise_failed_request_error(
     response: Response,
 ) -> None:
     TelemetryService.get_instance().log_http_request_error(
-        "HttpError%s" % str(response.status_code),
+        f"HttpError{response.status_code}",
         url,
         method,
         SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -149,15 +149,7 @@ COMPILER = COMPILER
 
 CLIENT_NAME = CLIENT_NAME  # don't change!
 CLIENT_VERSION = CLIENT_VERSION
-PYTHON_CONNECTOR_USER_AGENT = (
-    "{name}/{version} ({platform}) {python_implementation}/{python_version}".format(
-        name=CLIENT_NAME,
-        version=SNOWFLAKE_CONNECTOR_VERSION,
-        python_implementation=IMPLEMENTATION,
-        python_version=PYTHON_VERSION,
-        platform=PLATFORM,
-    )
-)
+PYTHON_CONNECTOR_USER_AGENT = f"{CLIENT_NAME}/{SNOWFLAKE_CONNECTOR_VERSION} ({PLATFORM}) {IMPLEMENTATION}/{PYTHON_VERSION}"
 
 NO_TOKEN = "no-token"
 
@@ -621,12 +613,7 @@ class SnowflakeRestful(object):
         if "Content-Length" in headers:
             del headers["Content-Length"]
 
-        full_url = "{protocol}://{host}:{port}{url}".format(
-            protocol=self._protocol,
-            host=self._host,
-            port=self._port,
-            url=url,
-        )
+        full_url = f"{self._protocol}://{self._host}:{self._port}{url}"
         ret = self.fetch(
             "get",
             full_url,
@@ -664,12 +651,7 @@ class SnowflakeRestful(object):
         socket_timeout=DEFAULT_SOCKET_CONNECT_TIMEOUT,
         _include_retry_params=False,
     ):
-        full_url = "{protocol}://{host}:{port}{url}".format(
-            protocol=self._protocol,
-            host=self._host,
-            port=self._port,
-            url=url,
-        )
+        full_url = f"{self._protocol}://{self._host}:{self._port}{url}"
         if self._connection._probe_connection:
             from pprint import pprint
 
@@ -916,14 +898,9 @@ class SnowflakeRestful(object):
             except Exception:
                 logger.info("data is not JSON")
         logger.error(
-            "Failed to get the response. Hanging? "
-            "method: {method}, url: {url}, headers:{headers}, "
-            "data: {data}".format(
-                method=method,
-                url=full_url,
-                headers=headers,
-                data=data,
-            )
+            f"Failed to get the response. Hanging? "
+            f"method: {method}, url: {full_url}, headers:{headers}, "
+            f"data: {data}"
         )
         Error.errorhandler_wrapper(
             conn,
@@ -996,7 +973,7 @@ class SnowflakeRestful(object):
 
                 if is_retryable_http_code(raw_ret.status_code):
                     error = get_http_retryable_error(raw_ret.status_code)
-                    logger.debug("%s. Retrying...", error)
+                    logger.debug(f"{error}. Retrying...")
                     # retryable server exceptions
                     raise RetryRequest(error)
 

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1005,9 +1005,7 @@ class SnowflakeRestful(object):
                     and catch_okta_unauthorized_error
                 ):
                     # OKTA Unauthorized errors
-                    raise_okta_unauthorized_error(
-                        self._connection, raw_ret.status_code, raw_ret.reason
-                    )
+                    raise_okta_unauthorized_error(self._connection, raw_ret)
                     return None  # required for tests
                 else:
                     raise_failed_request_error(

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -305,9 +305,9 @@ class ResultBatch(abc.ABC):
                         raise_failed_request_error(None, chunk_url, "get", response)
 
             except (RetryRequest, Exception) as e:
-                e = e.args[0] if isinstance(e, RetryRequest) else e
                 if retry == MAX_DOWNLOAD_RETRY - 1:
                     # Re-throw if we failed on the last retry
+                    e = e.args[0] if isinstance(e, RetryRequest) else e
                     raise e
                 sleep_timer = backoff.next_sleep(1, sleep_timer)
                 logger.exception(

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -304,10 +304,11 @@ class ResultBatch(abc.ABC):
                     else:
                         raise_failed_request_error(None, chunk_url, "get", response)
 
-            except Exception as e:
+            except (RetryRequest, Exception) as e:
+                e = e.args[0] if isinstance(e, RetryRequest) else e
                 if retry == MAX_DOWNLOAD_RETRY - 1:
                     # Re-throw if we failed on the last retry
-                    raise
+                    raise e
                 sleep_timer = backoff.next_sleep(1, sleep_timer)
                 logger.exception(
                     f"Failed to fetch the large result set batch "

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -23,9 +23,17 @@ from typing import (
 )
 
 from .arrow_context import ArrowConverterContext
+from .compat import OK, UNAUTHORIZED
 from .constants import IterUnit
 from .errorcode import ER_FAILED_TO_CONVERT_ROW_TO_PYTHON_TYPE, ER_NO_PYARROW
 from .errors import Error, InterfaceError, NotSupportedError, ProgrammingError
+from .network import (
+    RetryRequest,
+    get_http_retryable_error,
+    is_retryable_http_code,
+    raise_failed_request_error,
+    raise_okta_unauthorized_error,
+)
 from .options import installed_pandas, pandas
 from .time_util import DecorrelateJitterBackoff, TimerContextManager
 from .vendored import requests
@@ -271,17 +279,31 @@ class ResultBatch(abc.ABC):
                     logger.debug(
                         f"started downloading result batch of size {self.rowcount}"
                     )
+                    chunk_url = self._remote_chunk_info.url
                     response = requests.get(
-                        self._remote_chunk_info.url,
+                        chunk_url,
                         headers=self._chunk_headers,
                         timeout=DOWNLOAD_TIMEOUT,
                         stream=True,
                     )
-                    if response.ok:
+
+                    if response.status_code == OK:
                         logger.debug(
                             f"successfully downloaded result batch of size {self.rowcount}"
                         )
                         break
+
+                    # Raise error here to correctly go in to exception clause
+                    if is_retryable_http_code(response.status_code):
+                        # retryable server exceptions
+                        error: Error = get_http_retryable_error(response.status_code)
+                        raise RetryRequest(error)
+                    elif response.status_code == UNAUTHORIZED:
+                        # make a unauthorized error
+                        raise_okta_unauthorized_error(None, response)
+                    else:
+                        raise_failed_request_error(None, chunk_url, "get", response)
+
             except Exception as e:
                 if retry == MAX_DOWNLOAD_RETRY - 1:
                     # Re-throw if we failed on the last retry
@@ -326,7 +348,7 @@ class ResultBatch(abc.ABC):
             )
             errno = ER_NO_PYARROW
 
-            Error.errorhandler_make_exception(
+            raise Error.errorhandler_make_exception(
                 ProgrammingError,
                 {
                     "msg": msg,

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+
+from mock import Mock
+
+from snowflake.connector.compat import OK
+
+
+def create_mock_response(status_code: int) -> Mock:
+    """Create a Mock "Response" with a given status code. See `test_result_batch.py` for examples.
+    Args:
+        status_code: the status code of the response.
+    Returns:
+        A Mock object that can be used as a Mock Response in tests.
+    """
+    mock_resp = Mock()
+    mock_resp.status_code = status_code
+    mock_resp.raw = "success" if status_code == OK else "fail"
+    return mock_resp

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1343,7 +1343,12 @@ def test_resultbatch_lazy_fetching_and_schemas(conn_cnx, result_format, patch_pa
                 # short circuits and just parses (for JSON batches) and then returns
                 # an iterator through that data, so we expect the call count to be 5.
                 # (0 local and 1, 2, 3, 4 pre-fetched) = 5 total
-                assert patched_download.call_count == 5
+                start_time = time.time()
+                while time.time() < start_time + 1:
+                    if patched_download.call_count == 5:
+                        break
+                else:
+                    assert patched_download.call_count == 5
 
 
 @pytest.mark.skipolddriver(reason="new feature in v2.5.0")

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -82,6 +82,7 @@ def test_ok_response_download(mock_get):
     ],
 )
 def test_retryable_response_download(errcode, error_class):
+    """This test checks that responses which are deemed 'retryable' are handled correctly."""
     # retryable exceptions
     with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
         mock_get.return_value = create_mock_response(errcode)
@@ -98,7 +99,7 @@ def test_retryable_response_download(errcode, error_class):
 
 
 def test_unauthorized_response_download():
-    # unauthorized = 401
+    """This tests that the Unauthorized response (401 status code) is handled correctly."""
     with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
         mock_get.return_value = create_mock_response(UNAUTHORIZED)
 
@@ -112,9 +113,9 @@ def test_unauthorized_response_download():
         assert mock_get.call_count == MAX_DOWNLOAD_RETRY
 
 
-# retry on success codes that are not 200
 @pytest.mark.parametrize("status_code", [201, 302])
 def test_non_200_response_download(status_code):
+    """This test checks that "success" codes which are not 200 still retry."""
     with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
         mock_get.return_value = create_mock_response(status_code)
 
@@ -130,6 +131,8 @@ def test_non_200_response_download(status_code):
 def test_retries_until_success():
     with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
         error_codes = [BAD_REQUEST, UNAUTHORIZED, 201]
+        # There is an OK added to the list of responses so that there is a success
+        # and the retry loop ends.
         mock_responses = [create_mock_response(code) for code in error_codes + [OK]]
         mock_get.side_effect = mock_responses
 

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
+#
+
+import importlib
+from collections import namedtuple
+from http import HTTPStatus
+from unittest import mock
+
+import pytest
+from mock import Mock
+
+from snowflake.connector import DatabaseError, InterfaceError
+from snowflake.connector.compat import (
+    BAD_GATEWAY,
+    BAD_REQUEST,
+    FORBIDDEN,
+    GATEWAY_TIMEOUT,
+    INTERNAL_SERVER_ERROR,
+    METHOD_NOT_ALLOWED,
+    OK,
+    REQUEST_TIMEOUT,
+    SERVICE_UNAVAILABLE,
+    UNAUTHORIZED,
+)
+from snowflake.connector.errorcode import (
+    ER_FAILED_TO_CONNECT_TO_DB,
+    ER_FAILED_TO_REQUEST,
+)
+from snowflake.connector.network import RetryRequest
+from snowflake.connector.result_batch import MAX_DOWNLOAD_RETRY, JSONResultBatch
+from snowflake.connector.sqlstate import (
+    SQLSTATE_CONNECTION_REJECTED,
+    SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+)
+
+REQUEST_MODULE_PATH = (
+    "snowflake.connector.vendored.requests"
+    if importlib.util.find_spec("snowflake.connector.vendored.requests")
+    else "requests"
+)
+
+MockRemoteChunkInfo = namedtuple("MockRemoteChunkInfo", "url")
+
+
+def create_mock_response(status_code):
+    mock_resp = Mock()
+    mock_resp.status_code = status_code
+    mock_resp.raw = "success" if status_code == OK else "fail"
+    return mock_resp
+
+
+@mock.patch(REQUEST_MODULE_PATH + ".get")
+def test_ok_response_download(mock_get):
+    mock_get.return_value = create_mock_response(200)
+    chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+
+    result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+    response = result_batch._download()
+
+    # successful on first try
+    assert mock_get.call_count == 1
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "errcode",
+    [
+        BAD_REQUEST,  # 400
+        FORBIDDEN,  # 403
+        METHOD_NOT_ALLOWED,  # 405
+        REQUEST_TIMEOUT,  # 408
+        INTERNAL_SERVER_ERROR,  # 500
+        BAD_GATEWAY,  # 502
+        SERVICE_UNAVAILABLE,  # 503
+        GATEWAY_TIMEOUT,  # 504
+        555,  # random 5xx error
+    ],
+)
+def test_retryable_response_download(errcode):
+    # retryable exceptions
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(errcode)
+
+        chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+        result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(RetryRequest) as ex:
+                _ = result_batch._download()
+            err_msg = ex.value.args[0].msg
+            if isinstance(errcode, HTTPStatus):
+                assert str(errcode.value) in err_msg
+            else:
+                assert str(errcode) in err_msg
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+def test_unauthorized_response_download():
+    # unauthorized = 401
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(UNAUTHORIZED)
+
+        chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+        result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(DatabaseError) as ex:
+                _ = result_batch._download()
+            error = ex.value
+            assert error.errno == ER_FAILED_TO_CONNECT_TO_DB
+            assert error.sqlstate == SQLSTATE_CONNECTION_REJECTED
+            assert "401" in error.msg
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+# retry on success codes that are not 200
+@pytest.mark.parametrize("status_code", [201, 302])
+def test_non_200_response_download(status_code):
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(status_code)
+
+        chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+        result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(InterfaceError) as ex:
+                _ = result_batch._download()
+            error = ex.value
+            assert error.errno == ER_FAILED_TO_REQUEST
+            assert error.sqlstate == SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+def test_retries_until_success():
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        error_codes = [BAD_REQUEST, UNAUTHORIZED, 201]
+        mock_responses = [create_mock_response(code) for code in error_codes + [OK]]
+        mock_get.side_effect = mock_responses
+
+        chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+        result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+        with mock.patch("time.sleep", return_value=None):
+            res = result_batch._download()
+            assert res.raw == "success"
+        # call `get` once for each error and one last time when it succeeds
+        assert mock_get.call_count == len(error_codes) + 1


### PR DESCRIPTION
This PR addresses changes requested in: [SNOW-361210](https://snowflakecomputing.atlassian.net/browse/SNOW-361210).

The core functionality for retries was already there, but there were a few differences between this and the old `ChunkDownloader` error handling. See [this comment](https://snowflakecomputing.atlassian.net/browse/SNOW-361210?focusedCommentId=1683481) for more details. In short, the old code didn't log/raise retry errors quite correctly, and accepted status codes other than 200 which this PR addresses.

I also added quite a few unit tests to verify that retries are working as we expect.