### PR TITLE
Wait for URL input after SSO login

### DIFF
--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -41,11 +41,6 @@ BUF_SIZE = 16384
 # Snowflake server
 
 
-def _get_url_from_input(self):
-    # function here to facilitate tests better
-    return input("Enter the URL the SSO URL redirected you to: ")
-
-
 class AuthByWebBrowser(AuthByPlugin):
     """Authenticates user by web browser. Only used for SAML based authentication."""
 
@@ -140,7 +135,7 @@ class AuthByWebBrowser(AuthByPlugin):
                     "URL you are redirected to into the terminal."
                 )
                 print(f"URL: {sso_url}")
-                url = _get_url_from_input()
+                url = input("Enter the URL the SSO URL redirected you to: ")
                 self._process_get_url(url)
                 if not self._token:
                     # Input contained no token, either URL was incorrectly pasted,

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -41,6 +41,11 @@ BUF_SIZE = 16384
 # Snowflake server
 
 
+def _get_url_from_input(self):
+    # function here to facilitate tests better
+    return input("Enter the URL the SSO URL redirected you to: ")
+
+
 class AuthByWebBrowser(AuthByPlugin):
     """Authenticates user by web browser. Only used for SAML based authentication."""
 
@@ -129,23 +134,30 @@ class AuthByWebBrowser(AuthByPlugin):
 
             logger.debug("step 2: open a browser")
             if not self._webbrowser.open_new(sso_url):
-                logger.error(
-                    "Unable to open a browser in this environment.", exc_info=True
-                )
                 print(
                     "We were unable to open a browser window for you, "
-                    f"please open the following url manually: {sso_url}"
+                    "please open the following url manually then paste the "
+                    "URL you are redirected to into the terminal."
                 )
-                self.handle_failure(
-                    {
-                        "code": ER_UNABLE_TO_OPEN_BROWSER,
-                        "message": "Unable to open a browser in this environment.",
-                    }
-                )
-                return  # required for test case
-
-            logger.debug("step 3: accept SAML token")
-            self._receive_saml_token(socket_connection)
+                print(f"URL: {sso_url}")
+                url = _get_url_from_input()
+                self._process_get_url(url)
+                if not self._token:
+                    # Input contained no token, either URL was incorrectly pasted,
+                    # empty or just wrong
+                    self.handle_failure(
+                        {
+                            "code": ER_UNABLE_TO_OPEN_BROWSER,
+                            "message": (
+                                "Unable to open a browser in this environment and "
+                                "SSO URL contained no token"
+                            ),
+                        }
+                    )
+                    return
+            else:
+                logger.debug("step 3: accept SAML token")
+                self._receive_saml_token(socket_connection)
         finally:
             socket_connection.close()
 
@@ -265,6 +277,14 @@ You can close this window now and go back where you started from.
             ":".join(origin_line.split(":")[1:]).strip(),
         )
 
+    def _process_get_url(self, url: str) -> None:
+        parsed = parse_qs(urlparse(url).query)
+        if "token" not in parsed:
+            return
+        if not parsed["token"][0]:
+            return
+        self._token = parsed["token"][0]
+
     def _process_get(self, data):
         for line in data:
             if line.startswith("GET "):
@@ -275,7 +295,7 @@ You can close this window now and go back where you started from.
 
         self._get_user_agent(data)
         _, url, _ = target_line.split()
-        self._token = parse_qs(urlparse(url).query)["token"][0]
+        self._process_get_url(url)
         return True
 
     def _process_post(self, data):

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -6,6 +6,8 @@
 
 from mock import MagicMock, Mock, PropertyMock
 
+import pytest
+
 from snowflake.connector.auth_webbrowser import AuthByWebBrowser
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
@@ -108,9 +110,21 @@ def test_auth_webbrowser_post():
     assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
 
 
-def test_auth_webbrowser_fail_webbrowser():
+@pytest.mark.parametrize(
+    "input_text,expected_error",
+    [
+        ("", True),
+        ("http://example.com/notokenurl", True),
+        ("http://example.com/sso?token=", True),
+        ("http://example.com/sso?token=MOCK_TOKEN", False),
+    ],
+)
+def test_auth_webbrowser_fail_webbrowser(
+    monkeypatch, capsys, input_text, expected_error
+):
     """Authentication by WebBrowser with failed to start web browser case."""
     rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+    ref_token = "MOCK_TOKEN"
 
     # mock webbrowser
     mock_webbrowser = MagicMock()
