### PR TITLE
SNOW-584166: Fix the error message when pandas is not installed 

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -888,7 +888,7 @@ class SnowflakeCursor:
     def check_can_use_pandas(self):
         if not installed_pandas:
             msg = (
-                "Optional dependency: 'pyarrow' is not installed, please see the following link for install "
+                "Optional dependency: 'pandas' is not installed, please see the following link for install "
                 "instructions: https://docs.snowflake.com/en/user-guide/python-connector-pandas.html#installation"
             )
             errno = ER_NO_PYARROW

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -364,7 +364,7 @@ class ResultBatch(abc.ABC):
     def _check_can_use_pandas(self) -> None:
         if not installed_pandas:
             msg = (
-                "Optional dependency: 'pyarrow' is not installed, please see the following link for install "
+                "Optional dependency: 'pandas' is not installed, please see the following link for install "
                 "instructions: https://docs.snowflake.com/en/user-guide/python-connector-pandas.html#installation"
             )
             errno = ER_NO_PYARROW

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1273,7 +1273,7 @@ def test_check_cannot_use_pandas(conn_cnx):
             with mock.patch("snowflake.connector.cursor.installed_pandas", False):
                 with pytest.raises(
                     ProgrammingError,
-                    match=r"Optional dependency: 'pyarrow' is not installed, please see the "
+                    match=r"Optional dependency: 'pandas' is not installed, please see the "
                     "following link for install instructions: https:.*",
                 ) as pe:
                     cur.check_can_use_pandas()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-584166

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Our optional dependency is `pandas` but the error message shows `pyarrow`. This PR fixes this error message. 
