### PR TITLE
SNOW-584369 get_results_from_sfqid missing errno

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,7 +10,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 
 
-- v2.7.9()
+- v2.7.9(Unreleased)
+`
 
    - Fixed a bug where errors raised during get_results_from_sfqid() were missing errno
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,13 +10,18 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 
 
+- v2.7.9()
+
+   - Fixed a bug where errors raised during get_results_from_sfqid() were missing errno
+
+
 - v2.7.8(May 28,2022)
 
-   - Updated PyPi documentation link to python specific main page 
+   - Updated PyPi documentation link to python specific main page
    - Fixed an error message that appears when pandas optional dependency group is required but is not installed
    - Implemented the DB API 2 callproc() method
    - Fixed a bug where decryption took place before decompression when downloading files from stages
-   - Fixed a bug where s3 accelerate configuration was handled incorrectly 
+   - Fixed a bug where s3 accelerate configuration was handled incorrectly
    - Extra named arguments given executemany() are now forwarded to execute()
    - Automatically sets the application name to streamlit when streamlit is imported and application name was not explicitly set
    - Bumped pyopenssl dependency version to >=16.2.0,<23.0.0

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1439,9 +1439,7 @@ class SnowflakeConnection:
             message = status_resp.get("message")
             if message is None:
                 message = ""
-            code = status_resp.get("code")
-            if code is None:
-                code = -1
+            code = queries[0].get("errorCode", -1)
             sql_state = None
             if "data" in status_resp:
                 message += (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-584369

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Errors raised when running `get_results_from_sfqid` are missing `errno` numbers. In addition I found that we had no nice error messages when a query is not found by the same method. So I added error checking and nicer error message when this happens.