### PR TITLE
SNOW-424556 bump macosx target version

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Generate wheel
         run: python3 -m pip wheel -v -w dist --no-deps .
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.13  # Should be kept in sync with ci/build_darwin.sh
+          MACOSX_DEPLOYMENT_TARGET: 10.14  # Should be kept in sync with ci/build_darwin.sh
       - name: Show wheels generated
         run: ls -lh dist/
       - uses: actions/upload-artifact@v2

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -18,7 +18,7 @@ mkdir -p ${DIST_DIR}
 
 # Make sure we build for our lowest target
 # Should be kept in sync with .github/worklfows/build_test.yml
-export MACOSX_DEPLOYMENT_TARGET="10.13"
+export MACOSX_DEPLOYMENT_TARGET="10.14"
 for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     # Constants and setup
     PYTHON="python${PYTHON_VERSION}"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-424556

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Bumping the Mac OSX target version to `10.14` as we dropped support for `10.13`.
