### PR TITLE
SNOW-414845 Fix Pandas and JSON Parallel Fetch

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -17,6 +17,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Generator,
     Iterator,
     List,
     NamedTuple,
@@ -1015,7 +1016,9 @@ class SnowflakeCursor(object):
             self.execute(command, param, _do_reset=False)
         return self
 
-    def _result_iterator(self):
+    def _result_iterator(
+        self,
+    ) -> Union[Generator[Dict, None, None], Generator[Tuple, None, None]]:
         """Yields the elements from _result and raises an exception when appropriate."""
         for _next in self._result:
             if isinstance(_next, Exception):
@@ -1111,7 +1114,7 @@ class SnowflakeCursor(object):
             self._inner_cursor = None
         self._prefetch_hook = None
 
-    def __iter__(self):
+    def __iter__(self) -> Union[Iterator[Dict], Iterator[Tuple]]:
         """Iteration over the result set."""
         # set _result if _result_set is not None
         if self._result is None and self._result_set is not None:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1015,14 +1015,9 @@ class SnowflakeCursor(object):
             self.execute(command, param, _do_reset=False)
         return self
 
-    def fetchone(self):
-        """Fetches one row."""
-        if self._prefetch_hook is not None:
-            self._prefetch_hook()
-        if self._result is None and self._result_set is not None:
-            self._result = iter(self._result_set)
-        try:
-            _next = next(self._result)
+    def _result_iterator(self):
+        """Yields the elements from _result and raises an exception when appropriate."""
+        for _next in self._result:
             if isinstance(_next, Exception):
                 Error.errorhandler_wrapper_from_ready_exception(
                     self._connection,
@@ -1030,7 +1025,16 @@ class SnowflakeCursor(object):
                     _next,
                 )
             self._rownumber += 1
-            return _next
+            yield _next
+
+    def fetchone(self) -> Optional[Union[Dict, Tuple]]:
+        """Fetches one row."""
+        if self._prefetch_hook is not None:
+            self._prefetch_hook()
+        if self._result is None and self._result_set is not None:
+            self._result = iter(self._result_set)
+        try:
+            return next(self._result_iterator())
         except StopIteration:
             return None
 
@@ -1109,9 +1113,10 @@ class SnowflakeCursor(object):
 
     def __iter__(self):
         """Iteration over the result set."""
+        # set _result if _result_set is not None
         if self._result is None and self._result_set is not None:
             self._result = iter(self._result_set)
-        return iter(self._result)
+        return self._result_iterator()
 
     def __cancel_query(self, query):
         if self._sequence_counter >= 0 and not self.is_closed():

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -200,8 +200,8 @@ class ResultBatch(abc.ABC):
 
     As you are iterating through a ResultBatch you should check whether the yielded
     value is an ``Exception`` in case there was some error parsing the current row
-    we might yield on of these to allow iteration to continue instead of raising the
-    ``Exception`` when it occures.
+    we might yield one of these to allow iteration to continue instead of raising the
+    ``Exception`` when it occurs.
 
     These objects are pickleable for easy distribution and replication.
 
@@ -454,6 +454,7 @@ class JSONResultBatch(ResultBatch):
                         self.schema,
                     ):
                         row_result[col.name] = v if c is None or v is None else c(v)
+                    result_list.append(row_result)
                 except Exception as error:
                     msg = f"Failed to convert: field {col.name}: {_t}::{v}, Error: {error}"
                     logger.exception(msg)
@@ -466,7 +467,6 @@ class JSONResultBatch(ResultBatch):
                             },
                         )
                     )
-                result_list.append(row_result)
         else:
             for row in downloaded_data:
                 row_result = [None] * len(self.schema)
@@ -479,6 +479,7 @@ class JSONResultBatch(ResultBatch):
                     ):
                         row_result[idx] = v if c is None or v is None else c(v)
                         idx += 1
+                    result_list.append(tuple(row_result))
                 except Exception as error:
                     msg = f"Failed to convert: field {_col.name}: {_t}::{v}, Error: {error}"
                     logger.exception(msg)
@@ -491,7 +492,6 @@ class JSONResultBatch(ResultBatch):
                             },
                         )
                     )
-                result_list.append(tuple(row_result))
         return result_list
 
     def __repr__(self) -> str:

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -228,6 +228,12 @@ class ResultBatch(abc.ABC):
         self._use_dict_result = use_dict_result
         self._metrics: Dict[str, int] = {}
         self._data: Optional[Union[str, List[Tuple[Any, ...]]]] = None
+        if self._remote_chunk_info:
+            parsed_url = urlparse(self._remote_chunk_info.url)
+            path_parts = parsed_url.path.rsplit("/", 1)
+            self.id = path_parts[-1]
+        else:
+            self.id = str(self.rowcount)
 
     @property
     def _local(self) -> bool:
@@ -257,16 +263,6 @@ class ResultBatch(abc.ABC):
     @property
     def column_names(self) -> List[str]:
         return [col.name for col in self.schema]
