### PR TITLE
SNOW-507942 handle s3 accelerate configuration correctly

### DIFF
--- a/ci/test_docker.sh
+++ b/ci/test_docker.sh
@@ -46,6 +46,7 @@ docker run --network=host \
     -e cloud_provider \
     -e JENKINS_HOME \
     -e is_old_driver \
+    -e GITHUB_ACTIONS \
     --mount type=bind,source="${CONNECTOR_DIR}",target=/home/user/snowflake-connector-python \
     ${CONTAINER_NAME}:1.0 \
     /home/user/snowflake-connector-python/ci/test_linux.sh ${PYTHON_ENV}

--- a/ci/test_fips_docker.sh
+++ b/ci/test_fips_docker.sh
@@ -31,6 +31,7 @@ docker run --network=host \
     -e SF_PROJECT_ROOT \
     -e cloud_provider \
     -e PYTEST_ADDOPTS \
+    -e GITHUB_ACTIONS \
     --mount type=bind,source="${CONNECTOR_DIR}",target=/home/user/snowflake-connector-python \
     ${CONTAINER_NAME}:1.0 \
     /home/user/snowflake-connector-python/ci/test_fips.sh $1

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -338,7 +338,10 @@ class SnowflakeFileTransferAgent:
             get_azure_callback if get_azure_callback else get_callback
         )
         self._get_callback_output_stream = get_callback_output_stream
-        self._use_accelerate_endpoint = False
+        # when we have not checked whether we should use accelerate, this boolean is None
+        # _use_accelerate_endpoint in SnowflakeFileTransferAgent could be passed to each SnowflakeS3RestClient
+        # so we could avoid check accelerate configuration for each S3 client created for each file meta.
+        self._use_accelerate_endpoint = None
         self._raise_put_get_error = raise_put_get_error
         self._show_progress_bar = show_progress_bar
         self._force_put_overwrite = force_put_overwrite
@@ -646,6 +649,7 @@ class SnowflakeFileTransferAgent:
                 self._credentials,
                 self._stage_info,
                 S3_CHUNK_SIZE,
+                use_accelerate_endpoint=self._use_accelerate_endpoint,
                 use_s3_regional_url=self._use_s3_regional_url,
             )
         elif self._stage_location_type == GCS_FS:

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -341,7 +341,7 @@ class SnowflakeFileTransferAgent:
         # when we have not checked whether we should use accelerate, this boolean is None
         # _use_accelerate_endpoint in SnowflakeFileTransferAgent could be passed to each SnowflakeS3RestClient
         # so we could avoid check accelerate configuration for each S3 client created for each file meta.
-        self._use_accelerate_endpoint = None
+        self._use_accelerate_endpoint: bool | None = None
         self._raise_put_get_error = raise_put_get_error
         self._show_progress_bar = show_progress_bar
         self._force_put_overwrite = force_put_overwrite

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -59,14 +59,13 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         credentials: StorageCredential,
         stage_info: dict[str, Any],
         chunk_size: int,
-        use_accelerate_endpoint: bool = False,
+        use_accelerate_endpoint: bool = None,
         use_s3_regional_url=False,
     ) -> None:
         """Rest client for S3 storage.
 
         Args:
             stage_info:
-            use_accelerate_endpoint:
         """
         super().__init__(meta, stage_info, chunk_size, credentials=credentials)
         # Signature version V4
@@ -81,25 +80,40 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             )
         )
         self.use_s3_regional_url = use_s3_regional_url
+
         # if GS sends us an endpoint, it's likely for FIPS. Use it.
+        self.endpoint = None
         if stage_info["endPoint"]:
             self.endpoint = (
                 f"https://{self.s3location.bucket_name}." + stage_info["endPoint"]
             )
-        elif use_accelerate_endpoint:
+        self.transfer_accelerate_config(use_accelerate_endpoint)
+
+    def transfer_accelerate_config(self, use_accelerate_endpoint: bool = None) -> bool:
+        # if self.endpoint has been set, e.g. by metadata, no more config is needed.
+        if self.endpoint is not None:
+            return self.endpoint.find("s3-accelerate.amazonaws.com") >= 0
+        if self.use_s3_regional_url:
             self.endpoint = (
-                f"https://{self.s3location.bucket_name}.s3-accelerate.amazonaws.com"
+                f"https://{self.s3location.bucket_name}."
+                f"s3.{self.region_name}.amazonaws.com"
             )
+            return False
         else:
-            if self.use_s3_regional_url:
+            if use_accelerate_endpoint is None:
+                use_accelerate_endpoint = self._get_bucket_accelerate_config(
+                    self.s3location.bucket_name
+                )
+
+            if use_accelerate_endpoint:
                 self.endpoint = (
-                    f"https://{self.s3location.bucket_name}."
-                    f"s3.{self.region_name}.amazonaws.com"
+                    f"https://{self.s3location.bucket_name}.s3-accelerate.amazonaws.com"
                 )
             else:
                 self.endpoint = (
                     f"https://{self.s3location.bucket_name}.s3.amazonaws.com"
                 )
