### PR TITLE
SNOW-514815 handling no sms case for DUO

### DIFF
--- a/src/snowflake/connector/auth.py
+++ b/src/snowflake/connector/auth.py
@@ -289,7 +289,10 @@ class Auth(object):
             )
 
         # waiting for MFA authentication
-        if ret["data"].get("nextAction") == "EXT_AUTHN_DUO_ALL":
+        if ret["data"].get("nextAction") in (
+            "EXT_AUTHN_DUO_ALL",
+            "EXT_AUTHN_DUO_PUSH_N_PASSCODE",
+        ):
             body["inFlightCtx"] = ret["data"]["inFlightCtx"]
             body["data"]["EXT_AUTHN_DUO_METHOD"] = "push"
             self.ret = {"message": "Timeout", "data": {}}


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-514815

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   There's a bug, where if a customer enrolls into DUO MFA with a "tablet" (which means that no sms authentication is available) this is not handled correctly by the connector.
   I've modified an already existing test and verified the fix manually.
