### PR TITLE
SNOW-157438 Allow web authenticator to select its listening port and address

### DIFF
--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -96,9 +96,10 @@ class AuthByWebBrowser(AuthByPlugin):
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             try:
-                socket_addr = os.getenv("SF_AUTH_SOCKET_ADDR", "localhost")
-                socket_port = int(os.getenv("SF_AUTH_SOCKET_PORT", 0))
-                socket_connection.bind((socket_addr, socket_port))
+                socket_connection.bind((
+                    os.getenv("SF_AUTH_SOCKET_ADDR", "localhost"),
+                    int(os.getenv("SF_AUTH_SOCKET_PORT", 0))
+                ))
             except socket.gaierror as ex:
                 if ex.args[0] == socket.EAI_NONAME:
                     raise OperationalError(

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import socket
 import time
 import webbrowser
@@ -95,7 +96,9 @@ class AuthByWebBrowser(AuthByPlugin):
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             try:
-                socket_connection.bind(("localhost", 0))
+                socket_addr = os.getenv("SF_AUTH_SOCKET_ADDR", "localhost")
+                socket_port = int(os.getenv("SF_AUTH_SOCKET_PORT", 0))
+                socket_connection.bind((socket_addr, socket_port))
             except socket.gaierror as ex:
                 if ex.args[0] == socket.EAI_NONAME:
                     raise OperationalError(


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #303

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

By allowing users to specify their socket port and address, we can use this from within containers running DBT with SSO authentication.

Example compose configuration:
```
version: "3.8"
services:
  dbt:
    image: some-magic-dbt-image
    environment:
      SF_AUTH_SOCKET_ADDR: 0.0.0.0
      SF_AUTH_SOCKET_PORT: 8080
      BROWSER: /bin/echo
    ports:
      - 8080:8080
    volumes:
      - ~/.dbt:/root/.dbt # Mount your DBT profile
      - ./:/usr/app # Mount your app
      - ~/.cache/snowflake:/root/.cache/snowflake # Mount cache so it does not ask again
```

This also leverages the clever trick in https://github.com/snowflakedb/snowflake-connector-python/issues/303#issuecomment-949988461 to avoid requiring https://github.com/snowflakedb/snowflake-connector-python/pull/883

---

Im not sure this is the right place to put these env vars or and its code but we need a place to set those parameters with env-vars. Let me know if you have a preference.