### PR TITLE
SNOW-361211 Allow ResultBatches to use existing Sessions

### DIFF
--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -259,7 +259,12 @@ class ResultBatch(abc.ABC):
     def column_names(self) -> List[str]:
         return [col.name for col in self.schema]
 
-    def set_use_sessions(self, use_sessions):
+    @property
+    def use_sessions(self):
+        return self._use_sessions
+
+    @use_sessions.setter
+    def use_sessions(self, use_sessions: bool):
         self._use_sessions = use_sessions
 
     def __iter__(

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -228,8 +228,6 @@ class ResultBatch(abc.ABC):
         self._use_dict_result = use_dict_result
         self._metrics: Dict[str, int] = {}
         self._data: Optional[Union[str, List[Tuple[Any, ...]]]] = None
-        # a flag that indicates if the result batch download should use sessions or not
-        self.use_sessions: bool = False
 
     @property
     def _local(self) -> bool:
@@ -290,7 +288,7 @@ class ResultBatch(abc.ABC):
                         "timeout": DOWNLOAD_TIMEOUT,
                         "stream": True,
                     }
-                    if self.use_sessions and connection:
+                    if connection:
                         with connection._rest._use_requests_session() as session:
                             logger.debug(
                                 f"downloading result batch of size {self.rowcount} with existing session {session}"
@@ -358,8 +356,7 @@ class ResultBatch(abc.ABC):
 
     def _done_load(self, response: "Response") -> None:
         """Performs cleanup after loading from `response` is done."""
-        if self.use_sessions:
-            response.close()
+        response.close()
 
     def _check_can_use_pandas(self) -> None:
         if not installed_pandas:

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -223,7 +223,7 @@ class ResultSet(Iterable[List[Any]]):
         # setup result batches to use sessions
         kwargs["connection"] = self._cursor.connection
         for b in self.batches:
-            b.set_use_sessions(True)
+            b.use_sessions = True
 
         first_batch_iter = self.batches[0].create_iter(**kwargs)
 

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -220,6 +220,11 @@ class ResultSet(Iterable[List[Any]]):
         This function is a helper function to ``__iter__`` and it was introduced for the
         cases where we need to propagate some values to later ``_download`` calls.
         """
+        # setup result batches to use sessions
+        kwargs["connection"] = self._cursor.connection
+        for b in self.batches:
+            b.set_use_sessions(True)
+
         first_batch_iter = self.batches[0].create_iter(**kwargs)
 
         # Iterator[Tuple] Futures that have not been consumed by the user

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -153,6 +153,15 @@ class ResultSet(Iterable[List[Any]]):
                 metrics.get(DownloadMetrics.parse.value),
             )
 
+    def _finish_iterating(self):
+        """Used for any cleanup after the result set iterator is done."""
+
+        # ensure batch use_sessions attribute is set to false after iteration
+        for b in self.batches:
+            b.use_sessions = False
+
+        self._report_metrics()
+
     def _can_create_arrow_iter(self) -> None:
         # For now we don't support mixed ResultSets, so assume first partition's type
         #  represents them all
@@ -239,7 +248,7 @@ class ResultSet(Iterable[List[Any]]):
             first_batch_iter,
             unconsumed_batches,
             unfetched_batches,
-            self._report_metrics,
+            self._finish_iterating,
             **kwargs,
         )
 

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -156,10 +156,6 @@ class ResultSet(Iterable[List[Any]]):
     def _finish_iterating(self):
         """Used for any cleanup after the result set iterator is done."""
 
-        # ensure batch use_sessions attribute is set to false after iteration
-        for b in self.batches:
-            b.use_sessions = False
-
         self._report_metrics()
 
     def _can_create_arrow_iter(self) -> None:
@@ -229,10 +225,8 @@ class ResultSet(Iterable[List[Any]]):
         This function is a helper function to ``__iter__`` and it was introduced for the
         cases where we need to propagate some values to later ``_download`` calls.
         """
-        # setup result batches to use sessions
+        # add connection so that result batches can use sessions
         kwargs["connection"] = self._cursor.connection
-        for b in self.batches:
-            b.use_sessions = True
 
         first_batch_iter = self.batches[0].create_iter(**kwargs)
 

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1074,8 +1074,7 @@ def test_simple_arrow_fetch(conn_cnx):
 
 @pytest.mark.parametrize("fetch_fn_name", ["to_arrow", "to_pandas", "create_iter"])
 @pytest.mark.parametrize("pass_connection", [True, False])
-@pytest.mark.parametrize("use_sessions", [True, False])
-def test_sessions_used(conn_cnx, fetch_fn_name, pass_connection, use_sessions):
+def test_sessions_used(conn_cnx, fetch_fn_name, pass_connection):
     rowcount = 250_000
     with conn_cnx() as cnx:
         with cnx.cursor() as cur:
@@ -1084,7 +1083,6 @@ def test_sessions_used(conn_cnx, fetch_fn_name, pass_connection, use_sessions):
             batches = cur.get_result_batches()
             assert len(batches) > 1
             batch = batches[-1]
-            batch.use_sessions = use_sessions
 
             connection = cnx if pass_connection else None
             fetch_fn = getattr(batch, fetch_fn_name)
@@ -1095,6 +1093,4 @@ def test_sessions_used(conn_cnx, fetch_fn_name, pass_connection, use_sessions):
                 side_effect=cnx._rest._use_requests_session,
             ) as get_session_mock:
                 fetch_fn(connection=connection)