@@ -130,12 +144,34 @@ def test_auth_webbrowser_fail_webbrowser():
     auth = AuthByWebBrowser(
         rest, APPLICATION, webbrowser_pkg=mock_webbrowser, socket_pkg=mock_socket
     )
+    mock__get_url_from_input = Mock(return_value=input_text)
+    monkeypatch.setattr(
+        "snowflake.connector.auth_webbrowser._get_url_from_input",
+        mock__get_url_from_input,
+    )
     auth.authenticate(AUTHENTICATOR, SERVICE_NAME, ACCOUNT, USER, PASSWORD)
-    assert rest._connection.errorhandler.called  # an error
-    assert auth.assertion_content is None
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "Initiating login request with your identity provider. A browser window "
+        "should have opened for you to complete the login. If you can't see it, "
+        "check existing browser windows, or your OS settings. Press CTRL+C to "
+        "abort and try again...\nWe were unable to open a browser window for "
+        "you, please open the following url manually then paste the URL you "
+        f"are redirected to into the terminal.\nURL: {REF_SSO_URL}\n"
+    )
+    if expected_error:
+        assert rest._connection.errorhandler.called  # an error
+        assert auth.assertion_content is None
+    else:
+        assert not rest._connection.errorhandler.called  # no error
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
 
 
-def test_auth_webbrowser_fail_webserver():
+def test_auth_webbrowser_fail_webserver(capsys):
     """Authentication by WebBrowser with failed to start web browser case."""
     rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
@@ -159,6 +195,13 @@ def test_auth_webbrowser_fail_webserver():
         rest, APPLICATION, webbrowser_pkg=mock_webbrowser, socket_pkg=mock_socket
     )
     auth.authenticate(AUTHENTICATOR, SERVICE_NAME, ACCOUNT, USER, PASSWORD)
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "Initiating login request with your identity provider. A browser window "
+        "should have opened for you to complete the login. If you can't see it, "
+        "check existing browser windows, or your OS settings. Press CTRL+C to "
+        "abort and try again...\n"
+    )
     assert rest._connection.errorhandler.called  # an error
     assert auth.assertion_content is None
 

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -3,10 +3,8 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
 #
-
-from mock import MagicMock, Mock, PropertyMock
-
 import pytest
+from mock import MagicMock, Mock, PropertyMock, patch
 
 from snowflake.connector.auth_webbrowser import AuthByWebBrowser
 from snowflake.connector.constants import OCSPMode
@@ -144,12 +142,8 @@ def test_auth_webbrowser_fail_webbrowser(
     auth = AuthByWebBrowser(
         rest, APPLICATION, webbrowser_pkg=mock_webbrowser, socket_pkg=mock_socket
     )
-    mock__get_url_from_input = Mock(return_value=input_text)
-    monkeypatch.setattr(
-        "snowflake.connector.auth_webbrowser._get_url_from_input",
-        mock__get_url_from_input,
-    )
-    auth.authenticate(AUTHENTICATOR, SERVICE_NAME, ACCOUNT, USER, PASSWORD)
+    with patch("builtins.input", return_value=input_text):
+        auth.authenticate(AUTHENTICATOR, SERVICE_NAME, ACCOUNT, USER, PASSWORD)
     captured = capsys.readouterr()
     assert captured.out == (
         "Initiating login request with your identity provider. A browser window "


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #303

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   PR #847 only added printing of the SSO URL however that is not enough when you depend on the response or in this case the URL you are redirected to as part of the SSO Authentication. This PR waits for the user to copy/paste the URL they are redirected to and extracts the token from it.

I can now use Snowflake from Google Colab by installing from my branch
```
pip install "https://github.com/iserko/snowflake-connector-python/archive/refs/heads/SNOW-XXXXXX_wait_for_url_input_after_sso.zip#egg=snowflake-connector-python[secure-local-storage]"
```

Caveat, prior to installing it, you may need to ensure you have the build requirements:
```
pip install "setuptools>=40.6.0" wheel cython "pyarrow>=5.0.0,<5.1.0"
```

Example from Google Colab:
<img width="1031" alt="Screenshot 2021-09-30 at 21 10 00" src="https://user-images.githubusercontent.com/473071/135525764-fc763c42-50c4-4b55-996e-d679d4272b2b.png">