### PR TITLE
SNOW-480963: URL quote for s3 has to use "safe=" identical to boto lib

### DIFF
--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -103,10 +103,13 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
 
     @staticmethod
     def _url_quote(url: str) -> str:
-        """Per Python document at https://docs.python.org/3/library/urllib.parse.html:
-        Changed in version 3.7: Moved from RFC 2396 to RFC 3986 for quoting URL strings.
-        “~” is now included in the set of unreserved characters.
-        This fix for SNOW-480963 is not needed on Python 3.7 and above"""
+        """Wrapper function for actual function urllib.quote.
+
+        As per https://docs.python.org/3/library/urllib.parse.html:
+        'Changed in version 3.7: Moved from RFC 2396 to RFC 3986 for quoting URL strings.
+        “~” is now included in the set of unreserved characters.', the customized 'safe'
+         is for backward compatibility with python 3.6 and before.
+        """
         return quote(url, safe="/~")
 
     @staticmethod

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -103,6 +103,10 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
 
     @staticmethod
     def _url_quote(url: str) -> str:
+        """Per Python document at https://docs.python.org/3/library/urllib.parse.html:
+        Changed in version 3.7: Moved from RFC 2396 to RFC 3986 for quoting URL strings.
+        “~” is now included in the set of unreserved characters.
+        This fix for SNOW-480963 is not needed on Python 3.7 and above"""
         return quote(url, safe="/~")
 
     @staticmethod

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -360,7 +360,9 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             None if HEAD returns 404, otherwise a FileHeader instance populated
             with metadata
         """
-        path = self._url_quote(self.s3location.path + filename.lstrip("/"))
+        path = SnowflakeS3RestClient._url_quote(
+            self.s3location.path + filename.lstrip("/")
+        )
         url = self.endpoint + f"/{path}"
 
         retry_id = "HEAD"
@@ -415,7 +417,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
 
     def _initiate_multipart_upload(self) -> None:
         query_parts = (("uploads", ""),)
-        path = self._url_quote(
+        path = SnowflakeS3RestClient._url_quote(
             self.s3location.path + self.meta.dst_file_name.lstrip("/")
         )
         query_string = self._construct_query_string(query_parts)
@@ -439,7 +441,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             response.raise_for_status()
 
     def _upload_chunk(self, chunk_id: int, chunk: bytes) -> None:
-        path = self._url_quote(
+        path = SnowflakeS3RestClient._url_quote(
             self.s3location.path + self.meta.dst_file_name.lstrip("/")
         )
         url = self.endpoint + f"/{path}"
@@ -478,7 +480,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
 
     def _complete_multipart_upload(self) -> None:
         query_parts = (("uploadId", self.upload_id),)
-        path = self._url_quote(
+        path = SnowflakeS3RestClient._url_quote(
             self.s3location.path + self.meta.dst_file_name.lstrip("/")
         )
         query_string = self._construct_query_string(query_parts)
@@ -510,7 +512,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         if self.upload_id is None:
             return
         query_parts = (("uploadId", self.upload_id),)
-        path = self._url_quote(
+        path = SnowflakeS3RestClient._url_quote(
             self.s3location.path + self.meta.dst_file_name.lstrip("/")
         )
         query_string = self._construct_query_string(query_parts)
@@ -528,7 +530,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
 
     def download_chunk(self, chunk_id: int) -> None:
         logger.debug(f"Downloading chunk {chunk_id}")
-        path = self._url_quote(
+        path = SnowflakeS3RestClient._url_quote(
             self.s3location.path + self.meta.src_file_name.lstrip("/")
         )
         url = self.endpoint + f"/{path}"

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -628,13 +628,12 @@ def test_put_special_file_name(tmp_path, conn_cnx):
     test_file = tmp_path / "data~%23.csv"
     test_file.write_text("1,2,3\n")
     stage_name = random_string(5, "test_special_filename_")
-    with conn_cnx() as con:
-        with con.cursor() as cur:
+    with conn_cnx() as cnx:
+        with cnx.cursor() as cur:
             cur.execute(f"create temporary stage {stage_name}")
+            filename_in_put = str(test_file).replace("\\", "/")
             cur.execute(
-                "PUT 'file://{}' @{}".format(
-                    str(test_file).replace("\\", "/"), stage_name
-                )
+                f"PUT 'file://{filename_in_put}' @{stage_name}",
             ).fetchall()
             cur.execute(f"select $1, $2, $3 from  @{stage_name}")
             assert cur.fetchone() == ("1", "2", "3")

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -621,3 +621,20 @@ def test_multipart_put(conn_cnx, tmp_path):
     downloaded_file = get_dir / upload_file.name
     assert downloaded_file.exists()
     assert filecmp.cmp(upload_file, downloaded_file)
+
+
+@pytest.mark.skipolddriver
+def test_put_special_file_name(tmp_path, conn_cnx):
+    test_file = tmp_path / "data~%23.csv"
+    test_file.write_text("1,2,3\n")
+    stage_name = random_string(5, "test_special_filename_")
+    with conn_cnx() as con:
+        with con.cursor() as cur:
+            cur.execute(f"create temporary stage {stage_name}")
+            cur.execute(
+                "PUT 'file://{}' @{}".format(
+                    str(test_file).replace("\\", "/"), stage_name
+                )
+            ).fetchall()
+            cur.execute(f"select $1, $2, $3 from  @{stage_name}")
+            assert cur.fetchone() == ("1", "2", "3")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-480963

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In SDKless implementation, when file name is something like `data~%23.gz`, this will be encoded to `data%7%2523.gz` into request URL. This is different than old implementation, in which S3 SDK uses a different "safe" parameter `quote(url, safe="/~")` and encodes the URL into `data~%2523.gz`. Without this fix, customers will receive 403  error when they try to PUT a file name that contains "~".
