### PR TITLE
Update documentation link to python specific main page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 keywords = Snowflake db database cloud analytics warehouse
 project_urls =
-    Documentation=https://docs.snowflake.com/
+    Documentation=https://docs.snowflake.com/en/user-guide/python-connector.html
     Source=https://github.com/snowflakedb/snowflake-connector-python
     Issues=https://github.com/snowflakedb/snowflake-connector-python/issues
     Changelog=https://github.com/snowflakedb/snowflake-connector-python/blob/master/DESCRIPTION.md


### PR DESCRIPTION
When browsing PyPI, I'm expecting a documentation page to be specific to the package, not a general page about the related platform. If one needs access to generic Snowflake doc, it is one click away from the Python Conncetor's Doc. Pointing directly to the Python Conncetor's Documentation feels more natural.
If this is against your guidelines, or there's any other objection, just reject the PR. 