### PR TITLE
SNOW-513061 fix pyformat not un-escaping SQL command with no parameters

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1159,9 +1159,9 @@ class SnowflakeConnection(object):
 
     def _process_params_pyformat(
         self,
-        params: Optional[Union[Any, Sequence[Any], Dict[Any, Any]]],
+        params: Optional[Union[Any, Sequence[Any], Dict[Any, Any], None]],
         cursor: Optional["SnowflakeCursor"] = None,
-    ) -> Union[Tuple[Any], Dict[str, Any]]:
+    ) -> Union[Tuple[Any], Dict[str, Any], None]:
         """Process parameters for client-side parameter binding.
 
         Args:
@@ -1170,7 +1170,7 @@ class SnowflakeConnection(object):
             cursor: The SnowflakeCursor used to report errors if necessary.
         """
         if params is None:
-            return {}
+            return None
         if isinstance(params, dict):
             return self._process_params_dict(params)
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -654,7 +654,7 @@ class SnowflakeCursor:
                         f"with input=[{params}], "
                         f"processed=[{processed_params}]",
                     )
-                if len(processed_params) > 0:
+                if processed_params is not None:
                     query = command % processed_params
                 else:
                     query = command


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   TODO
