### PR TITLE
SNOW-496977 adding delocate to mac builds

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -133,7 +133,7 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.14  # Should be kept in sync with ci/build_darwin.sh
       - name: Run delocate
-        run: delocate-wheel --wheel-dir dist dist_tmp/*.whl
+        run: delocate-wheel --wheel-dir dist -v dist_tmp/*.whl
       - name: Show wheels generated
         run: ls -lh dist/
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -124,7 +124,9 @@ jobs:
           python3 get-pip.py
       - name: Display Python version
         run: python3 -c "import sys; print(sys.version)"
-      - name: Upgrade setuptools, pip, wheel and build
+      - name: Add bin directory to path
+        run: python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))" >> $GITHUB_PATH
+      - name: Upgrade setuptools, pip, wheel, build and delocate
         run: python3 -m pip install -U setuptools pip wheel build delocate
       - name: Generate wheel
         run: python3 -m build --wheel --outdir dist_tmp .

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Generate wheel
         run: python${{ matrix.python-version }} -m build --wheel --outdir dist_tmp .
       - name: Run auditwheel
-        run: auditwheel repair --plat manylinux2014_x86_64 -L connector dist_tmp/snowflake_connector_python*.whl -w dist
+        run: auditwheel repair --plat manylinux2014_x86_64 -L connector dist_tmp/*.whl -w dist
       - name: Show wheels generated
         run: ls -lh dist
       - uses: actions/upload-artifact@v1
@@ -125,11 +125,13 @@ jobs:
       - name: Display Python version
         run: python3 -c "import sys; print(sys.version)"
       - name: Upgrade setuptools, pip, wheel and build
-        run: python3 -m pip install -U setuptools pip wheel build
+        run: python3 -m pip install -U setuptools pip wheel build delocate
       - name: Generate wheel
-        run: python3 -m build --wheel .
+        run: python3 -m build --wheel --outdir dist_tmp .
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.14  # Should be kept in sync with ci/build_darwin.sh
+      - name: Run delocate
+        run: delocate-wheel --wheel-dir dist dist_tmp/*.whl
       - name: Show wheels generated
         run: ls -lh dist/
       - uses: actions/upload-artifact@v2

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -36,8 +36,8 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     # Update PEP-517 dependencies
     python -m pip install -U pip setuptools wheel build delocate
     # Use new PEP-517 build
-    python -m build --wheel --outdir dist_tmp .
-    delocate-wheel --wheel-dir dist dist_tmp/*.whl
+    python -m build --wheel --outdir "dist_tmp${PYTHON_VERSION}" .
+    delocate-wheel --wheel-dir dist "dist_tmp${PYTHON_VERSION}"/*.whl
     deactivate
     echo "[Info] Deleting venv at ${VENV_DIR}"
     rm -rf ${VENV_DIR}

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -37,7 +37,7 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     python -m pip install -U pip setuptools wheel build delocate
     # Use new PEP-517 build
     python -m build --wheel --outdir "dist_tmp${PYTHON_VERSION}" .
-    delocate-wheel --wheel-dir dist "dist_tmp${PYTHON_VERSION}"/*.whl
+    delocate-wheel --wheel-dir dist -v "dist_tmp${PYTHON_VERSION}"/*.whl
     deactivate
     echo "[Info] Deleting venv at ${VENV_DIR}"
     rm -rf ${VENV_DIR}

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -34,9 +34,10 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     # Clean up possible build artifacts
     rm -rf build generated_version.py
     # Update PEP-517 dependencies
-    python -m pip install -U pip setuptools wheel build
+    python -m pip install -U pip setuptools wheel build delocate
     # Use new PEP-517 build
-    python -m build --wheel .
+    python -m build --wheel --outdir dist_tmp .
+    delocate-wheel --wheel-dir dist dist_tmp/*.whl
     deactivate
     echo "[Info] Deleting venv at ${VENV_DIR}"
     rm -rf ${VENV_DIR}


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-496977

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `delocate` is similar to `auditwheel` for OSX, I'm adding support for using it in our build pipelines
