### PR TITLE
SNOW-499804 Add Geography Types

### DIFF
--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -33,6 +33,7 @@ FIELD_TYPES: List[FieldType] = [
     FieldType(name="BINARY", dbapi_type=[DBAPI_TYPE_BINARY]),
     FieldType(name="TIME", dbapi_type=[DBAPI_TYPE_TIMESTAMP]),
     FieldType(name="BOOLEAN", dbapi_type=[]),
+    FieldType(name="GEOGRAPHY", dbapi_type=[DBAPI_TYPE_STRING]),
 ]
 
 FIELD_NAME_TO_ID: DefaultDict[Any, int] = defaultdict(int)

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -129,7 +129,11 @@ class ResultMetadata(NamedTuple):
         """Initializes a ResultMetadata object from the column description in the query response."""
         return cls(
             col["name"],
-            FIELD_NAME_TO_ID[col["type"].upper()],
+            FIELD_NAME_TO_ID[
+                col["extTypeName"].upper()
+                if "extTypeName" in col
+                else col["type"].upper()
+            ],
             None,
             col["length"],
             col["precision"],


### PR DESCRIPTION
Description

Added support for geoJson to show up as GEOGRAPHY when enabled

Testing

Added testing for when it is disabled and enabled

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-499804

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Recognizes geoJson as a GEOGRAPHY type in the connector
