### PR TITLE
SNOW-436322 mark HeartBeatTimer threads as daemon threads

### DIFF
--- a/src/snowflake/connector/time_util.py
+++ b/src/snowflake/connector/time_util.py
@@ -25,6 +25,8 @@ class HeartBeatTimer(Timer):
     def __init__(self, client_session_keep_alive_heartbeat_frequency, f):
         interval = client_session_keep_alive_heartbeat_frequency
         super(HeartBeatTimer, self).__init__(interval, f)
+        # Mark this as a daemon thread, so that it won't prevent Python from exiting.
+        self.daemon = True
 
     def run(self):
         while not self.finished.is_set():


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #836 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This marks non-critical HeartBeatTimer threads as daemon threads (threads that should not keep the Python process from exiting while they are running).
