### PR TITLE
SNOW-526691 adding new telemetry reporting

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -648,6 +648,14 @@ class SnowflakeCursor:
                 processed_params = self._connection._process_params_pyformat(
                     params, self
                 )
+                # SNOW-513061 collect telemetry for empty sequence usage before we make the breaking change announcement
+                if params is not None and len(params) == 0:
+                    self._log_telemetry_job_data(
+                        TelemetryField.EMPTY_SEQ_INTERPOLATION,
+                        TelemetryData.TRUE
+                        if self.connection._interpolate_empty_sequences
+                        else TelemetryData.FALSE,
+                    )
                 if logger.getEffectiveLevel() <= logging.DEBUG:
                     logger.debug(
                         f"binding: [{self._format_query_for_log(command)}] "

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -23,6 +23,7 @@ class TelemetryField(Enum):
     TIME_PARSING_CHUNKS = "client_time_parsing_chunks"
     SQL_EXCEPTION = "client_sql_exception"
     GET_PARTITIONS_USED = "client_get_partitions_used"
+    EMPTY_SEQ_INTERPOLATION = "client_pyformat_empty_seq_interpolation"
     # fetch_pandas_* usage
     PANDAS_FETCH_ALL = "client_fetch_pandas_all"
     PANDAS_FETCH_BATCHES = "client_fetch_pandas_batches"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-526691

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This is just adding extra telemetry that we'd like to collect before switching the default value of of the connection parameter `interpolate_empty_sequences`. Relates to #993 
