### PR TITLE
WIP: Import libarrow_python conditionally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
                 sources=[os.path.join(CONNECTOR_SRC_DIR, "arrow_iterator.pyx")],
             ),
         ],
+        compile_time_env={'PYARROW_HAS_LIBARROW_PYTHON':
+                          int(pyarrow.__version__.split('.', 1)[0]) >= 8}
     )
 
     class MyBuildExt(build_ext):

--- a/src/snowflake/connector/arrow_iterator.pyx
+++ b/src/snowflake/connector/arrow_iterator.pyx
@@ -19,10 +19,14 @@ from pyarrow.includes.libarrow cimport (
     CRecordBatchStreamReader,
     FileInterface,
     FileMode,
-    PyReadableFile,
     Readable,
     Seekable,
 )
+
+IF PYARROW_HAS_LIBARROW_PYTHON:
+    from pyarrow.includes.libarrow_python cimport PyReadableFile
+ELSE:
+    from pyarrow.includes.libarrow cimport PyReadableFile
 
 from .constants import IterUnit
 from .errorcode import (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Partially fixes #1189 

2. Fill out the following pre-review checklist:

   N/A

3. Please describe how your code solves the related issue.

   PyArrow 8 moves the `PyReadableFile` import from `libarrow` to `libarrow_python`. Because this
   is a Cython module, we can't use the common Python idiom of try/except to conditionally import
   `libarrow_python`. So we must do this with a Cython compile-time constant.