### PR TITLE
SNOW-560944 fix python_requires tag from setup.cfg

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 
 
+- v2.7.6(March 17,2022)
+
+   - Fixed missing python_requires tag in setup.cfg
+
 - v2.7.5(March 17,2022)
 
    - Added an option for partners to inject their name through an environmental variable (SF_PARTNER)
@@ -17,7 +21,6 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
    - Deprecate support for Python 3.6
    - Exported a type definition for SnowflakeConnection
    - Fixed a bug where final Arrow table would contain duplicate index numbers when using fetch_pandas_all
-
 
 - v2.7.4(February 05,2022)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,9 @@ project_urls =
     Source=https://github.com/snowflakedb/snowflake-connector-python
     Issues=https://github.com/snowflakedb/snowflake-connector-python/issues
     Changelog=https://github.com/snowflakedb/snowflake-connector-python/blob/master/DESCRIPTION.md
-python_requires = >=3.7
 
 [options]
+python_requires = >=3.7
 packages = find_namespace:
 install_requires =
     asn1crypto>0.24.0,<2.0.0

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 7, 5, None)
+VERSION = (2, 7, 6, None)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-560944

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The release `2.7.5` released today broke support for Python 3.6 and the `python_requires` tag was in an incorrect position. I have now manually tested that this will correctly fail to install on Python 3.6.
  This PR also has all the release stuff in it for a new release.
