### PR TITLE
SNOW-469340 add _no_retry option when submitting queries

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -913,6 +913,7 @@ class SnowflakeConnection:
         describe_only: bool = False,
         _no_results: bool = False,
         _update_current_object: bool = True,
+        _no_retry: bool = False,
     ):
         """Executes a query with a sequence counter."""
         logger.debug("_cmd_query")
@@ -953,6 +954,7 @@ class SnowflakeConnection:
             client=client,
             _no_results=_no_results,
             _include_retry_params=True,
+            _no_retry=_no_retry,
         )
 
         if ret is None:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -801,7 +801,6 @@ class SnowflakeCursor:
         for documentation.
         """
         kwargs["_exec_async"] = True
-        kwargs["_no_retry"] = kwargs.pop("no_retry", False)
         return self.execute(*args, **kwargs)
 
     def describe(self, *args, **kwargs) -> list[ResultMetadata]:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -408,6 +408,7 @@ class SnowflakeCursor:
         describe_only: bool = False,
         _no_results: bool = False,
         _is_put_get=None,
+        _no_retry: bool = False,
     ):
         del self.messages[:]
 
@@ -512,6 +513,7 @@ class SnowflakeCursor:
                 is_internal=is_internal,
                 describe_only=describe_only,
                 _no_results=_no_results,
+                _no_retry=_no_retry,
             )
         finally:
             try:
@@ -561,6 +563,7 @@ class SnowflakeCursor:
         _bind_stage: str | None = None,
         timeout: int | None = None,
         _exec_async: bool = False,
+        _no_retry: bool = False,
         _do_reset: bool = True,
         _put_callback: SnowflakeProgressPercentage = None,
         _put_azure_callback: SnowflakeProgressPercentage = None,
@@ -587,6 +590,7 @@ class SnowflakeCursor:
             _bind_stage: Path in temporary stage where binding parameters are uploaded as CSV files.
             timeout: Number of seconds after which to abort the query.
             _exec_async: Whether to execute this query asynchronously.
+            _no_retry: Whether or not to retry on known errors.
             _do_reset: Whether or not the result set needs to be reset before executing query.
             _put_callback: Function to which GET command should call back to.
             _put_azure_callback: Function to which an Azure GET command should call back to.
@@ -636,6 +640,7 @@ class SnowflakeCursor:
             "describe_only": _describe_only,
             "_no_results": _no_results,
             "_is_put_get": _is_put_get,
+            "_no_retry": _no_retry,
         }
 
         if self._connection.is_pyformat:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -801,6 +801,7 @@ class SnowflakeCursor:
         for documentation.
         """
         kwargs["_exec_async"] = True
+        kwargs["_no_retry"] = kwargs.pop("no_retry", False)
         return self.execute(*args, **kwargs)
 
     def describe(self, *args, **kwargs) -> list[ResultMetadata]:

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -875,42 +875,12 @@ class SnowflakeRestful:
                 )
             cause = e.args[0]
             if no_retry:
-                logger.error(cause)
-                TelemetryService.get_instance().log_http_request_error(
-                    "HttpRequestError: %s" % str(cause),
-                    full_url,
-                    method,
-                    SQLSTATE_IO_ERROR,
-                    ER_FAILED_TO_REQUEST,
-                    retry_timeout=retry_ctx.total_timeout,
-                    retry_count=retry_ctx.cnt,
-                    exception=str(e),
-                    stack_trace=traceback.format_exc(),
-                )
-                if isinstance(cause, Error):
-                    Error.errorhandler_wrapper_from_cause(conn, cause)
-                else:
-                    self.handle_invalid_certificate_error(conn, full_url, cause)
+                self.log_and_handle_http_error_with_cause(e, full_url, method, retry_ctx, conn, timed_out=False)
                 return {}  # required for tests
             if retry_ctx.timeout is not None:
                 retry_ctx.timeout -= int(time.time() - start_request_thread)
                 if retry_ctx.timeout <= 0:
-                    logger.error(cause, exc_info=True)
-                    TelemetryService.get_instance().log_http_request_error(
-                        "HttpRequestRetryTimeout",
-                        full_url,
-                        method,
-                        SQLSTATE_IO_ERROR,
-                        ER_FAILED_TO_REQUEST,
-                        retry_timeout=retry_ctx.total_timeout,
-                        retry_count=retry_ctx.cnt,
-                        exception=str(e),
-                        stack_trace=traceback.format_exc(),
-                    )
-                    if isinstance(cause, Error):
-                        Error.errorhandler_wrapper_from_cause(conn, cause)
-                    else:
-                        self.handle_invalid_certificate_error(conn, full_url, cause)
+                    self.log_and_handle_http_error_with_cause(e, full_url, method, retry_ctx, conn)
                     return {}  # required for tests
             sleeping_time = retry_ctx.next_sleep()
             logger.debug(
@@ -933,6 +903,25 @@ class SnowflakeRestful:
                 raise e
             logger.debug("Ignored error", exc_info=True)
             return {}
+
+    def log_and_handle_http_error_with_cause(self, e, full_url, method, retry_ctx, conn, timed_out=True):
+        cause = e.args[0]
+        logger.error(cause, exc_info=True)
+        TelemetryService.get_instance().log_http_request_error(
+            "HttpRequestRetryTimeout" if timed_out else "HttpRequestError: %s" % str(cause),
+            full_url,
+            method,
+            SQLSTATE_IO_ERROR,
+            ER_FAILED_TO_REQUEST,
+            retry_timeout=retry_ctx.total_timeout,
+            retry_count=retry_ctx.cnt,
+            exception=str(e),
+            stack_trace=traceback.format_exc(),
+        )
+        if isinstance(cause, Error):
+            Error.errorhandler_wrapper_from_cause(conn, cause)
+        else:
+            self.handle_invalid_certificate_error(conn, full_url, cause)
 
     def handle_invalid_certificate_error(self, conn, full_url, cause):
         # all other errors raise exception

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -431,6 +431,7 @@ class SnowflakeRestful:
         _no_results=False,
         timeout=None,
         _include_retry_params=False,
+        _no_retry=False,
     ):
         if body is None:
             body = {}
@@ -470,6 +471,7 @@ class SnowflakeRestful:
                 _no_results=_no_results,
                 timeout=timeout,
                 _include_retry_params=_include_retry_params,
+                no_retry=_no_retry,
             )
         else:
             return self._get_request(url, headers, token=self.token, timeout=timeout)

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -209,3 +209,11 @@ def test_fetch():
     cnt.set(NOT_RETRYABLE)
     with pytest.raises(NotRetryableException):
         rest.fetch(timeout=7, **default_parameters)
+
+    # first attempt fails and will not retry
+    cnt.reset()
+    default_parameters["no_retry"] = True
+    ret = rest.fetch(timeout=10, **default_parameters)
+    assert ret == {}
+    assert cnt.c == 1  # failed on first call - did not retry
+    assert rest._connection.errorhandler.called  # error


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-469340](https://github.com/snowflakedb/snowflake-connector-python/issues/878)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This makes it possible to pass a `no_retry=True` parameter to the `execute_async` outer method to allow the user to skip the retries done by the connector and return the error to the user. The underlying `_post_request` method in `network.py` already had a parameter `no_retry`. The change only propagates that parameter from the upper methods down to that `_post_request` method and in case set to `True` it returns an indicative and desired error to the user.