### PR TITLE
SNOW-544463 fix index numbers when using fetch_pandas_all

### DIFF
--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -198,7 +198,11 @@ class ResultSet(Iterable[List[Any]]):
         """Fetches a single Pandas dataframe."""
         dataframes = list(self._fetch_pandas_batches())
         if dataframes:
-            return pandas.concat(dataframes, **kwargs)
+            return pandas.concat(
+                dataframes,
+                ignore_index=True,  # Don't keep in result batch indexes
+                **kwargs,
+            )
         return pandas.DataFrame(columns=self.batches[0].column_names)
 
     def _get_metrics(self) -> Dict[str, int]:

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -966,6 +966,7 @@ def test_resultbatches_pandas_functionality(conn_cnx):
             )
             assert cur._result_set.total_row_index() == rowcount
             result_batches = cur.get_result_batches()
+            assert cur.fetch_pandas_all().index[-1] == rowcount - 1
             assert len(result_batches) > 1
     tables = itertools.chain.from_iterable(
         list(b.create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="arrow"))


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-544463

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The `fetch_pandas_all` function does not put nice index numbers into the resulting `pandas.DataFrame` it produces, This PR fixes this and adds a test to verify this behavior in the future.
