### PR TITLE
SNOW-368531 Fix `executemany` insert qmarks behaviour

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1076,9 +1076,7 @@ class SnowflakeConnection(object):
                         "errno": ER_FAILED_PROCESSING_QMARK,
                     },
                 )
-            return TypeAndBinding(
-                v[0], self.converter.to_snowflake_bindings(v[0], v[1])
-            )
+            snowflake_type, v = v
         else:
             snowflake_type = self.converter.snowflake_type(v)
             if snowflake_type is None:
@@ -1094,10 +1092,10 @@ class SnowflakeConnection(object):
                         "errno": ER_NOT_IMPLICITY_SNOWFLAKE_DATATYPE,
                     },
                 )
-            return TypeAndBinding(
-                snowflake_type,
-                self.converter.to_snowflake_bindings(snowflake_type, v),
-            )
+        return TypeAndBinding(
+            snowflake_type,
+            self.converter.to_snowflake_bindings(snowflake_type, v),
+        )
 
     # TODO we could probably rework this to not make dicts like this: {'1': 'value', '2': '13'}
     def _process_params_qmarks(

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1066,8 +1066,11 @@ class SnowflakeConnection(object):
             }
             Error.errorhandler_wrapper(self, cursor, ProgrammingError, errorvalue)
 
-        def get_snowflake_type_and_binding(v):
-            TypeAndBinding = namedtuple("TypeAndBinding", ["type", "binding"])
+        TypeAndBinding = namedtuple("TypeAndBinding", ["type", "binding"])
+
+        def get_snowflake_type_and_binding(
+            v: Union[Tuple[str, Any], Any]
+        ) -> TypeAndBinding:
             if isinstance(v, tuple):
                 if len(v) != 2:
                     Error.errorhandler_wrapper(

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -344,9 +344,9 @@ class SnowflakeConverter(object):
         The output is bound in a query in the server side.
         """
         type_name = value.__class__.__name__.lower()
-        return getattr(
-            self, "_{type_name}_to_snowflake_bindings".format(type_name=type_name)
-        )(snowflake_type, value)
+        return getattr(self, f"_{type_name}_to_snowflake_bindings")(
+            snowflake_type, value
+        )
 
     def _str_to_snowflake_bindings(self, _, value):
         # NOTE: str type is always taken as a text data and never binary

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -97,7 +97,7 @@ def _convert_date_to_epoch_milliseconds(dt: datetime) -> str:
     return "{:.3f}".format((dt - ZERO_EPOCH_DATE).total_seconds()).replace(".", "")
 
 
-def _convert_time_to_epoch_nanoseconds(tm):
+def _convert_time_to_epoch_nanoseconds(tm: dt_t) -> str:
     return (
         str(tm.hour * 3600 + tm.minute * 60 + tm.second)
         + "{:06d}".format(tm.microsecond)
@@ -348,7 +348,7 @@ class SnowflakeConverter(object):
             snowflake_type, value
         )
 
-    def _str_to_snowflake_bindings(self, _, value):
+    def _str_to_snowflake_bindings(self, _, value: str) -> str:
         # NOTE: str type is always taken as a text data and never binary
         return str(value)
 
@@ -358,26 +358,28 @@ class SnowflakeConverter(object):
     _unicode_to_snowflake_bindings = _str_to_snowflake_bindings
     _decimal_to_snowflake_bindings = _str_to_snowflake_bindings
 
-    def _bytes_to_snowflake_bindings(self, _, value):
+    def _bytes_to_snowflake_bindings(self, _, value: bytes) -> str:
         return binascii.hexlify(value).decode("utf-8")
 
     _bytearray_to_snowflake_bindings = _bytes_to_snowflake_bindings
 
-    def _bool_to_snowflake_bindings(self, _, value):
+    def _bool_to_snowflake_bindings(self, _, value: bool) -> str:
         return str(value).lower()
 
-    def _nonetype_to_snowflake_bindings(self, *_):
+    def _nonetype_to_snowflake_bindings(self, *_) -> None:
         return None
 
-    def _date_to_snowflake_bindings(self, _, value):
+    def _date_to_snowflake_bindings(self, _, value: date) -> str:
         # milliseconds
         return _convert_date_to_epoch_milliseconds(value)
 
-    def _time_to_snowflake_bindings(self, _, value):
+    def _time_to_snowflake_bindings(self, _, value: dt_t) -> str:
         # nanoseconds
         return _convert_time_to_epoch_nanoseconds(value)
 
-    def _datetime_to_snowflake_bindings(self, snowflake_type, value):
+    def _datetime_to_snowflake_bindings(
+        self, snowflake_type: str, value: datetime
+    ) -> str:
         snowflake_type = snowflake_type.upper()
         if snowflake_type == "TIMESTAMP_LTZ":
             _, t = self._derive_offset_timestamp(value)
@@ -411,12 +413,16 @@ class SnowflakeConverter(object):
         offset = tzinfo.utcoffset(t.replace(tzinfo=None)).total_seconds() / 60 + 1440
         return offset, t
 
-    def _struct_time_to_snowflake_bindings(self, snowflake_type, value):
+    def _struct_time_to_snowflake_bindings(
+        self, snowflake_type: str, value: time.struct_time
+    ) -> str:
         return self._datetime_to_snowflake_bindings(
             snowflake_type, datetime.fromtimestamp(time.mktime(value))
         )
 
-    def _timedelta_to_snowflake_bindings(self, snowflake_type, value):
+    def _timedelta_to_snowflake_bindings(
+        self, snowflake_type: str, value: timedelta
+    ) -> str:
         snowflake_type = snowflake_type.upper()
         if snowflake_type != "TIME":
             raise ProgrammingError(
@@ -439,42 +445,40 @@ class SnowflakeConverter(object):
         The output is bound in a query in the client side.
         """
         type_name = value.__class__.__name__.lower()
-        return getattr(self, "_{type_name}_to_snowflake".format(type_name=type_name))(
-            value
-        )
+        return getattr(self, f"_{type_name}_to_snowflake")(value)
 
-    def _int_to_snowflake(self, value):
+    def _int_to_snowflake(self, value: int) -> int:
         return int(value)
 
     def _long_to_snowflake(self, value):
         return long(value)  # noqa: F821
 
-    def _float_to_snowflake(self, value):
+    def _float_to_snowflake(self, value: float) -> float:
         return float(value)
 
-    def _str_to_snowflake(self, value):
+    def _str_to_snowflake(self, value: str) -> str:
         return str(value)
 
     _unicode_to_snowflake = _str_to_snowflake
 
-    def _bytes_to_snowflake(self, value):
+    def _bytes_to_snowflake(self, value: bytes) -> bytes:
         return binary_to_snowflake(value)
 
     _bytearray_to_snowflake = _bytes_to_snowflake
 
-    def _bool_to_snowflake(self, value):
+    def _bool_to_snowflake(self, value: bool) -> bool:
         return value
 
-    def _bool__to_snowflake(self, value):
+    def _bool__to_snowflake(self, value) -> bool:
         return bool(value)
 
     def _nonetype_to_snowflake(self, _):
         return None
 
-    def _total_seconds_from_timedelta(self, td):
+    def _total_seconds_from_timedelta(self, td: timedelta) -> int:
         return sfdatetime_total_seconds_from_timedelta(td)
 
-    def _datetime_to_snowflake(self, value):
+    def _datetime_to_snowflake(self, value: datetime) -> str:
         tzinfo_value = value.tzinfo
         if tzinfo_value:
             if pytz.utc != tzinfo_value:
@@ -545,18 +549,18 @@ class SnowflakeConverter(object):
                 second=value.second,
             )
 
