### PR TITLE
SNOW-507544 shifted package metadata from setup.py to setup.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     -   id: end-of-file-fixer
         exclude: license_header.txt
     -   id: check-yaml
+        exclude: .github/repo_meta.yaml
     -   id: debug-statements
     -   id: check-ast
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,4 @@ requires = [
     "cython",
     # Must be kept in sync with the `setup_requirements` in `setup.cfg`
     "pyarrow>=6.0.0,<6.1.0",
-    "dataclasses<1.0;python_version=='3.6'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "setuptools>=40.6.0",
     "wheel",
     "cython",
-    # Must be kept in sync with the `setup_requirements` in `setup.py`
+    # Must be kept in sync with the `setup_requirements` in `setup.cfg`
     "pyarrow>=6.0.0,<6.1.0",
+    "dataclasses<1.0;python_version=='3.6'",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     cffi>=1.9,<2.0.0
     charset-normalizer~=2.0.0
     cryptography>=3.1.0,<36.0.0
+    dataclasses;python_version=="3.6"
     idna>=2.5,<4
     oscrypto<2.0.0
     pyOpenSSL>=16.2.0,<22.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,98 @@
+[metadata]
+name = snowflake_connector_python
+version = attr: snowflake.connector.description.SNOWFLAKE_CONNECTOR_VERSION
+description = Snowflake Connector for Python
+long_description = file: DESCRIPTION.md
+long_description_content_type = text/markdown
+url = https://www.snowflake.com/
+author = Snowflake, Inc
+author_email = ecosystem-team-dl@snowflake.com
+license = Apache-2.0
+license_files = LICENSE.txt, NOTICE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Environment :: Other Environment
+    Intended Audience :: Developers
+    Intended Audience :: Education
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: SQL
+    Topic :: Database
+    Topic :: Scientific/Engineering :: Information Analysis
+    Topic :: Software Development
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Application Frameworks
+    Topic :: Software Development :: Libraries :: Python Modules
+keywords = Snowflake db database cloud analytics warehouse
+project_urls =
+    Documentation=https://docs.snowflake.com/
+    Source=https://github.com/snowflakedb/snowflake-connector-python
+    Issues=https://github.com/snowflakedb/snowflake-connector-python/issues
+    Changelog=https://github.com/snowflakedb/snowflake-connector-python/blob/master/DESCRIPTION.md
+python_requires = >=3.6
+
+[options]
+packages = find_namespace:
+install_requires =
+    asn1crypto>0.24.0,<2.0.0
+    certifi>=2017.4.17
+    cffi>=1.9,<2.0.0
+    charset-normalizer~=2.0.0
+    cryptography>=3.1.0,<36.0.0
+    idna>=2.5,<4
+    oscrypto<2.0.0
+    pyOpenSSL>=16.2.0,<22.0.0
+    pycryptodomex!=3.5.0,>=3.2,<4.0.0
+    pyjwt<3.0.0
+    pytz
+    requests<3.0.0
+    setuptools>34.0.0
+include_package_data = True
+namespace_packages = snowflake
+package_dir =
+    =src
+zip_safe = False
+
+[options.packages.find]
+where = src
+exclude = snowflake.connector.cpp*
+include = snowflake.*
+
+[options.entry_points]
+console_scripts =
+    snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
+    snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
+    snowflake-dump-certs = snowflake.connector.tool.dump_certs:main
+    snowflake-export-certs = snowflake.connector.tool.export_certs:main
+
+[options.extras_require]
+development =
+    Cython
+    coverage
+    mock
+    more-itertools
+    numpy<1.22.0
+    pendulum!=2.1.1
+    pexpect
+    pytest<6.3.0
+    pytest-cov
+    pytest-rerunfailures
+    pytest-timeout
+    pytest-xdist
+    pytz
+    pytzdata
+pandas =
+    pandas>=1.0.0,<1.4.0
+    pyarrow>=6.0.0,<6.1.0
+secure_local_storage =
+    keyring!=16.1.0,<24.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = snowflake_connector_python
-version = attr: snowflake.connector.description.SNOWFLAKE_CONNECTOR_VERSION
 description = Snowflake Connector for Python
 long_description = file: DESCRIPTION.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,5 +94,5 @@ development =
 pandas =
     pandas>=1.0.0,<1.4.0
     pyarrow>=6.0.0,<6.1.0
-secure_local_storage =
+secure-local-storage =
     keyring!=16.1.0,<24.0.0

--- a/setup.py
+++ b/setup.py
@@ -6,27 +6,11 @@
 import os
 import sys
 import warnings
-from codecs import open
 from shutil import copy
 
-from setuptools import Extension, find_namespace_packages, setup
+from setuptools import Extension, setup
 
 CONNECTOR_SRC_DIR = os.path.join("src", "snowflake", "connector")
-
-VERSION = (1, 1, 1, None)  # Default
-try:
-    with open(
-        os.path.join(CONNECTOR_SRC_DIR, "generated_version.py"), encoding="utf-8"
-    ) as f:
-        exec(f.read())
-except Exception:
-    with open(os.path.join(CONNECTOR_SRC_DIR, "version.py"), encoding="utf-8") as f:
-        exec(f.read())
-version = ".".join([str(v) for v in VERSION if v is not None])
-
-with open("DESCRIPTION.md", encoding="utf-8") as f:
-    long_description = f.read()
-
 
 # Parse command line flags
 
@@ -45,12 +29,6 @@ for flag in options_def:
 
 extensions = None
 cmd_class = {}
-
-pandas_requirements = [
-    # Must be kept in sync with pyproject.toml
-    "pyarrow>=6.0.0,<6.1.0",
-    "pandas>=1.0.0,<1.4.0",
-]
 
 try:
     import numpy
@@ -180,107 +158,6 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
     cmd_class = {"build_ext": MyBuildExt}
 
 setup(
-    name="snowflake-connector-python",
-    version=version,
-    description="Snowflake Connector for Python",
     ext_modules=extensions,
     cmdclass=cmd_class,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Snowflake, Inc",
-    author_email="ecosystem-team-dl@snowflake.com",
-    license="Apache License, Version 2.0",
-    keywords="Snowflake db database cloud analytics warehouse",
-    url="https://www.snowflake.com/",
-    project_urls={
-        "Documentation": "https://docs.snowflake.com/",
-        "Code": "https://github.com/snowflakedb/snowflake-connector-python",
-        "Issue tracker": "https://github.com/snowflakedb/snowflake-connector-python/issues",
-    },
-    python_requires=">=3.6",
-    install_requires=[
-        # While requests is vendored, we use regular requests to perform OCSP checks
-        "requests<3.0.0",
-        "pytz",
-        "pycryptodomex>=3.2,!=3.5.0,<4.0.0",
-        "pyOpenSSL>=16.2.0,<22.0.0",
-        "cffi>=1.9,<2.0.0",
-        "cryptography>=3.1.0,<36.0.0",
-        "pyjwt<3.0.0",
-        "oscrypto<2.0.0",
-        "asn1crypto>0.24.0,<2.0.0",
-        'dataclasses<1.0;python_version=="3.6"',
-        # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is
-        # required. Python 3.6 was released at the end of 2016. setuptools 34.0.0 was released
-        # in early 2017, so we pick this version as a reasonably modern base.
-        "setuptools>34.0.0",
-        # requests requirements
-        "charset_normalizer~=2.0.0",
-        "idna>=2.5,<4",
-        "certifi>=2017.4.17",
-    ],
-    namespace_packages=["snowflake"],
-    packages=find_namespace_packages(
-        where="src", include=["snowflake.*"], exclude=["snowflake.connector.cpp*"]
-    ),
-    package_dir={
-        "": "src",
-    },
-    include_package_data=True,
-    entry_points={
-        "console_scripts": [
-            "snowflake-dump-ocsp-response = "
-            "snowflake.connector.tool.dump_ocsp_response:main",
-            "snowflake-dump-ocsp-response-cache = "
-            "snowflake.connector.tool.dump_ocsp_response_cache:main",
-            "snowflake-dump-certs = " "snowflake.connector.tool.dump_certs:main",
-            "snowflake-export-certs = " "snowflake.connector.tool.export_certs:main",
-        ],
-    },
-    extras_require={
-        "secure-local-storage": [
-            "keyring!=16.1.0,<24.0.0",
-        ],
-        "pandas": pandas_requirements,
-        "development": [
-            "pytest<6.3.0",
-            "pytest-cov",
-            "pytest-rerunfailures",
-            "pytest-timeout",
-            "pytest-xdist",
-            "coverage",
-            "pexpect",
-            "mock",
-            "pytz",
-            "pytzdata",
-            "Cython",
-            "pendulum!=2.1.1",
-            "more-itertools",
-            "numpy<1.22.0",
-        ],
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Environment :: Other Environment",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Information Technology",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: SQL",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Topic :: Database",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Application Frameworks",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Scientific/Engineering :: Information Analysis",
-    ],
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,17 @@ from setuptools import Extension, setup
 
 CONNECTOR_SRC_DIR = os.path.join("src", "snowflake", "connector")
 
+VERSION = (1, 1, 1, None)  # Default
+try:
+    with open(
+        os.path.join(CONNECTOR_SRC_DIR, "generated_version.py"), encoding="utf-8"
+    ) as f:
+        exec(f.read())
+except Exception:
+    with open(os.path.join(CONNECTOR_SRC_DIR, "version.py"), encoding="utf-8") as f:
+        exec(f.read())
+version = ".".join([str(v) for v in VERSION if v is not None])
+
 # Parse command line flags
 
 # This list defines the options definitions in a set
@@ -158,6 +169,7 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
     cmd_class = {"build_ext": MyBuildExt}
 
 setup(
+    version=version,
     ext_modules=extensions,
     cmdclass=cmd_class,
 )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-507544

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Many open-source Python project switched to using `setup.cfg` instead of `setup.py`.
   We should also start transitioning towards using it in case support of `setup.py` winds down.
