### PR TITLE
SNOW-452162 remove deprecated setuptools option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,6 @@ setup(
     license="Apache License, Version 2.0",
     keywords="Snowflake db database cloud analytics warehouse",
     url="https://www.snowflake.com/",
-    use_2to3=False,
     project_urls={
         "Documentation": "https://docs.snowflake.com/",
         "Code": "https://github.com/snowflakedb/snowflake-connector-python",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-452162

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `use_2to3` was deprecated yesterday by `setuptools` https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5802 , removing this option now