### PR TITLE
SNOW-446950 default value bugfix

### DIFF
--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -166,7 +166,7 @@ def create_batches_from_response(
             column_converters,
             cursor._use_dict_result,
         )
-    elif rowset_b64:
+    elif rowset_b64 is not None:
         first_chunk = ArrowResultBatch.from_data(
             rowset_b64,
             first_chunk_len,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-446950

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The newest release has a bug where the else clause of the modified if-then clause gets triggered when `rowset_b64` because empty string evaluates as `False`. This fixes the bug, so that the else clause shouldn't be triggered.