### PR TITLE
SNOW-501058 adding connection parameter to protect behavior change

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -191,6 +191,8 @@ DEFAULT_CONFIGURATION: Dict[str, Tuple[Any, Union[Type, Tuple[Type, ...]]]] = {
     ),  # only use regional url when the param is set
     # Allows cursors to be re-iterable
     "reuse_results": (False, bool),
+    # parameter protecting behavior change of SNOW-501058
+    "interpolate_empty_sequences": (False, bool),
 }
 
 APPLICATION_RE = re.compile(r"[\w\d_]+")
@@ -1170,7 +1172,9 @@ class SnowflakeConnection(object):
             cursor: The SnowflakeCursor used to report errors if necessary.
         """
         if params is None:
-            return None
+            if self._interpolate_empty_sequences:
+                return None
+            return {}
         if isinstance(params, dict):
             return self._process_params_dict(params)
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -654,7 +654,13 @@ class SnowflakeCursor:
                         f"with input=[{params}], "
                         f"processed=[{processed_params}]",
                     )
-                if processed_params is not None:
+                if (
+                    self.connection._interpolate_empty_sequences
+                    and processed_params is not None
+                ) or (
+                    not self.connection._interpolate_empty_sequences
+                    and len(processed_params) > 0
+                ):
                     query = command % processed_params
                 else:
                     query = command

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -801,14 +801,17 @@ def test_process_params(conn, db_parameters):
 
 
 @pytest.mark.skipolddriver
-def test_process_params_empty(conn_cnx):
+@pytest.mark.parametrize(
+    ("interpolate_empty_sequences", "expected_outcome"), [(False, "%%s"), (True, "%s")]
+)
+def test_process_params_empty(conn_cnx, interpolate_empty_sequences, expected_outcome):
     """SQL is interpolated if params aren't None."""
-    with conn_cnx() as cnx:
+    with conn_cnx(interpolate_empty_sequences=interpolate_empty_sequences) as cnx:
         with cnx.cursor() as cursor:
             cursor.execute("select '%%s'", None)
-            assert cursor.fetchone() == ('%%s',)
+            assert cursor.fetchone() == ("%%s",)
             cursor.execute("select '%%s'", ())
-            assert cursor.fetchone() == ('%s',)
+            assert cursor.fetchone() == (expected_outcome,)
 
 
 def test_real_decimal(conn, db_parameters):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Relates to #961 SNOW-501058 and SNOW-513807

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When we merged #962 I didn't catch that it was a behavior change, which led to some of our internal tests being broken.
   This PR introduces a connection parameter that switches between old and new behaviors. Will be following up with a behavior change announcement and switching the default value as soon as possible.
