### PR TITLE
Clip nano precision int64_t arrow values

### DIFF
--- a/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -789,7 +789,15 @@ void CArrowTableIterator::convertTimestampColumn(
                 structArray->GetFieldByName(sf::internal::FIELD_NAME_EPOCH))->Value(rowIdx);
               int32_t fraction = std::static_pointer_cast<arrow::Int32Array>(
                 structArray->GetFieldByName(sf::internal::FIELD_NAME_FRACTION))->Value(rowIdx);
-              val = epoch * sf::internal::powTenSB4[9] + fraction;
+              // Clip the epoch to max/min values avoiding overflows
+              int powTenSB4 = sf::internal::powTenSB4[9];
+              if (epoch > (INT64_MAX / powTenSB4)) {
+                val = INT64_MAX;
+              } else if (epoch < (INT64_MIN / powTenSB4)) {
+                val = INT64_MIN;
+              } else {
+                val = epoch * powTenSB4 + fraction;
+              }
             }
             break;
           default:


### PR DESCRIPTION
This prevents data from overflows.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes case 00343142

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This code avoid overflows in arrow table iterator.