+            return use_accelerate_endpoint
 
     @staticmethod
     def _sign_bytes(secret_key: bytes, _input: str) -> bytes:
@@ -539,10 +553,10 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
                 self.write_downloaded_chunk(chunk_id, response.content)
             response.raise_for_status()
 
-    def transfer_accelerate_config(self) -> bool:
+    def _get_bucket_accelerate_config(self, bucket_name: str) -> bool:
         query_parts = (("accelerate", ""),)
         query_string = self._construct_query_string(query_parts)
-        url = self.endpoint + f"/{self.endpoint}/?{query_string}"
+        url = f"https://{bucket_name}.s3.amazonaws.com/?{query_string}"
         retry_id = "accelerate"
         self.retry_count[retry_id] = 0
         response = self._send_request_with_authentication_and_retry(
@@ -550,8 +564,11 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         )
         if response.status_code == 200:
             config = ET.fromstring(response.text)
+            namespace = config.tag[: config.tag.index("}") + 1]
+            statusTag = f"{namespace}Status"
+            found = config.find(statusTag)
             use_accelerate_endpoint = (
-                config.find("Status") and config.find("Status").text == "Enabled"
+                False if found is None else (found.text == "Enabled")
             )
             logger.debug(f"use_accelerate_endpoint: {use_accelerate_endpoint}")
             return use_accelerate_endpoint

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -59,7 +59,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         credentials: StorageCredential,
         stage_info: dict[str, Any],
         chunk_size: int,
