### PR TITLE
SNOW-487478 streaming multipart upload

### DIFF
--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -144,7 +144,7 @@ class SnowflakeFileMeta:
     dst_file_name: Optional[str] = None
     dst_file_size: int = -1
     intermediate_stream: Optional[IO[bytes]] = None
-    real_src_stream: Optional[IO[bytes]] = None
+    src_stream: Optional[IO[bytes]] = None
     # Specific to Downloads only
     local_location: Optional[str] = None
 

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -143,7 +143,7 @@ class SnowflakeFileMeta:
     require_compress: bool = False
     dst_file_name: Optional[str] = None
     dst_file_size: int = -1
-    src_stream: Optional[IO[bytes]] = None
+    intermediate_stream: Optional[IO[bytes]] = None
     real_src_stream: Optional[IO[bytes]] = None
     # Specific to Downloads only
     local_location: Optional[str] = None
@@ -970,7 +970,7 @@ class SnowflakeFileTransferAgent:
                     SnowflakeFileMeta(
                         name=os.path.basename(self._src_files[0]),
                         src_file_name=self._src_files[0],
-                        src_stream=self._source_from_stream,
+                        intermediate_stream=self._source_from_stream,
                         src_file_size=self._source_from_stream.seek(0, os.SEEK_END),
                         stage_location_type=self._stage_location_type,
                         encryption_material=self._encryption_material[0]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #909 SNOW-487478

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The issue is perfectly described in #909 the `BytesIO` context manager closes the file and so multipart streaming puts haven't worked since we switched to the SDKless PUT/GET. Here I abandon using the context manager and manually close the stream in case of us opening a new one.
