### PR TITLE
SNOW-544967: Print URL when trying browser authentication

### DIFF
--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -115,16 +115,17 @@ class AuthByWebBrowser(AuthByPlugin):
             socket_connection.listen(0)  # no backlog
             callback_port = socket_connection.getsockname()[1]
 
+            logger.debug("step 1: query GS to obtain SSO url")
+            sso_url = self._get_sso_url(
+                authenticator, service_name, account, callback_port, user
+            )
+
             print(
                 "Initiating login request with your identity provider. A "
                 "browser window should have opened for you to complete the "
                 "login. If you can't see it, check existing browser windows, "
-                "or your OS settings. Press CTRL+C to abort, and try again..."
-            )
-
-            logger.debug("step 1: query GS to obtain SSO url")
-            sso_url = self._get_sso_url(
-                authenticator, service_name, account, callback_port, user
+                f"your OS settings or click the following link:\n{sso_url}\n"
+                "If that doesn't work, press CTRL+C to abort, and try again..."
             )
 
             logger.debug("step 2: open a browser")

--- a/src/snowflake/connector/auth_webbrowser.py
+++ b/src/snowflake/connector/auth_webbrowser.py
@@ -119,7 +119,7 @@ class AuthByWebBrowser(AuthByPlugin):
                 "Initiating login request with your identity provider. A "
                 "browser window should have opened for you to complete the "
                 "login. If you can't see it, check existing browser windows, "
-                "or your OS settings. Press CTRL+C to abort and try again..."
+                "or your OS settings. Press CTRL+C to abort, and try again..."
             )
 
             logger.debug("step 1: query GS to obtain SSO url")


### PR DESCRIPTION
- Clarify that Ctrl + C only aborts and doesnt retry
- Print authentication link, in case browser window fails to appear

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
Fixes #1064

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

The URL is now shown, so that the user can click it if the browser is opened.

Also added a comma to the "try again" sentence, since Ctrl + C does not retry the run for the user.