### PR TITLE
SNOW-522489 Ignore content-encoding when GET

### DIFF
--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -121,7 +121,8 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
         r = self._send_request_with_authentication_and_retry("HEAD", url, retry_id)
         if r.status_code == 200:
             meta.result_status = ResultStatus.UPLOADED
-            encryption_data = json.loads(r.headers.get(ENCRYPTION_DATA))
+            enc_data_str = r.headers.get(ENCRYPTION_DATA)
+            encryption_data = None if enc_data_str is None else json.loads(enc_data_str)
             encryption_metadata = (
                 None
                 if not encryption_data

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -166,26 +166,13 @@ class SnowflakeEncryptionUtil:
         return metadata, temp_output_file
 
     @staticmethod
-    def decrypt_file(
+    def decrypt_stream(
         metadata: EncryptionMetadata,
         encryption_material: SnowflakeFileEncryptionMaterial,
-        in_filename: str,
-        chunk_size: int = 64 * kilobyte,
-        tmp_dir=None,
-    ) -> str:
-        """Decrypts a file and stores the output in the temporary directory.
-
-        Args:
-            metadata: The file's metadata input.
-            encryption_material: The file's encryption material.
-            in_filename: The name of the input file.
-            chunk_size: The size of read chunks (Default value = block_size * 4 * 1024).
-            tmp_dir: Temporary directory to use, optional (Default value = None).
-
-        Returns:
-            The decrypted file's location.
-        """
-        logger = getLogger(__name__)
+        src: IO[bytes],
+        out: IO[bytes],
+        chunk_size: int = 64 * kilobyte,  # block_size * 4 * 1024,
+    ) -> None:
         use_openssl_only = os.getenv("SF_USE_OPENSSL_ONLY", "False") == "True"
         key_base64 = metadata.key
         iv_base64 = metadata.iv
@@ -209,28 +196,57 @@ class SnowflakeEncryptionUtil:
             )
             decryptor = cipher.decryptor()
 
+        total_file_size = 0
+        last_decrypted_chunk = None
+        chunk = src.read(chunk_size)
+        while True:
+            if len(chunk) == 0:
+                break
+            if last_decrypted_chunk is not None:
+                out.write(last_decrypted_chunk)
+            total_file_size += len(chunk)
+            if not use_openssl_only:
+                d = data_cipher.decrypt(chunk)
+            else:
+                d = decryptor.update(chunk)
+            last_decrypted_chunk = d
+            chunk = src.read(chunk_size)
+
+        if last_decrypted_chunk is not None:
+            offset = PKCS5_OFFSET(last_decrypted_chunk)
+            total_file_size -= offset
+            out.write(last_decrypted_chunk[:-offset])
+        if use_openssl_only:
+            out.write(decryptor.finalize())
+
+    @staticmethod
+    def decrypt_file(
+        metadata: EncryptionMetadata,
+        encryption_material: SnowflakeFileEncryptionMaterial,
+        in_filename: str,
+        chunk_size: int = 64 * kilobyte,
+        tmp_dir=None,
+    ) -> str:
+        """Decrypts a file and stores the output in the temporary directory.
+
+        Args:
+            metadata: The file's metadata input.
+            encryption_material: The file's encryption material.
+            in_filename: The name of the input file.
+            chunk_size: The size of read chunks (Default value = block_size * 4 * 1024).
+            tmp_dir: Temporary directory to use, optional (Default value = None).
+
+        Returns:
+            The decrypted file's location.
+        """
         temp_output_fd, temp_output_file = tempfile.mkstemp(
             text=False, dir=tmp_dir, prefix=os.path.basename(in_filename) + "#"
         )
-        total_file_size = 0
-        prev_chunk = None
+        logger = getLogger(__name__)
         logger.debug("encrypted file: %s, tmp file: %s", in_filename, temp_output_file)
         with open(in_filename, "rb") as infile:
             with os.fdopen(temp_output_fd, "wb") as outfile:
