### PR TITLE
SNOW-487250 remove D_GLIBCXX_USE_CXX11_ABI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
                     ext.extra_compile_args.append("-isystem" + numpy.get_include())
                     if "std=" not in os.environ.get("CXXFLAGS", ""):
                         ext.extra_compile_args.append("-std=c++11")
-                        ext.extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
                 ext.library_dirs.append(
                     os.path.join(current_dir, self.build_lib, "snowflake", "connector")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-487250

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This build flag was added back in the day for what I think was a workaround for the really old compiler we internally used.
   This flag has been causing issues to some of our customers, who are using Anaconda.
   In this PR I want to remove it as it doesn't seem necessary anymore.