-    def _date_to_snowflake(self, value):
+    def _date_to_snowflake(self, value: date) -> str:
         """Converts Date object to Snowflake object."""
         return "{year:d}-{month:02d}-{day:02d}".format(
             year=value.year, month=value.month, day=value.day
         )
 
-    def _time_to_snowflake(self, value):
+    def _time_to_snowflake(self, value: dt_t) -> str:
         if value.microsecond:
             return value.strftime("%H:%M:%S.%%06d") % value.microsecond
         return value.strftime("%H:%M:%S")
 
-    def _struct_time_to_snowflake(self, value):
+    def _struct_time_to_snowflake(self, value: time.struct_time) -> str:
         tzinfo_value = _generate_tzinfo_from_tzoffset(time.timezone // 60)
         t = datetime.fromtimestamp(time.mktime(value))
         if pytz.utc != tzinfo_value:
@@ -564,7 +568,7 @@ class SnowflakeConverter(object):
         t = t.replace(tzinfo=tzinfo_value)
         return self._datetime_to_snowflake(t)
 
-    def _timedelta_to_snowflake(self, value):
+    def _timedelta_to_snowflake(self, value: timedelta) -> str:
         (hours, r) = divmod(value.seconds, 3600)
         (mins, secs) = divmod(r, 60)
         hours += value.days * 24
@@ -576,13 +580,13 @@ class SnowflakeConverter(object):
             hour=hours, minute=mins, second=secs
         )
 
