### PR TITLE
SNOW-507674: v2.7.1 - Blocked queries are now be considered to be still running- Not working as expected

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1468,7 +1468,7 @@ class SnowflakeConnection(object):
             QueryStatus.ABORTED,
             QueryStatus.FAILED_WITH_INCIDENT,
             QueryStatus.DISCONNECTED,
-            QueryStatus.BLOCKED,
+            # QueryStatus.BLOCKED, SNOW-507674: v2.7.1 - Blocked queries are now be considered to be still running- Not working as expected
         )
 
     def _all_async_queries_finished(self) -> bool:


### PR DESCRIPTION
v2.7.1 - If we consider BLOCKED to be still running then it shouldn't count as an error

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #987

2. Fill out the following pre-review checklist:
   - [ ] I am modifying OCSP code

3. Please describe how your code solves the related issue.

   As part of v2.7.1 release note, we had advised that, All BLOCKED queries can be considered as running, but unfortunately, it is 
   still considering as part of error check (is_an_error()). thus, i've disabled the BLOCKED check in is_an_error function.
