### PR TITLE
SNOW-629080: investigate and implement lastrowid

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
    - Release wheels are now built on manylinux2014
    - Bumped supported pyarrow version to >=8.0.0,<8.1.0
+   - Added attribute `lastrowid` to `SnowflakeCursor` in compliance with PEP249.
 
 
 - v2.7.9(June 26,2022)

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -368,8 +368,8 @@ class SnowflakeCursor:
         return hasattr(self, "_is_file_transfer") and self._is_file_transfer
 
     @property
-    def lastrowid(self):
-        # snowflake does not support lastrowid in which case None should be returned as per PEP249
+    def lastrowid(self) -> None:
+        """Snowflake does not support lastrowid in which case None should be returned as per PEP249."""
         return None
 
     def callproc(self, procname: str, args: T = ()) -> T:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -367,6 +367,11 @@ class SnowflakeCursor:
         """Whether the command is PUT or GET."""
         return hasattr(self, "_is_file_transfer") and self._is_file_transfer
 
+    @property
+    def lastrowid(self):
+        # snowflake does not support lastrowid in which case None should be returned as per PEP249
+        return None
+
     def callproc(self, procname: str, args: T = ()) -> T:
         """Call a stored procedure.
 

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
 try:
@@ -17,6 +18,12 @@ except ImportError:
         PUT = "put"
 
 
+class FakeConnection(SnowflakeConnection):
+    def __init__(self):
+        self._log_max_query_length = 0
+        self._reuse_results = None
+
+
 @pytest.mark.parametrize(
     "sql,_type",
     (
@@ -27,3 +34,9 @@ except ImportError:
 )
 def test_get_filetransfer_type(sql, _type):
     assert SnowflakeCursor.get_file_transfer_type(sql) == _type
+
+
+def test_cursor_attribute():
+    fake_conn = FakeConnection()
+    cursor = SnowflakeCursor(fake_conn)
+    assert not cursor.lastrowid

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -39,4 +39,4 @@ def test_get_filetransfer_type(sql, _type):
 def test_cursor_attribute():
     fake_conn = FakeConnection()
     cursor = SnowflakeCursor(fake_conn)
-    assert not cursor.lastrowid
+    assert cursor.lastrowid is None


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-629080

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Snowflake doesn't support lastrowid, according to [PEP249](https://peps.python.org/pep-0249/#lastrowid), we should return None for this attribute.

    ```definition in pep249
    Cursor.lastrowid
    This read-only attribute provides the rowid of the last modified row 
    (most databases return a rowid only when a single INSERT operation is performed).
    If the operation does not set a rowid or if the database does not support rowids,
    this attribute should be set to None.
    The semantics of .lastrowid are undefined in case the last executed
    statement modified more than one row, e.g. when using INSERT with .executemany().
    ```