-    def _decimal_to_snowflake(self, value):
+    def _decimal_to_snowflake(self, value: decimal.Decimal) -> Optional[str]:
         if isinstance(value, decimal.Decimal):
             return str(value)
 
         return None
 
-    def _list_to_snowflake(self, value):
+    def _list_to_snowflake(self, value: list) -> list:
         return [
             SnowflakeConverter.quote(v0)
             for v0 in [SnowflakeConverter.escape(v) for v in value]
@@ -605,10 +609,10 @@ class SnowflakeConverter(object):
     _float32_to_snowflake = __numpy_to_snowflake
     _float64_to_snowflake = __numpy_to_snowflake
 
-    def _datetime64_to_snowflake(self, value):
+    def _datetime64_to_snowflake(self, value) -> str:
         return str(value) + "+00:00"
 
-    def _quoted_name_to_snowflake(self, value):
+    def _quoted_name_to_snowflake(self, value) -> str:
         return str(value)
 
     def __getattr__(self, item):

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -399,7 +399,9 @@ class SnowflakeConverter(object):
                 errno=ER_NOT_SUPPORT_DATA_TYPE,
             )
 
-    def _derive_offset_timestamp(self, value, is_utc: bool = False):
+    def _derive_offset_timestamp(
+        self, value: datetime, is_utc: bool = False
+    ) -> Tuple[float, datetime]:
         """Derives TZ offset and timestamp from the datetime objects."""
         tzinfo = value.tzinfo
         if tzinfo is None:

--- a/src/snowflake/connector/sfbinaryformat.py
+++ b/src/snowflake/connector/sfbinaryformat.py
@@ -5,6 +5,7 @@
 #
 
 from base64 import b16decode, b16encode, standard_b64encode
+from typing import Union
 
 from .errors import InternalError
 

--- a/src/snowflake/connector/sfbinaryformat.py
+++ b/src/snowflake/connector/sfbinaryformat.py
@@ -12,7 +12,7 @@ from .errors import InternalError
 binary_to_python = b16decode
 
 
-def binary_to_snowflake(binary_value):
+def binary_to_snowflake(binary_value) -> Union[bytes, bytearray]:
     """Encodes a "bytes" object for passing to Snowflake."""
     result = b16encode(binary_value)
 

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -646,6 +646,7 @@ def test_executemany(conn, db_parameters):
         c.close()
 
 
+@pytest.mark.skipolddriver
 def test_executemany_qmark_types(conn, db_parameters):
     table_name = "date_test"
     with conn(paramstyle="qmark") as cnx:


### PR DESCRIPTION
This PR addresses changes requested in [SNOW-368531](https://snowflakecomputing.atlassian.net/browse/SNOW-368531)/ [GH Issue](https://github.com/snowflakedb/snowflake-connector-python/issues/750).

Our behavior when resolving the "type" of value had a bug. The best way to illustrate this would be with an example.

When using `executemany` to insert values, you would use a command such as this:

```python
    cursor.executemany(
        'INSERT INTO date_test (birth_date) values (?)',
        [[datetime.date(1969, 2, 7)],[datetime.date(1969, 1, 1)]]
    )
```
The `executemany` function would then transform the values in to a list like this ([see this](https://github.com/snowflakedb/snowflake-connector-python/blob/master/src/snowflake/connector/cursor.py#L985)) :
  ```python 

[ datetime.date(1969, 2, 7), datetime.date(1969, 1, 1) ] 

```

We would then determine the corresponding "snowflake type" for this list. [Lists are type "TEXT"](https://github.com/snowflakedb/snowflake-connector-python/blob/master/src/snowflake/connector/converter.py#L59) and thus when inserting these datetimes, Snowflake would interpret the epochs as "TEXT" which leads to the invalid dates appearing in the DB.

To fix this, I have set the "snowflake type" to  "TEXT" by default. However, if all of the values of the list have a certain type, say "DATE" in this case, we would update the "snowflake type" to "DATE" - which leads to a valid insert. 

Furthermore, users can now use Tuples to specify exactly which type they would like.
For example, they may do this:
```python
    cursor.executemany(
        'INSERT INTO date_test (birth_date) values (?)',
        [
               [ ("DATE", datetime.date(1969, 2, 7)) ],
               [ ("DATE", datetime.date(1969, 1, 1)) ]
        ]
    )
```




