### PR TITLE
SNOW-361263: Fix describe method when running `insert into ...`

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -786,7 +786,8 @@ class SnowflakeCursor(object):
         else:
             self._result = self._json_result_class(data, self)
 
-        if is_dml:
+        # don't update the row count when the result is returned from `describe` method
+        if is_dml and "rowset" in data and len(data["rowset"]) > 0:
             updated_rows = 0
             for idx, desc in enumerate(self._description):
                 if (

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1222,9 +1222,10 @@ def test_out_of_range_year(conn_cnx, result_format, cursor_type):
 
 
 @pytest.mark.skipolddriver
-def test_describe(conn_cnx):
+def test_describe(conn_cnx, db_parameters):
     with conn_cnx() as con:
         with con.cursor() as cur:
+            # test select
             description = cur.describe(
                 "select * from VALUES(1, 3.1415926, 'snow', TO_TIMESTAMP('2021-01-01 00:00:00'))"
             )
@@ -1235,3 +1236,15 @@ def test_describe(conn_cnx):
             assert constants.FIELD_ID_TO_NAME[column_types[2]] == "TEXT"
             assert "TIMESTAMP" in constants.FIELD_ID_TO_NAME[column_types[3]]
             assert len(cur.fetchall()) == 0
+
+            # test insert
+            cur.execute(
+                "create table {name} (aa int)".format(name=db_parameters["name"])
+            )
+            description = cur.describe(
+                "insert into {name}(aa) values({value})".format(
+                    name=db_parameters["name"], value="1234"
+                )
+            )
+            assert description[0][0].startswith("number of rows inserted")
+            assert cur._total_rowcount == -1

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1246,5 +1246,5 @@ def test_describe(conn_cnx, db_parameters):
                     name=db_parameters["name"], value="1234"
                 )
             )
-            assert description[0][0].startswith("number of rows inserted")
+            assert description[0][0] == "number of rows inserted"
             assert cur.rowcount is None

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1247,4 +1247,4 @@ def test_describe(conn_cnx, db_parameters):
                 )
             )
             assert description[0][0].startswith("number of rows inserted")
-            assert cur._total_rowcount == -1
+            assert cur.rowcount is None


### PR DESCRIPTION
Before this change, if we run `cursor.describe("insert into ...")` (or `delete ...`), an "out of index" error will be returned because `data['rowset']` is empty, in `_init_result_and_meta` method in `cursor.py`. This PR fixes this bug and adds a corresponding test. 