### PR TITLE
SNOW-430464 rework stream request get to process all the response at request time

### DIFF
--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -356,10 +356,6 @@ class ResultBatch(abc.ABC):
         """
         raise NotImplementedError()
 
-    def _done_load(self, response: "Response") -> None:
-        """Performs cleanup after loading from `response` is done."""
-        response.close()
-
     def _check_can_use_pandas(self) -> None:
         if not installed_pandas:
             msg = (
@@ -575,7 +571,6 @@ class ArrowResultBatch(ResultBatch):
         if row_unit == IterUnit.TABLE_UNIT:
             iter.init_table_unit()
 
-        self._done_load(response)
         return iter
 
     def _from_data(

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -7,7 +7,6 @@ import json
 import time
 from base64 import b64decode
 from enum import Enum, unique
-from gzip import GzipFile
 from logging import getLogger
 from typing import (
     TYPE_CHECKING,
@@ -290,7 +289,6 @@ class ResultBatch(abc.ABC):
                         "url": chunk_url,
                         "headers": self._chunk_headers,
                         "timeout": DOWNLOAD_TIMEOUT,
-                        "stream": True,
                     }
                     if connection:
                         with connection._rest._use_requests_session() as session:
@@ -437,10 +435,8 @@ class JSONResultBatch(ResultBatch):
             Unfortunately there's not type hint for this.
             For context: https://github.com/python/typing/issues/182
         """
-        with GzipFile(fileobj=response.raw, mode="r") as gfd:
-            read_data: str = gfd.read().decode("utf-8", "replace")
-            self._done_load(response)
-            return json.loads("".join(["[", read_data, "]"]))
+        read_data = response.text
+        return json.loads("".join(["[", read_data, "]"]))
 
     def _parse(
         self, downloaded_data
@@ -568,11 +564,9 @@ class ArrowResultBatch(ResultBatch):
         """
         from .arrow_iterator import PyArrowIterator
 
-        gfd = GzipFile(fileobj=response.raw, mode="r")
-
         iter = PyArrowIterator(
             None,
-            gfd,
+            io.BytesIO(response.content),
             self._context,
             self._use_dict_result,
             self._numpy,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-430464

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Ever since we merged https://github.com/snowflakedb/snowflake-connector-python/commit/740d9b9003ca8c0adee77628dce85d981919e66f our performance tests have been failing on Azure.
   I tracked the issue down to https://github.com/snowflakedb/snowflake-connector-python/blob/740d9b9003ca8c0adee77628dce85d981919e66f/src/snowflake/connector/result_batch.py#L324 not retrying as it should have.
   
   When I dove into the diff between the old `chunk_downloader` code I found the same retry logic here: https://github.com/snowflakedb/snowflake-connector-python/blob/8466e8d455186c270ef90f9070eea20f17373f25/src/snowflake/connector/chunk_downloader.py#L173
   I tracked down the new retry to not work because download returned a stream (just like we did before), but we don't read the stream right after inside of that retry `try-catch` clause.
   So my solution is to stop using streaming and force reading all of the response at the request time, to force `ECONNRESET`s to happen then. When using `ArrowResultBatch` we do need to send in a file like object, so I wrap the `bytes` in a `BytesIO`.

   Successful performance test against Azure: https://jenkins.int.snowflakecomputing.com/job/ClientPerfRunner/8192/


   Funny enough, these `ECONNRESET`s look to have been always happening with Azure, if you take a look at https://jenkins.int.snowflakecomputing.com/job/ClientPerfRunner/8107/artifact/python_connector.log.gz which is from before we merged the parallel fetch changes, you'll see that the same error happened and we just retried. We should maybe look into why these connections get reset.