### PR TITLE
SNOW-620973: Ensure log_max_query_length is an int

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -452,7 +452,7 @@ class SnowflakeConnection:
 
     @property
     def log_max_query_length(self):
-        return self._log_max_query_length
+        return int(self._log_max_query_length)
 
     @property
     def disable_request_pooling(self):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-620973

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When log_max_query_length is set via a kwarg argument to URL(), then cursor.log_max_query_length is set to a string value instead of an int. This causes the statement `if len(ret) < self.log_max_query_length` in connection.py to throw an error.
