### PR TITLE
added ability for snowflake managed infrastructure partners to get cr…

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -148,7 +148,7 @@ DEFAULT_CONFIGURATION = {
     "authenticator": (DEFAULT_AUTHENTICATOR, (type(None), str)),
     "mfa_callback": (None, (type(None), Callable)),
     "password_callback": (None, (type(None), Callable)),
-    "application": (CLIENT_NAME, (type(None), str)),
+    "application": (os.environ.get('SNOWFLAKE_PARTNER', CLIENT_NAME), (type(None), str)),
     "internal_application_name": (CLIENT_NAME, (type(None), str)),
     "internal_application_version": (CLIENT_VERSION, (type(None), str)),
     "insecure_mode": (False, bool),  # Error security fix requirement


### PR DESCRIPTION
Allows snowflake's managed infrastructure providers to add a "SNOWFLAKE_PARNTER" environment variable to their build images. Therefore, if a user downloads the snowflake connector to use as a part of the partners value-added service, they will get credit for that connection/consumption