-                while True:
-                    chunk = infile.read(chunk_size)
-                    if len(chunk) == 0:
-                        break
-                    total_file_size += len(chunk)
-                    if not use_openssl_only:
-                        d = data_cipher.decrypt(chunk)
-                    else:
-                        d = decryptor.update(chunk)
-                    outfile.write(d)
-                    prev_chunk = d
-                if prev_chunk is not None:
-                    total_file_size -= PKCS5_OFFSET(prev_chunk)
-                if use_openssl_only:
-                    outfile.write(decryptor.finalize())
-                outfile.truncate(total_file_size)
+                SnowflakeEncryptionUtil.decrypt_stream(
+                    metadata, encryption_material, infile, outfile, chunk_size
+                )
         return temp_output_file

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -104,7 +104,7 @@ class SnowflakeFileMeta:
     stage_location_type: str
     result_status: ResultStatus | None = None
 
-    self: SnowflakeFileTransferAgent | None = None
+    sfagent: SnowflakeFileTransferAgent | None = None
     put_callback: type[SnowflakeProgressPercentage] | None = None
     put_azure_callback: type[SnowflakeProgressPercentage] | None = None
     put_callback_output_stream: IO[str] | None = None
@@ -362,7 +362,7 @@ class SnowflakeFileTransferAgent:
             self._process_file_compression_type()
 
         for m in self._file_metadata:
-            m.self = self
+            m.sfagent = self
 
         self._transfer_accelerate_config()
 
@@ -376,7 +376,7 @@ class SnowflakeFileTransferAgent:
 
         for m in self._file_metadata:
             m.overwrite = self._overwrite
-            m.self = self
+            m.sfagent = self
             if self._stage_location_type != LOCAL_FS:
                 m.put_callback = self._put_callback
                 m.put_azure_callback = self._put_azure_callback

--- a/src/snowflake/connector/gcs_storage_client.py
+++ b/src/snowflake/connector/gcs_storage_client.py
@@ -348,7 +348,7 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
                 return None
             elif response.status_code == 200:
                 digest = response.headers.get(GCS_METADATA_SFC_DIGEST, None)
-                content_length = response.headers.get("content-length", None)
+                content_length = int(response.headers.get("content-length", "0"))
 
                 encryption_metadata = EncryptionMetadata("", "", "")
                 if response.headers.get(GCS_METADATA_ENCRYPTIONDATAPROP, None):

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -48,7 +48,7 @@ METHODS = {
 }
 
 
