### PR TITLE
SNOW-487961 set use_s3_regional_url with named arguments only

### DIFF
--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -652,7 +652,7 @@ class SnowflakeFileTransferAgent:
                 self._credentials,
                 self._stage_info,
                 S3_CHUNK_SIZE,
-                self._use_s3_regional_url,
+                use_s3_regional_url = self._use_s3_regional_url,
             )
         elif self._stage_location_type == GCS_FS:
             return SnowflakeGCSRestClient(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-487961

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fixing a bug where `use_s3_regional_url` was sent in as a positional argument into the wrong argument.