### PR TITLE
DATA-1339 Set application name based on streamlit being in sys.modules

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -268,8 +268,11 @@ class SnowflakeConnection:
 
         self.heartbeat_thread = None
 
-        if "application" not in kwargs and ENV_VAR_PARTNER in os.environ.keys():
-            kwargs["application"] = os.environ[ENV_VAR_PARTNER]
+        if "application" not in kwargs:
+            if ENV_VAR_PARTNER in os.environ.keys():
+                kwargs["application"] = os.environ[ENV_VAR_PARTNER]
+            elif "streamlit" in sys.modules:
+                kwargs["application"] = "streamlit"
 
         self.converter = None
         self.__set_error_attributes()

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -20,7 +20,7 @@ except ImportError:
     QueryStatus = None
 
 
-def fake_connector() -> snowflake.connector:
+def fake_connector() -> snowflake.connector.SnowflakeConnection:
     return snowflake.connector.connect(
         user="user",
         account="account",

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -20,45 +20,43 @@ except ImportError:
     QueryStatus = None
 
 
-@patch("snowflake.connector.network.SnowflakeRestful._post_request")
-def test_connect_with_service_name(mockSnowflakeRestfulPostRequest):
-    def mock_post_request(url, headers, json_body, **kwargs):
-        global mock_cnt
-        ret = None
-        if mock_cnt == 0:
-            # return from /v1/login-request
-            ret = {
-                "success": True,
-                "message": None,
-                "data": {
-                    "token": "TOKEN",
-                    "masterToken": "MASTER_TOKEN",
-                    "idToken": None,
-                    "parameters": [
-                        {"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}
-                    ],
-                },
-            }
-        return ret
-
-    # POST requests mock
-    mockSnowflakeRestfulPostRequest.side_effect = mock_post_request
-
-    global mock_cnt
-    mock_cnt = 0
-
-    account = "testaccount"
-    user = "testuser"
-
-    # connection
-    con = snowflake.connector.connect(
-        account=account,
-        user=user,
+def fake_connector() -> snowflake.connector:
+    return snowflake.connector.connect(
+        user="user",
+        account="account",
         password="testpassword",
         database="TESTDB",
         warehouse="TESTWH",
     )
-    assert con.service_name == "FAKE_SERVICE_NAME"
+
+
+@pytest.fixture
+def mock_post_requests(monkeypatch):
+    request_body = {}
+
+    def mock_post_request(request, url, headers, json_body, **kwargs):
+        nonlocal request_body
+        request_body.update(json.loads(json_body))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+                "idToken": None,
+                "parameters": [{"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}],
+            },
+        }
+
+    monkeypatch.setattr(
+        snowflake.connector.network.SnowflakeRestful, "_post_request", mock_post_request
+    )
+
+    return request_body
+
+
+def test_connect_with_service_name(mock_post_requests):
+    assert fake_connector().service_name == "FAKE_SERVICE_NAME"
 
 
 @pytest.mark.skip(reason="Mock doesn't work as expected.")
@@ -137,69 +135,23 @@ def test_is_still_running():
         )
 
 
-@pytest.fixture
-def mock_post_requests(monkeypatch):
-    request_body = []
-
-    def mock_post_request(request, url, headers, json_body, **kwargs):
-        nonlocal request_body
-        request_body.append(json.loads(json_body))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-                "idToken": None,
-                "parameters": [{"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}],
-            },
-        }
-
-    monkeypatch.setattr(
-        snowflake.connector.network.SnowflakeRestful, "_post_request", mock_post_request
-    )
-
-    return request_body
-
-
 @pytest.mark.skipolddriver
 def test_partner_env_var(mock_post_requests):
     PARTNER_NAME = "Amanda"
 
     with patch.dict(os.environ, {ENV_VAR_PARTNER: PARTNER_NAME}):
-        # connection
-        assert (
-            snowflake.connector.connect(
-                user="user",
-                account="account",
-                password="testpassword",
-                database="TESTDB",
-                warehouse="TESTWH",
-            ).application
-            == PARTNER_NAME
-        )
+        assert fake_connector().application == PARTNER_NAME
 
     assert (
-        mock_post_requests[0]["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"]
-        == PARTNER_NAME
+        mock_post_requests["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"] == PARTNER_NAME
     )
 
 
 @pytest.mark.skipolddriver
 def test_imported_module(mock_post_requests):
     with patch.dict(sys.modules, {"streamlit": "foo"}):
-        assert (
-            snowflake.connector.connect(
-                user="user",
-                account="account",
-                password="testpassword",
-                database="TESTDB",
-                warehouse="TESTWH",
-            ).application
-            == "streamlit"
-        )
+        assert fake_connector().application == "streamlit"
 
     assert (
-        mock_post_requests[0]["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"]
-        == "streamlit"
+        mock_post_requests["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"] == "streamlit"
     )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   https://snowflakecomputing.atlassian.net/browse/DATA-1339

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In order to correctly attribute connector usage to streamlit, check sys.modules for the presence of "streamlit" and if found, and not set otherwise, use that to set the application appropriately.