-def remove_content_encoding(resp: requests.Response, **kwargs):
+def remove_content_encoding(resp: requests.Response, **kwargs) -> None:
     """Remove content-encoding header and decoder so decompression is not triggered"""
     if HTTP_HEADER_CONTENT_ENCODING in resp.headers:
         if isinstance(resp.raw, HTTPResponse):

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -51,7 +51,6 @@ METHODS = {
 def remove_content_encoding(resp: requests.Response, **kwargs):
     """Remove content-encoding header and decoder so decompression is not triggered"""
     if HTTP_HEADER_CONTENT_ENCODING in resp.headers:
-        # resp.headers.pop(HTTP_HEADER_CONTENT_ENCODING)
         if isinstance(resp.raw, HTTPResponse):
             resp.raw._decoder = None
             resp.raw.headers.pop(HTTP_HEADER_CONTENT_ENCODING)

--- a/test/integ/test_put_get_compress_enc.py
+++ b/test/integ/test_put_get_compress_enc.py
@@ -20,9 +20,7 @@ try:
     from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
 
     orig_send_req = SnowflakeS3RestClient._send_request_with_authentication_and_retry
-    hack_s3_rest_client = True
 except ImportError:
-    hack_s3_rest_client = False
     SnowflakeS3RestClient = None
     orig_send_req = None
 
@@ -101,10 +99,8 @@ def test_auto_compress_switch(
             # get this file, if the client handle compression meta correctly
             get_dir = tmp_path / "get_dir"
             get_dir.mkdir()
-            cnx.cursor().execute(
-                f"GET @~/{_test_name}/{file_name} file://{get_dir}"
-            ).fetchone()
-            # TODO: The downloaded file should always be the unzip (original) file
+            cnx.cursor().execute(f"GET @~/{_test_name}/{file_name} file://{get_dir}")
+
             downloaded_file = get_dir / (
                 uploaded_gz_name if auto_compress else file_name
             )
@@ -119,7 +115,6 @@ def test_auto_compress_switch(
 
 
 @pytest.mark.aws
-@pytest.mark.skipif(hack_s3_rest_client, reason="s3_rest_client could not be imported.")
 def test_get_gzip_content_encoding(
     tmp_path: pathlib.Path,
     conn_cnx,
@@ -167,7 +162,6 @@ def test_get_gzip_content_encoding(
 
 
 @pytest.mark.aws
-@pytest.mark.skipif(hack_s3_rest_client, reason="s3_rest_client could not be imported.")
 def test_sse_get_gzip_content_encoding(
     tmp_path: pathlib.Path,
     conn_cnx,

--- a/test/integ/test_put_get_compress_enc.py
+++ b/test/integ/test_put_get_compress_enc.py
@@ -25,7 +25,7 @@ except ImportError:
     orig_send_req = None
 
 
-def _prepare_tmp_file(to_dir: str) -> str:
+def _prepare_tmp_file(to_dir: pathlib.Path) -> tuple[pathlib.Path, str]:
     tmp_dir = to_dir / "data"
     tmp_dir.mkdir()
     file_name = "data.txt"

--- a/test/integ/test_put_get_compress_enc.py
+++ b/test/integ/test_put_get_compress_enc.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+#
+# Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+#
+import filecmp
+import pathlib
+from logging import getLogger
+from os import path
+from unittest.mock import patch
+
+import pytest
+
+from snowflake.connector.s3_storage_client import SnowflakeS3RestClient
+
+from ..integ_helpers import put
+
+try:
+    from ..parameters import CONNECTION_PARAMETERS_ADMIN
+except ImportError:
+    CONNECTION_PARAMETERS_ADMIN = {}
+
+THIS_DIR = path.dirname(path.realpath(__file__))
+
+logger = getLogger(__name__)
+
+
+def _prepare_tmp_file(to_dir: str) -> str:
+    tmp_dir = to_dir / "data"
+    tmp_dir.mkdir()
+    file_name = "data.txt"
+    test_path = tmp_dir / file_name
+    with test_path.open("w") as f:
+        f.write("test1,test2\n")
+        f.write("test3,test4")
+    return test_path, file_name
+
+
+orig_send_req = SnowflakeS3RestClient._send_request_with_authentication_and_retry
+
+
+def mock_send_request(
+    self,
+    url,
+    verb,
+    retry_id,
+    query_parts=None,
+    x_amz_headers=None,
+    headers=None,
+    payload=None,
+    unsigned_payload=False,
+    ignore_content_encoding=False,
+):
+    # when called under _initiate_multipart_upload and _upload_chunk, add content-encoding to header
+    if verb is not None and verb in ("POST", "PUT") and headers is not None:
+        headers["Content-Encoding"] = "gzip"
+    return orig_send_req(
+        self,
+        url,
+        verb,
+        retry_id,
+        query_parts,
+        x_amz_headers,
+        headers,
+        payload,
+        unsigned_payload,
+        ignore_content_encoding,
+    )
+
+
+@pytest.mark.skipolddriver
+@pytest.mark.aws
+@pytest.mark.skipif(
+    not CONNECTION_PARAMETERS_ADMIN, reason="Snowflake admin account is not accessible."
+)
+@pytest.mark.parametrize("auto_compress", [True, False])
+def test_auto_compress_switch(
+    tmp_path: pathlib.Path,
+    conn_cnx,
+    auto_compress,
+):
+    """Tests PUT command with auto_compress=False|True."""
+    _test_name = "test_auto_compress_switch"
+    test_data, file_name = _prepare_tmp_file(tmp_path)
+
+    with conn_cnx() as cnx:
+        cnx.cursor().execute(f"RM @~/{_test_name}")
+        try:
+            file_stream = test_data.open("rb")
+            with cnx.cursor() as cur:
+                put(
+                    cur,
+                    str(test_data),
+                    f"~/{_test_name}",
+                    False,
+                    sql_options=f"auto_compress={auto_compress}",
+                    file_stream=file_stream,
+                )
+
+            ret = cnx.cursor().execute(f"LS @~/{_test_name}").fetchone()
+            uploaded_gz_name = f"{file_name}.gz"
+            if auto_compress:
+                assert uploaded_gz_name in ret[0]
+            else:
+                assert uploaded_gz_name not in ret[0]
+
+            # get this file, if the client handle compression meta correctly
+            get_dir = tmp_path / "get_dir"
+            get_dir.mkdir()
+            cnx.cursor().execute(
+                f"GET @~/{_test_name}/{file_name} file://{get_dir}"
+            ).fetchone()
+            # TODO: The downloaded file should always be the unzip (original) file
+            downloaded_file = get_dir / (
+                uploaded_gz_name if auto_compress else file_name
+            )
+            assert downloaded_file.exists()
+            if not auto_compress:
+                assert filecmp.cmp(test_data, downloaded_file)
+
+        finally:
+            cnx.cursor().execute(f"RM @~/{_test_name}")
+            if file_stream:
+                file_stream.close()
+
+
+def test_get_gzip_content_encoding(
+    tmp_path: pathlib.Path,
+    conn_cnx,
+):
+    """Tests GET command for a content-encoding=GZIP in stage"""
+    _test_name = "test_get_gzip_content_encoding"
+    test_data, file_name = _prepare_tmp_file(tmp_path)
+
+    with patch(
+        "snowflake.connector.s3_storage_client.SnowflakeS3RestClient._send_request_with_authentication_and_retry",
+        mock_send_request,
+    ):
+        with conn_cnx() as cnx:
+            cnx.cursor().execute(f"RM @~/{_test_name}")
+            try:
+                file_stream = test_data.open("rb")
+                with cnx.cursor() as cur:
+                    put(
+                        cur,
+                        str(test_data),
+                        f"~/{_test_name}",
+                        False,
+                        sql_options="auto_compress=True",
+                        file_stream=file_stream,
+                    ).fetchone()
+
+                ret = cnx.cursor().execute(f"LS @~/{_test_name}").fetchone()
+                assert f"{file_name}.gz" in ret[0]
+
+                # get this file, if the client handle compression meta correctly
+                get_dir = tmp_path / "get_dir"
+                get_dir.mkdir()
+                ret = (
+                    cnx.cursor()
+                    .execute(f"GET @~/{_test_name}/{file_name} file://{get_dir}")
+                    .fetchone()
+                )
+                downloaded_file = get_dir / ret[0]
+                assert downloaded_file.exists()
+
+            finally:
+                cnx.cursor().execute(f"RM @~/{_test_name}")
+                if file_stream:
+                    file_stream.close()
+
+
+def test_sse_get_gzip_content_encoding(
+    tmp_path: pathlib.Path,
+    conn_cnx,
+):
+    """Tests GET command for a content-encoding=GZIP in stage and it is SSE(server side encrypted)"""
+    _test_name = "test_sse_get_gzip_content_encoding"
+    test_data, orig_file_name = _prepare_tmp_file(tmp_path)
+    stage_name = "sse_stage"
+    with patch(
+        "snowflake.connector.s3_storage_client.SnowflakeS3RestClient._send_request_with_authentication_and_retry",
+        mock_send_request,
+    ):
+        with conn_cnx() as cnx:
+            cnx.cursor().execute(
+                f"create or replace stage {stage_name} ENCRYPTION=(TYPE='SNOWFLAKE_SSE')"
+            )
+            cnx.cursor().execute(f"RM @{stage_name}/{_test_name}")
+            try:
+                file_stream = test_data.open("rb")
+                with cnx.cursor() as cur:
+                    put(
+                        cur,
+                        str(test_data),
+                        f"{stage_name}/{_test_name}",
+                        False,
+                        sql_options="auto_compress=True",
+                        file_stream=file_stream,
+                    )
+
+                ret = cnx.cursor().execute(f"LS @{stage_name}/{_test_name}").fetchone()
+                assert f"{orig_file_name}.gz" in ret[0]
+
+                # get this file, if the client handle compression meta correctly
+                get_dir = tmp_path / "get_dir"
+                get_dir.mkdir()
+                ret = (
+                    cnx.cursor()
+                    .execute(
+                        f"GET @{stage_name}/{_test_name}/{orig_file_name} file://{get_dir}"
+                    )
+                    .fetchone()
+                )
+                # TODO: The downloaded file should always be the unzip (original) file
+                downloaded_file = get_dir / ret[0]
+                assert downloaded_file.exists()
+
+            finally:
+                cnx.cursor().execute(f"RM @{stage_name}/{_test_name}")
+                if file_stream:
+                    file_stream.close()


### PR DESCRIPTION
when content-encoding header of download response is set to 'gzip', urllib3 decompression on fly was
triggered and failed on encrypted data. This is not backward compatible with previous behavior.

Integrated Test added to mock the scenario when Content-Encoding=gzip is added
which is the case when PUT by JDBC.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