-
-    @property
-    def id(self) -> str:
-        """Returns an id for the chunk."""
-        if self._remote_chunk_info:
-            parsed_url = urlparse(self._remote_chunk_info.url)
-            path_parts = parsed_url.path.split("/")
-            return path_parts[-1]
-        else:
-            return str(self.rowcount)
 
     def __iter__(
         self,

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -72,7 +72,7 @@ def result_set_iterator(
 
         for _ in range(min(4, len(unfetched_batches))):
             logger.debug(
-                f"queuing download of result batch of size {unfetched_batches[0].rowcount}"
+                f"queuing download of result batch id: {unfetched_batches[0].id}"
             )
             unconsumed_batches.append(
                 pool.submit(unfetched_batches.popleft().create_iter, **kw)
@@ -87,7 +87,7 @@ def result_set_iterator(
             # Submit the next un-fetched batch to the pool
             if unfetched_batches:
                 logger.debug(
-                    f"queuing download of result batch of size {unfetched_batches[0].rowcount}"
+                    f"queuing download of result batch id: {unfetched_batches[0].id}"
                 )
                 future = pool.submit(unfetched_batches.popleft().create_iter, **kw)
                 unconsumed_batches.append(future)
@@ -236,7 +236,7 @@ class ResultSet(Iterable[List[Any]]):
         # batches that have not been fetched
         unfetched_batches = deque(self.batches[1:])
         for num, batch in enumerate(unfetched_batches):
-            logger.debug(f"result batch {num + 1} has size {batch.rowcount}")
+            logger.debug(f"result batch {num + 1} has id: {batch.id}")
 
         return result_set_iterator(
             first_batch_iter,

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1429,9 +1429,7 @@ def test_describe(conn_cnx):
             assert len(cur.fetchall()) == 0
 
             # test insert
-            cur.execute(
-                f"create table {table_name} (aa int)"
-            )
+            cur.execute(f"create table {table_name} (aa int)")
             try:
                 description = cur.describe(
                     "insert into {name}(aa) values({value})".format(
@@ -1441,10 +1439,10 @@ def test_describe(conn_cnx):
                 assert description[0][0] == "number of rows inserted"
                 assert cur.rowcount is None
             finally:
-                cur.execute(
-                    f"drop table if exists {table_name}"
-                )
+                cur.execute(f"drop table if exists {table_name}")
 
+
+@pytest.mark.skipolddriver
 def test_fetch_batches_with_sessions(conn_cnx):
     rowcount = 250_000
     with conn_cnx() as con:

--- a/test/unit/test_result_batch.py
+++ b/test/unit/test_result_batch.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All right reserved.
 #
 
-import importlib
 from collections import namedtuple
 from http import HTTPStatus
 from test.helpers import create_mock_response
@@ -39,23 +38,30 @@ from snowflake.connector.errors import (
     OtherHTTPRetryableError,
     ServiceUnavailableError,
 )
-from snowflake.connector.result_batch import MAX_DOWNLOAD_RETRY, JSONResultBatch
+
+try:
+    from snowflake.connector.result_batch import MAX_DOWNLOAD_RETRY, JSONResultBatch
+except ImportError:
+    MAX_DOWNLOAD_RETRY = None
+    JSONResultBatch = None
 from snowflake.connector.sqlstate import (
     SQLSTATE_CONNECTION_REJECTED,
     SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
 )
 
-pytestmark = pytest.mark.skipolddriver
+try:
+    from snowflake.connector.vendored import requests  # NOQA
 
-REQUEST_MODULE_PATH = (
-    "snowflake.connector.vendored.requests"
-    if importlib.util.find_spec("snowflake.connector.vendored.requests")
-    else "requests"
-)
+    REQUEST_MODULE_PATH = "snowflake.connector.vendored.requests"
+except ImportError:
+    REQUEST_MODULE_PATH = "requests"
+
 
 MockRemoteChunkInfo = namedtuple("MockRemoteChunkInfo", "url")
 chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
-result_batch = JSONResultBatch(100, None, chunk_info, [], [], True)
+result_batch = (
+    JSONResultBatch(100, None, chunk_info, [], [], True) if JSONResultBatch else None
+)
 
 
 @mock.patch(REQUEST_MODULE_PATH + ".get")


### PR DESCRIPTION
1. What JIRA issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-361211](https://snowflakecomputing.atlassian.net/browse/SNOW-361211) with what should be the final performance-related bug. See performance runs 7903, 7911 on the ClientPerfs Dashboard.
2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
      -  logging when `_parse` is invoked.
   - [ ] I am modyfying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modyfying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This changes the `_get_pandas_iter` function to return an iterator rather than have it be a generator. Since it must return 
   an iterator, when `create_iter` is submitted to the TPE, the download will happen. 
  Likewise, JSONResultBatch's `_parse` function is changed to return a list rather than be a generator (and hence parsing 
  happens when the function is called rather than when the result is iterated over).