### PR TITLE
SNOW-510552 fix py.typed not being included in wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ core.*
 
 # Editor specific
 .vscode
+
+# Compiled Cython
+src/snowflake/connector/arrow_iterator.cpp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear == 20.11.1
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.47"
+    hooks:
+    -   id: check-manifest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,21 @@
 include *.md
+include *.rst
 include LICENSE.txt
 include NOTICE
 include pyproject.toml
 recursive-include src/snowflake/connector py.typed *.py *.pyx
+recursive-include src/snowflake/connector/vendored LICENSE*
+
 recursive-include src/snowflake/connector/cpp *.cpp *.hpp
+exclude src/snowflake/connector/arrow_iterator.cpp
+
+exclude .git-blame-ignore-revs
+exclude .pre-commit-config.yaml
+exclude license_header.txt
+exclude tox.ini
+
+prune ci
+prune benchmark
+prune test
+prune tested_requirements
+prune src/snowflake/connector/cpp/scripts

--- a/setup.py
+++ b/setup.py
@@ -225,14 +225,7 @@ setup(
     package_dir={
         "": "src",
     },
-    package_data={
-        "snowflake.connector": [
-            "*.md",
-            "LICENSE.txt",
-            "NOTICE",
-            "src/snowflake/connector/py.typed",
-        ],
-    },
+    include_package_data=True,
     entry_points={
         "console_scripts": [
             "snowflake-dump-ocsp-response = "


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-510552

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Updating `setup.py` to only use `MANIFEST.in` for tracking data files ([documentation](https://setuptools.pypa.io/en/latest/userguide/datafiles.html)). This means that from now on we won't have to track data files in `setup.py` anymore.
   Overall this should lead to less bugs and also fix the issue where `py.typed` was not included in wheels even thought it was in the `package_data` dictionary.
   I also fixed another bug that causes our description on PyPi to not render correctly.
