### PR TITLE
SNOW-533748 partner application name injection

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -45,6 +45,7 @@ from .auth_webbrowser import AuthByWebBrowser
 from .bind_upload_agent import BindUploadError
 from .compat import IS_LINUX, IS_WINDOWS, quote, urlencode
 from .constants import (
+    ENV_VAR_PARTNER,
     PARAMETER_AUTOCOMMIT,
     PARAMETER_CLIENT_PREFETCH_THREADS,
     PARAMETER_CLIENT_REQUEST_MFA_TOKEN,
@@ -285,8 +286,12 @@ class SnowflakeConnection(object):
         self._telemetry = TelemetryClient(self._rest)
         # Some configuration files need to be updated here to make them testable
         # E.g.: if DEFAULT_CONFIGURATION pulled in env variables these would be not testable
-        if self.application == CLIENT_NAME and "SNOWFLAKE_PARTNER" in os.environ.keys():
-            self._application = os.environ["SNOWFLAKE_PARTNER"]
+        if (
+            self.application
+            == DEFAULT_CONFIGURATION["application"][0]  # still default value
+            and ENV_VAR_PARTNER in os.environ.keys()  # is defined as an env variable
+        ):
+            self._application = os.environ[ENV_VAR_PARTNER]
 
     def __del__(self):  # pragma: no cover
         try:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -150,7 +150,7 @@ DEFAULT_CONFIGURATION: Dict[str, Tuple[Any, Union[Type, Tuple[Type, ...]]]] = {
     "authenticator": (DEFAULT_AUTHENTICATOR, (type(None), str)),
     "mfa_callback": (None, (type(None), Callable)),
     "password_callback": (None, (type(None), Callable)),
-    "application": (os.environ.get('SNOWFLAKE_PARTNER', CLIENT_NAME), (type(None), str)),
+    "application": (CLIENT_NAME, (type(None), str)),
     "internal_application_name": (CLIENT_NAME, (type(None), str)),
     "internal_application_version": (CLIENT_VERSION, (type(None), str)),
     "insecure_mode": (False, bool),  # Error security fix requirement
@@ -283,6 +283,10 @@ class SnowflakeConnection(object):
         self.__set_error_attributes()
         self.connect(**kwargs)
         self._telemetry = TelemetryClient(self._rest)
+        # Some configuration files need to be updated here to make them testable
+        # E.g.: if DEFAULT_CONFIGURATION pulled in env variables these would be not testable
+        if self.application == CLIENT_NAME and "SNOWFLAKE_PARTNER" in os.environ.keys():
+            self._application = os.environ["SNOWFLAKE_PARTNER"]
 
     def __del__(self):  # pragma: no cover
         try:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -150,7 +150,7 @@ DEFAULT_CONFIGURATION: Dict[str, Tuple[Any, Union[Type, Tuple[Type, ...]]]] = {
     "authenticator": (DEFAULT_AUTHENTICATOR, (type(None), str)),
     "mfa_callback": (None, (type(None), Callable)),
     "password_callback": (None, (type(None), Callable)),
-    "application": (CLIENT_NAME, (type(None), str)),
+    "application": (os.environ.get('SNOWFLAKE_PARTNER', CLIENT_NAME), (type(None), str)),
     "internal_application_name": (CLIENT_NAME, (type(None), str)),
     "internal_application_version": (CLIENT_VERSION, (type(None), str)),
     "insecure_mode": (False, bool),  # Error security fix requirement

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -258,4 +258,4 @@ S3_CHUNK_SIZE = 8388608  # boto3 default
 AZURE_CHUNK_SIZE = 4 * megabyte
 
 # TODO: all env variables definitions should be here
-ENV_VAR_PARTNER = "SNOWFLAKE_PARTNER"
+ENV_VAR_PARTNER = "SF_PARTNER"

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -256,3 +256,6 @@ class IterUnit(Enum):
 
 S3_CHUNK_SIZE = 8388608  # boto3 default
 AZURE_CHUNK_SIZE = 4 * megabyte
+
+# TODO: all env variables definitions should be here
+ENV_VAR_PARTNER = "SNOWFLAKE_PARTNER"

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
 #
+import os
 
 import pytest
 from mock import patch
@@ -130,3 +131,15 @@ def test_is_still_running():
             snowflake.connector.SnowflakeConnection.is_still_running(status)
             == expected_result
         )
+
+
+@pytest.mark.skipolddriver
+def test_partner_env_var():
+    with patch.dict(os.environ, SNOWFLAKE_PARTNER="Amanda"):
+        with patch("snowflake.connector.network.SnowflakeRestful.fetch"):
+            with snowflake.connector.connect(
+                user="user",
+                account="account",
+                password="password123",
+            ) as conn:
+                assert conn.application == "Amanda"

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -11,8 +11,9 @@ from mock import patch
 import snowflake.connector
 
 try:  # pragma: no cover
-    from snowflake.connector.constants import QueryStatus
+    from snowflake.connector.constants import ENV_VAR_PARTNER, QueryStatus
 except ImportError:
+    ENV_VAR_PARTNER = "SF_PARTNER"
     QueryStatus = None
 
 
@@ -135,7 +136,7 @@ def test_is_still_running():
 
 @pytest.mark.skipolddriver
 def test_partner_env_var():
-    with patch.dict(os.environ, SNOWFLAKE_PARTNER="Amanda"):
+    with patch.dict(os.environ, {ENV_VAR_PARTNER: "Amanda"}):
         with patch("snowflake.connector.network.SnowflakeRestful.fetch"):
             with snowflake.connector.connect(
                 user="user",


### PR DESCRIPTION
SNOW-533748
This is an enhancement to the python connector to allow snowflake to track partner driven consumption by searching for a partner defined environment variable in circumstances where a partner provides managed infrastructure, but a customer manual downloads the connector via pip.