### PR TITLE
SNOW-521102 fix long description rendering for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup(
     ext_modules=extensions,
     cmdclass=cmd_class,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Snowflake, Inc",
     author_email="ecosystem-team-dl@snowflake.com",
     license="Apache License, Version 2.0",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-521102

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   By specifying the description content type our PyPi description should render correctly once again.
