### PR TITLE
Cleaner quoting

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -184,7 +184,10 @@ def write_pandas(
     # in Snowflake, all parquet data is stored in a single column, $1, so we must select columns explicitly
     # see (https://docs.snowflake.com/en/user-guide/script-data-load-transform-parquet.html)
     if quote_identifiers:
-        parquet_columns = ", ".join([f'$1:"{c}"' for c in df.columns])
+        if quote_identifiers=='smart':
+            parquet_columns = ", ".join([f'$1:"{c}"' if '-' in c else c for c in df.columns])
+        else:
+            parquet_columns = ", ".join([f'$1:"{c}"' for c in df.columns])
     else:
         parquet_columns = ", ".join([f'$1:{c}' for c in df.columns])
     copy_into_sql = (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes: If the first field is quoted unnecessarily, the identifier is rejected.
   `quote_identifiers='smart'` will only wrap field identifiers in quotes if there is a `-` present. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   All or nothing identifier quoting can cause syntax errors. Double quotes should only be used when necessary to specify the correct field name in cases such as names with dashes. 
