### PR TITLE
SNOW-466099 fixed remote file HEAD bug

### DIFF
--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -319,7 +319,7 @@ class SnowflakeStorageClient(ABC):
             os.makedirs(base_dir)
 
         # HEAD
-        file_header = self.get_file_header(self.meta.dst_file_name)
+        file_header = self.get_file_header(self.meta.real_src_file_name)
 
         if file_header and file_header.encryption_metadata:
             self.encryption_metadata = file_header.encryption_metadata

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -619,9 +619,11 @@ def test_multipart_put(sdkless, conn_cnx, tmp_path):
                     "snowflake.connector.constants.S3_CHUNK_SIZE", chunk_size
                 ):
                     cur.execute(
-                        f"put file://{upload_file} @{stage_name} AUTO_COMPRESS=FALSE"
+                        f"put file://{upload_file} @{stage_name}/sub/folders/ AUTO_COMPRESS=FALSE"
                     )
-            cur.execute(f"get @{stage_name} file://{get_dir}")
-    downloaded_file = get_dir / "file0"
+            cur.execute(
+                f"get @{stage_name}/sub/folders/{upload_file.name} file://{get_dir}"
+            )
+    downloaded_file = get_dir / upload_file.name
     assert downloaded_file.exists()
     assert filecmp.cmp(upload_file, downloaded_file)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-466099

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   I made a bug, where before downloading a file we performed a HEAD on that remote file, when generating the url to perform the HEAD on I attached the name of the file instead of the url instead of the full path.
   As an example consider that we wanted to reach: `snowflakes-super-secret-customer-stage.s3.amazonaws.com/u8er7-s-afdas3255/stages/ae0c05e7-29a3-47frg-9555-35cssfde8787/sub/folders/test.csv`, we instead generated: `snowflakes-super-secret-customer-stage.s3.amazonaws.com/u8er7-s-afdas3255/stages/ae0c05e7-29a3-47frg-9555-35cssfde8787/test.csv` (notice the missing `sub/folders/`).
   
   This PR fixes the described bug and modifies an already existing test to verify behavior in the future.