-        use_accelerate_endpoint: bool = None,
+        use_accelerate_endpoint: bool | None = None,
         use_s3_regional_url=False,
     ) -> None:
         """Rest client for S3 storage.
@@ -82,14 +82,16 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         self.use_s3_regional_url = use_s3_regional_url
 
         # if GS sends us an endpoint, it's likely for FIPS. Use it.
-        self.endpoint = None
+        self.endpoint: str | None = None
         if stage_info["endPoint"]:
             self.endpoint = (
                 f"https://{self.s3location.bucket_name}." + stage_info["endPoint"]
             )
         self.transfer_accelerate_config(use_accelerate_endpoint)
 
-    def transfer_accelerate_config(self, use_accelerate_endpoint: bool = None) -> bool:
+    def transfer_accelerate_config(
+        self, use_accelerate_endpoint: bool | None = None
+    ) -> bool:
         # if self.endpoint has been set, e.g. by metadata, no more config is needed.
         if self.endpoint is not None:
             return self.endpoint.find("s3-accelerate.amazonaws.com") >= 0

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -10,10 +10,13 @@ import os
 import time
 from getpass import getuser
 from logging import getLogger
+from unittest.mock import patch
 
 import pytest
 
 from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
+from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
 
 from ..generate_test_files import generate_k_lines_of_n_files
 from ..integ_helpers import put
@@ -37,6 +40,67 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, fro
         number_of_lines=number_of_lines,
         from_path=from_path,
     )
+
+
+@pytest.mark.aws
+@pytest.mark.parametrize(
+    "from_path",
+    [True, pytest.param(False, marks=pytest.mark.skipolddriver)],
+)
+@pytest.mark.parametrize(
+    "accelerate_config", [True, pytest.param(False, marks=pytest.mark.skipolddriver)]
+)
+def test_put_get_accelerate_user_stage(
+    is_public_test, tmpdir, conn_cnx, from_path, accelerate_config
+):
+    """[s3] Puts and Gets Small Data via User Stage."""
+    if is_public_test or "AWS_ACCESS_KEY_ID" not in os.environ:
+        pytest.skip("This test requires to change the internal parameter")
+    number_of_files = 5 if from_path else 1
+    number_of_lines = 1
+    endpoints = []
+
+    def mocked_file_agent(*args, **kwargs):
+        agent = SnowflakeFileTransferAgent(*args, **kwargs)
+        mocked_file_agent.agent = agent
+        return agent
+
+    original_accelerate_config = SnowflakeS3RestClient.transfer_accelerate_config
+    expected_cfg = accelerate_config
+
+    def mock_s3_transfer_accelerate_config(self, *args, **kwargs) -> bool:
+        bret = original_accelerate_config(self, *args, **kwargs)
+        endpoints.append(self.endpoint)
+        return bret
+
+    def mock_s3_get_bucket_config(self, *args, **kwargs) -> bool:
+        return expected_cfg
+
+    with patch(
+        "snowflake.connector.cursor.SnowflakeFileTransferAgent",
+        side_effect=mocked_file_agent,
+    ):
+        with patch.multiple(
+            "snowflake.connector.s3_storage_client.SnowflakeS3RestClient",
+            _get_bucket_accelerate_config=mock_s3_get_bucket_config,
+            transfer_accelerate_config=mock_s3_transfer_accelerate_config,
+        ):
+            _put_get_user_stage(
+                tmpdir,
+                conn_cnx,
+                number_of_files=number_of_files,
+                number_of_lines=number_of_lines,
+                from_path=from_path,
+            )
+            config_accl = mocked_file_agent.agent._use_accelerate_endpoint
+            if accelerate_config:
+                assert (config_accl is True) and all(
+                    ele.find("s3-acc") >= 0 for ele in endpoints
+                )
+            else:
+                assert (config_accl is False) and all(
+                    ele.find("s3-acc") < 0 for ele in endpoints
+                )
 
 
 @pytest.mark.aws
@@ -143,6 +207,7 @@ def _put_get_user_stage(
     tmp_dir = generate_k_lines_of_n_files(
         number_of_lines, number_of_files, tmp_dir=str(tmpdir.mkdir("data"))
     )
+
     files = os.path.join(tmp_dir, "file*" if from_path else os.listdir(tmp_dir)[0])
     file_stream = None if from_path else open(files, "rb")
 

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -51,9 +51,7 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, fro
     "accelerate_config",
     [True, False],
 )
-def test_put_get_accelerate_user_stage(
-    is_public_test, tmpdir, conn_cnx, from_path, accelerate_config
-):
+def test_put_get_accelerate_user_stage(tmpdir, conn_cnx, from_path, accelerate_config):
     """[s3] Puts and Gets Small Data via User Stage."""
     from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
     from snowflake.connector.s3_storage_client import SnowflakeS3RestClient

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -40,6 +40,7 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, fro
     )
 
 
+@pytest.mark.internal
 @pytest.mark.skipolddriver
 @pytest.mark.aws
 @pytest.mark.parametrize(
@@ -53,12 +54,10 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, fro
 def test_put_get_accelerate_user_stage(
     is_public_test, tmpdir, conn_cnx, from_path, accelerate_config
 ):
+    """[s3] Puts and Gets Small Data via User Stage."""
     from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
     from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
 
-    """[s3] Puts and Gets Small Data via User Stage."""
-    if is_public_test or "AWS_ACCESS_KEY_ID" not in os.environ:
-        pytest.skip("This test requires to change the internal parameter")
     number_of_files = 5 if from_path else 1
     number_of_lines = 1
     endpoints = []

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -15,8 +15,6 @@ from unittest.mock import patch
 import pytest
 
 from snowflake.connector.cursor import SnowflakeCursor
-from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
-from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
 
 from ..generate_test_files import generate_k_lines_of_n_files
 from ..integ_helpers import put
@@ -42,17 +40,22 @@ def test_put_get_small_data_via_user_stage(is_public_test, tmpdir, conn_cnx, fro
     )
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.aws
 @pytest.mark.parametrize(
     "from_path",
-    [True, pytest.param(False, marks=pytest.mark.skipolddriver)],
+    [True, False],
 )
 @pytest.mark.parametrize(
-    "accelerate_config", [True, pytest.param(False, marks=pytest.mark.skipolddriver)]
+    "accelerate_config",
+    [True, False],
 )
 def test_put_get_accelerate_user_stage(
     is_public_test, tmpdir, conn_cnx, from_path, accelerate_config
 ):
+    from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
+    from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
+
     """[s3] Puts and Gets Small Data via User Stage."""
     if is_public_test or "AWS_ACCESS_KEY_ID" not in os.environ:
         pytest.skip("This test requires to change the internal parameter")

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -106,13 +106,20 @@ def test_upload_file_with_s3_upload_failed_error(tmp_path):
         },
     )
     exc = Exception("Stop executing")
+
+    def mock_transfer_accelerate_config(
+        self: SnowflakeS3RestClient, use_accelerate_endpoint: bool = None
+    ) -> bool:
+        self.endpoint = f"https://{self.s3location.bucket_name}.s3.awsamazon.com"
+        return False
+
     with mock.patch(
         "snowflake.connector.s3_storage_client.SnowflakeS3RestClient._has_expired_token",
         return_value=True,
     ):
         with mock.patch(
             "snowflake.connector.s3_storage_client.SnowflakeS3RestClient.transfer_accelerate_config",
-            return_value=False,
+            mock_transfer_accelerate_config,
         ):
             with mock.patch(
                 "snowflake.connector.file_transfer_agent.StorageCredential.update",

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -108,7 +108,8 @@ def test_upload_file_with_s3_upload_failed_error(tmp_path):
     exc = Exception("Stop executing")
 
     def mock_transfer_accelerate_config(
-        self: SnowflakeS3RestClient, use_accelerate_endpoint: bool = None
+        self: SnowflakeS3RestClient,
+        use_accelerate_endpoint: bool | None = None,
     ) -> bool:
         self.endpoint = f"https://{self.s3location.bucket_name}.s3.awsamazon.com"
         return False


### PR DESCRIPTION
A test is added to make sure right endpoint is used according to accelerate configuration

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-507942

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  1)  Check s3 accelerate config to use right URL; 2) parse XML response to retrieve configuration status correctly; 3) make sure the accelerate config could be updated correctly from previous s3 API call to all s3 client objects where they have their own endpoint.
  
  I have read the CLA Document and I hereby sign the CLA