### PR TITLE
SNOW-394801: Bumped up PythonConnector MINOR version from 2.4.6 to 2.5.0

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -10,6 +10,13 @@ Release Notes
 -------------------------------------------------------------------------------
 
 
+- v2.5.0(July 22,2021)
+
+   - Fixed a bug in write_pandas when quote_identifiers is set to True the function would not actually quote column names.
+   - Bumping idna dependency pin from <3,>=2.5 to >=2.5,<4
+   - Fix describe method when running `insert into ...` commands
+
+
 - v2.4.6(June 25,2021)
 
    - Fixed a potential memory leak.

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 4, 6, None)
+VERSION = (2, 5, 0, None)


### PR DESCRIPTION
@noreview - This is an automated process. No review is required