-                assert get_session_mock.call_count == (
-                    1 if pass_connection and use_sessions else 0
-                )
+                assert get_session_mock.call_count == (1 if pass_connection else 0)

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1432,9 +1432,6 @@ def test_fetch_batches_with_sessions(conn_cnx):
     with conn_cnx() as con:
         with con.cursor() as cur:
             cur.execute(
-                "alter session set python_connector_query_result_format='arrow'"
-            )
-            cur.execute(
                 f"select seq4() as foo from table(generator(rowcount=>{rowcount}))"
             )
 
@@ -1444,7 +1441,7 @@ def test_fetch_batches_with_sessions(conn_cnx):
                 "snowflake.connector.network.SnowflakeRestful._use_requests_session",
                 side_effect=con._rest._use_requests_session,
             ) as get_session_mock:
-                df = cur.fetch_pandas_all()
+                result = cur.fetchall()
                 # all but one batch is downloaded using a session
                 assert get_session_mock.call_count == num_batches - 1
-                assert df.shape == (rowcount, 1)
+                assert len(result) == rowcount

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -58,6 +58,9 @@ result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
 
 @mock.patch(REQUEST_MODULE_PATH + ".get")
 def test_ok_response_download(mock_get):
+    # set true but don't provide connection on download
+    result_batch.use_sessions = True
+
     mock_get.return_value = create_mock_response(200)
 
     response = result_batch._download()

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -60,9 +60,6 @@ result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
 
 @mock.patch(REQUEST_MODULE_PATH + ".get")
 def test_ok_response_download(mock_get):
-    # set true but don't provide connection on download
-    result_batch.use_sessions = True
-
     mock_get.return_value = create_mock_response(200)
 
     response = result_batch._download()

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -45,6 +45,8 @@ from snowflake.connector.sqlstate import (
     SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
 )
 
+pytestmark = pytest.mark.skipolddriver
+
 REQUEST_MODULE_PATH = (
     "snowflake.connector.vendored.requests"
     if importlib.util.find_spec("snowflake.connector.vendored.requests")


### PR DESCRIPTION
This PR addresses changes requested in [SNOW-361211](https://snowflakecomputing.atlassian.net/browse/SNOW-361211).

It adds the ability for a ResultBatch to make requests with an existing session if supplied. 
The ResultSet iterator will supply its connection when creating each ResultBatch iterator. This way, when iterating through all batches (either via a fetchall/fetch_pandas_all/fetch_arrow_all), sessions are reused at the download step.

To support this, ResultBatches have a new `_use_session` attribute that gets set to True by the ResultSet. The ResultSet also passes in `self._connection` to the ResultBatch create_iter.