### PR TITLE
Update requirements_37.reqs

### DIFF
--- a/tested_requirements/requirements_37.reqs
+++ b/tested_requirements/requirements_37.reqs
@@ -6,7 +6,7 @@ azure-common==1.1.25
 azure-core==1.8.2
 azure-storage-blob==12.5.0
 boto3==1.15.18
-botocore==1.18.18
+botocore==1.20.49
 certifi==2020.4.5.1
 cffi==1.14.3
 chardet==3.0.4


### PR DESCRIPTION
botocore==1.18.18 breaks s3fs which is needed to load parquet data files.
botocore==1.20.49 Solve the dependency for s3fs without breaking snowflake-connector-python