### PR TITLE
SNOW-534927 fix glob escaping issue

### DIFF
--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -816,7 +816,7 @@ class SnowflakeFileTransferAgent:
                     # Windows path: /C:/data/file1.txt where it starts with slash
                     # followed by a drive letter and colon.
                     file_name = file_name[1:]
-                files = glob.glob(file_name)
+                files = glob.glob(glob.escape(file_name))
                 canonical_locations += files
             else:
                 canonical_locations.append(file_name)

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -636,7 +636,7 @@ def test_multipart_put(conn_cnx, tmp_path, use_stream):
 
 @pytest.mark.skipolddriver
 def test_put_special_file_name(tmp_path, conn_cnx):
-    test_file = tmp_path / "data~%23.csv"
+    test_file = tmp_path / "data~%23[2] (1).csv"
     test_file.write_text("1,2,3\n")
     stage_name = random_string(5, "test_special_filename_")
     with conn_cnx() as cnx:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-534927

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   If a filename has`[]` characters in it the globing makes our upload not work.