### PR TITLE
SNOW-449590: Update signature of SnowflakeCursor.execute to accept Dict[Any, Any] as params

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1109,13 +1109,6 @@ class SnowflakeConnection(object):
             return None
         processed_params = {}
 
-        if not isinstance(params, (list, tuple)):
-            errorvalue = {
-                "msg": "Binding parameters must be a list: {}".format(params),
-                "errno": ER_FAILED_PROCESSING_PYFORMAT,
-            }
-            Error.errorhandler_wrapper(self, cursor, ProgrammingError, errorvalue)
-
         get_type_and_binding = partial(self._get_snowflake_type_and_binding, cursor)
 
         for idx, v in enumerate(params):

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -559,7 +559,7 @@ class SnowflakeCursor:
     def execute(
         self,
         command: str,
-        params: Optional[Sequence] = None,
+        params: Optional[Union[Sequence, Dict[Any, Any]]] = None,
         _bind_stage: Optional[str] = None,
         timeout: Optional[int] = None,
         _exec_async: bool = False,

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -42,6 +42,7 @@ from .constants import (
 )
 from .errorcode import (
     ER_CURSOR_IS_CLOSED,
+    ER_FAILED_PROCESSING_PYFORMAT,
     ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
     ER_INVALID_VALUE,
     ER_NO_ARROW_RESULT,
@@ -663,6 +664,17 @@ class SnowflakeCursor:
                 if _bind_stage:
                     kwargs["binding_stage"] = _bind_stage
                 else:
+                    if not isinstance(params, (list, tuple)):
+                        errorvalue = {
+                            "msg": "Binding parameters must be a list: {}".format(
+                                params
+                            ),
+                            "errno": ER_FAILED_PROCESSING_PYFORMAT,
+                        }
+                        Error.errorhandler_wrapper(
+                            self.connection, self, ProgrammingError, errorvalue
+                        )
+
                     kwargs["binding_params"] = self._connection._process_params_qmarks(
                         params, self
                     )


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #848 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The type hint of `SnowflakeCursor.execute` has been updated to accept a `Dict[Any, Any]` params. This is a valid type for the `pyformat` binding style and should thus be a valid input type to `execute`. The type check for the list-based `qmark` binding style has been moved out of `_process_params_qmarks` and into `SnowflakeCursor.execute` such that the types provided to the formatting function are true to its signature.
