### PR TITLE
SNOW-493094 removing s3_connection_pool_size connection parameter

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -44,8 +44,6 @@ from .auth_webbrowser import AuthByWebBrowser
 from .bind_upload_agent import BindUploadError
 from .compat import IS_LINUX, IS_WINDOWS, quote, urlencode
 from .constants import (
-    DEFAULT_S3_CONNECTION_POOL_SIZE,
-    MAX_S3_CONNECTION_POOL_SIZE,
     PARAMETER_AUTOCOMMIT,
     PARAMETER_CLIENT_PREFETCH_THREADS,
     PARAMETER_CLIENT_REQUEST_MFA_TOKEN,
@@ -165,7 +163,6 @@ DEFAULT_CONFIGURATION: Dict[str, Tuple[Any, Union[Type, Tuple[Type, ...]]]] = {
         (type(None), int),
     ),  # snowflake
     "client_prefetch_threads": (4, int),  # snowflake
-    "s3_connection_pool_s": (DEFAULT_S3_CONNECTION_POOL_SIZE, int),  # boto3 pool size
     "numpy": (False, bool),  # snowflake
     "ocsp_response_cache_filename": (None, (type(None), str)),  # snowflake internal
     "converter_class": (DefaultConverterClass(), SnowflakeConverter),
@@ -242,7 +239,6 @@ class SnowflakeConnection(object):
         network_timeout: Network timeout. Used for general purpose.
         client_session_keepalive: Whether to keep connection alive by issuing a heartbeat.
         client_session_keep_alive_heartbeat_frequency: Heartbeat frequency to keep connection alive in seconds.
-        s3_connection_pool_size: Size of connection pool for S3 boto driver.  Default is 10.
         client_prefetch_threads: Number of threads to download the result set.
         rest: Snowflake REST API object. Internal use only. Maybe removed in a later release.
         application: Application name to communicate with Snowflake as. By default, this is "PythonConnector".
@@ -391,15 +387,6 @@ class SnowflakeConnection(object):
     def client_session_keep_alive_heartbeat_frequency(self, value):
         self._client_session_keep_alive_heartbeat_frequency = value
         self._validate_client_session_keep_alive_heartbeat_frequency()
-
-    @property
-    def _s3_connection_pool_size(self) -> int:
-        return self._s3_connection_pool_s
-
-    @_s3_connection_pool_size.setter
-    def _s3_connection_pool_size(self, value: int) -> None:
-        self._s3_connection_pool_s = value
-        self._validate_s3_connection_pool_size()
 
     @property
     def client_prefetch_threads(self):
@@ -1272,13 +1259,6 @@ class SnowflakeConnection(object):
             self.client_session_keep_alive_heartbeat_frequency
         )
         return self.client_session_keep_alive_heartbeat_frequency
-
-    def _validate_s3_connection_pool_size(self) -> None:
-        if self._s3_connection_pool_s <= 0:
-            self._s3_connection_pool_s = 1
-        elif self._s3_connection_pool_s > MAX_S3_CONNECTION_POOL_SIZE:
-            self._s3_connection_pool_s = MAX_S3_CONNECTION_POOL_SIZE
-        self._s3_connection_pool_s = int(self._s3_connection_pool_s)
 
     def _validate_client_prefetch_threads(self):
         if self.client_prefetch_threads <= 0:

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -192,9 +192,6 @@ HTTP_HEADER_SERVICE_NAME = "X-Snowflake-Service"
 
 HTTP_HEADER_VALUE_OCTET_STREAM = "application/octet-stream"
 
-DEFAULT_S3_CONNECTION_POOL_SIZE = 10
-MAX_S3_CONNECTION_POOL_SIZE = 20
-
 
 @unique
 class OCSPMode(Enum):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-493094

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR is removing a now useless connection parameter `s3_connection_pool_size`
