### PR TITLE
SNOW-611961 in-file cache implementation

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,10 +9,13 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 
+- v2.7.12(unreleased)
+
+   - Added in-file cache to OCSP requests
+
 - v2.7.11(July 26,2022)
 
    - Added minimum version pin to typing_extensions
-
 
 - v2.7.10(July 22,2022)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     urllib3>=1.21.1,<1.27
     certifi>=2017.4.17
     typing_extensions>=4.3,<5
+    filelock>=3.5,<4
 include_package_data = True
 package_dir =
     =src

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -241,9 +241,7 @@ class SFDictCache(Generic[K, V]):
         given another SFDictCache then the timestamps will be taken
         from the other cache.
 
-        Returns a tuple of 2 booleans. The first one describes whether self learnt
-        from other and the second describes whether other could learn from self
-        (it's important to notice that other has not learnt anythin from self).
+        Returns a boolean. It describes whether self learnt anything from other.
 
         Note that clear_expired_entries will be called on both caches. To
         prevent deadlocks this is done without acquiring other._lock. The

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -5,10 +5,17 @@
 from __future__ import annotations
 
 import datetime
+import logging
+import os
+import pickle
+import platform
+import random
+import tempfile
 from collections.abc import Iterator
 from threading import Lock
 from typing import Generic, TypeVar
 
+from filelock import FileLock, Timeout
 from typing_extensions import NamedTuple, Self
 
 from . import constants
@@ -16,6 +23,8 @@ from . import constants
 now = datetime.datetime.now
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class CacheEntry(NamedTuple, Generic[T]):
@@ -42,6 +51,7 @@ class SFDictCache(Generic[K, V]):
         self,
         entry_lifetime: int = constants.DAY_IN_SECONDS,
     ) -> None:
+        """Inits a SFDictCache with lifetime."""
         self._entry_lifetime = datetime.timedelta(seconds=entry_lifetime)
         self._cache: dict[K, CacheEntry[V]] = {}
         self._lock = Lock()
@@ -129,14 +139,12 @@ class SFDictCache(Generic[K, V]):
     def items(self) -> list[tuple[K, V]]:
         with self._lock:
             values: list[tuple[K, V]] = []
-            for k in list(self._cache.keys()):
-                try:
-                    # TODO: this function could be further optimized by removing
-                    #  the need here to call _getitem here and call self._cache.keys()
-                    v = self._getitem(k, should_record_hits=False)
-                    values.append((k, v))
-                except KeyError:
-                    continue
+            for k, v in list(self._cache.items()):
+                if is_expired(v.expiry):
+                    self._expiration(k)
+                    self._delitem(k)
+                else:
+                    values.append((k, v.entry))
         return values
 
     def values(self) -> list[V]:
@@ -188,38 +196,76 @@ class SFDictCache(Generic[K, V]):
                 # Fall through
                 return False
 
+    def _update(
+        self,
+        other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
+    ) -> bool:
+        to_insert: dict[K, CacheEntry[V]]
+        self._clear_expired_entries()
+        if isinstance(other, (list, dict)):
+            expiry = now() + self._entry_lifetime
+            if isinstance(other, list):
+                g = iter(other)
+            elif isinstance(other, dict):
+                g = iter(other.items())
+            to_insert = {k: CacheEntry(expiry=expiry, entry=v) for k, v in g}
+        elif isinstance(other, SFDictCache):
+            other._clear_expired_entries()
+            others_items = list(other._cache.items())
+            # Only accept values from another cache if their key is not in self,
+            #  or if expiry is later the self known one
+            to_insert = {
+                k: v
+                for k, v in others_items
+                if (
+                    # self doesn't have this key
+                    k not in self._cache
+                    # other has newer expiry time
+                    or self._cache[k].expiry < v.expiry
+                )
+            }
+        else:
+            raise TypeError
+        self._cache.update(to_insert)
+        self.telemetry["size"] = len(self._cache)
+        return len(to_insert) > 0
+
     def update(
         self,
-        other: dict[K, V] | SFDictCache[K, V],
-    ) -> None:
-        """Insert multiple values at the same time.
+        other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
+    ) -> bool:
+        """Insert multiple values at the same time, if dicts could learn from the other.
 
-        If this function is given a dictionary, expiration timestamps
+        If this function is given a dictionary, or list expiration timestamps
         will be all the same a self._entry_lifetime form now. If it's
         given another SFDictCache then the timestamps will be taken
         from the other cache.
+
+        Returns a tuple of 2 booleans. The first one describes whether self learnt
+        from other and the second describes whether other could learn from self
+        (it's important to notice that other has not learnt anythin from self).
+
+        Note that clear_expired_entries will be called on both caches. To
+        prevent deadlocks this is done without acquiring other._lock. The
+        intended behavior is to use this function with an unpickled/unused cache.
+        If live caches are are being merged then use .items() on them first and
+        merge those into the other caches.
         """
-        if isinstance(other, dict):
-            t = now() + self._entry_lifetime
-            to_insert: dict[K, CacheEntry[V]] = {
-                k: CacheEntry(expiry=t, entry=v) for k, v in other.items()
-            }
-        elif isinstance(other, SFDictCache):
-            to_insert: dict[K, CacheEntry[V]] = {k: v for k, v in other._cache.items()}
-        else:
-            raise TypeError
         with self._lock:
-            self._cache.update(to_insert)
-            self.telemetry["size"] = len(self._cache)
+            return self._update(other)
 
     def _clear_expired_entries(self) -> None:
+        for k in list(self._cache.keys()):
+            try:
+                self._getitem(k, should_record_hits=False)
+            except KeyError:
+                continue
+        self.telemetry["size"] = len(self._cache)
+
+    def clear_expired_entries(self) -> None:
+        """Remove expired entries from the cache."""
         with self._lock:
-            for k in self._cache.keys():
-                try:
-                    self._getitem(k, should_record_hits=False)
-                except KeyError:
-                    continue
-            self.telemetry["size"] = len(self._cache)
+            self._clear_expired_entries()
 
     # Telemetry related functions, these can be plugged by child classes
     def _reset_telemetry(self) -> None:
@@ -260,3 +306,185 @@ class SFDictCache(Generic[K, V]):
         called from contexts where the lock is already held.
         """
         self.telemetry["expiration"] += 1
+
+
+class SFDictFileCache(SFDictCache):
+    def __init__(
+        self,
+        file_path: str | dict[str, str],
+        entry_lifetime: int = constants.DAY_IN_SECONDS,
+        file_timeout: int = 0,
+    ) -> None:
+        """Inits an SFDictFileCache with path, lifetime and .
+
+        File path can be a dictionary that contains different paths for different OSes,
+        possible keys are: 'darwin', 'linux' and 'windows'. If a current platform
+        cannot be determined, or is not in the dictionary we'll use the first value.
+        """
+        super().__init__(
+            entry_lifetime=entry_lifetime,
+        )
+        if isinstance(file_path, str):
+            self.file_path = os.path.expanduser(file_path)
+        else:
+            current_platform = platform.system().lower()
+            if current_platform is None or current_platform not in file_path:
+                self.file_path = next(iter(file_path.values()))
+            else:
+                self.file_path = os.path.expanduser(file_path[current_platform])
+        self.file_timeout = file_timeout
+        self._file_lock_path = f"{self.file_path}.lock"
+        self._file_lock = FileLock(self._file_lock_path, timeout=self.file_timeout)
+        self.last_loaded: datetime.datetime | None = None
+        if os.path.exists(self.file_path):
+            self._load()
+
+    def __getitem__(self, k: K) -> V:
+        """Returns an element if it hasn't expired yet in a thread-safe way."""
+        self._lock.acquire()
+        # TODO: This variable could be replaced by a wrapper class that keeps track
+        #  of whether the lock is locked, but unless this function gets extended I
+        #  feel like it's an overkill. Make sure to change the bool right after
+        #  self._lock.acquire() and self._lock.release().
+        currently_holding = True
+        try:
+            try:
+                t, v = self._cache[k]
+            except KeyError:
+                # Load if we should and try to see if we can turn the miss into a hit
+                self._lock.release()
+                currently_holding = False
+                loaded = self._load_if_should()
+                self._lock.acquire()
+                currently_holding = True
+                if loaded:
+                    try:
+                        t, v = self._cache[k]
+                    except KeyError:
+                        self._miss(k)
+                        raise
+                else:
+                    self._miss(k)
+                    raise
+            if is_expired(t):
+                self._lock.release()
+                currently_holding = False
+                loaded = self._load_if_should()
+                self._lock.acquire()
+                currently_holding = True
+                expire_item = True
+                if loaded:
+                    t, v = self._cache[k]
+                    if not is_expired(t):
+                        expire_item = False
+                if expire_item:
+                    self._expiration(k)
+                    self._delitem(k)
+                    raise KeyError
+            self._hit(k)
+            return v
+        finally:
+            if currently_holding:
+                self._lock.release()
+
+    def _setitem(self, k: K, v: V) -> None:
+        super()._setitem(k, v)
+        self._save_if_should()
+
+    def _load(self) -> bool:
+        """Load cache from disk if possible, returns whether it was able to load."""
+        try:
+            with open(self.file_path, "rb") as r_file:
+                other = pickle.load(r_file)
+            _ = self._update(other)
+            self.last_loaded = now()
+            return True
+        except OSError:
+            return False
+
+    def _save(self) -> bool:
+        """Save cache to disk if possible, returns whether it was able to save."""
+        self._clear_expired_entries()
+        try:
+            with self._file_lock:
+                self._load_if_should()
+                _dir, fname = os.path.split(self.file_path)
+                tmp_file, tmp_file_path = tempfile.mkstemp(
+                    prefix=fname,
+                    dir=_dir,
+                )
+                with open(tmp_file, "wb") as w_file:
+                    pickle.dump(self, w_file)
+                # We write to a tmp file and then move it to have atomic write
+                os.replace(tmp_file_path, self.file_path)
+                self.last_loaded = datetime.datetime.fromtimestamp(
+                    os.path.getmtime(self.file_path),
+                )
+                return True
+        except Timeout:
+            logger.debug(
+                f"acquiring {self._file_lock_path} timed out, skipping saving..."
+            )
+        return False
+
+    def _save_if_should(self) -> bool:
+        """Saves file to disk if necessary and returns whether it saved.
+
+        Uses self._should_save to decide whether to save.
+        """
+        if self._should_save():
+            return self._save()
+        return False
+
+    def _load_if_should(self) -> bool:
+        """Load file to disk if necessary and returns whether it loaded.
+
+        Uses self._should_load to decide whether to load.
+        """
+        if self._should_load():
+            return self._load()
+        return False
+
+    def _should_save(self) -> bool:
+        """Decide whether we should save.
+
+        This is a simple random number generator to randomize writes across processes
+        that are possibly saving the same values in this cache.
+        """
+        return random.randint(0, 9) == 1
+
+    def _should_load(self) -> bool:
+        """Decide whether we should load.
+
+        We should load if the file on disk has changed since we have last read it.
+        """
+        if os.path.exists(self.file_path) and os.path.isfile(self.file_path):
+            if self.last_loaded is None:
+                return True
+            return (
+                datetime.datetime.fromtimestamp(
+                    os.path.getmtime(self.file_path),
+                )
+                >= self.last_loaded
+            )
+        return False
+
+    def __del__(self) -> None:
+        self._save()
+
+    def clear_expired_entries(self) -> None:
+        super().clear_expired_entries()
+        self._save_if_should()
+
+    # Custom pickling implementation
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        del state["_lock"]
+        del state["_file_lock"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = Lock()
+        self._file_lock = FileLock(self._file_lock_path, timeout=self.file_timeout)

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -315,7 +315,7 @@ class SFDictFileCache(SFDictCache):
         entry_lifetime: int = constants.DAY_IN_SECONDS,
         file_timeout: int = 0,
     ) -> None:
-        """Inits an SFDictFileCache with path, lifetime and .
+        """Inits an SFDictFileCache with path, lifetime.
 
         File path can be a dictionary that contains different paths for different OSes,
         possible keys are: 'darwin', 'linux' and 'windows'. If a current platform

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -63,7 +63,7 @@ class SFDictCache(Generic[K, V]):
             cache[k] = v
         return cache
 
-    def __getitem(
+    def _getitem(
         self,
         k: K,
         *,
@@ -81,13 +81,13 @@ class SFDictCache(Generic[K, V]):
             raise
         if is_expired(t):
             self._expiration(k)
-            self.__delitem(k)
+            self._delitem(k)
             raise KeyError
         if should_record_hits:
             self._hit(k)
         return v
 
-    def __setitem(
+    def _setitem(
         self,
         k: K,
         v: V,
@@ -109,7 +109,7 @@ class SFDictCache(Generic[K, V]):
     ) -> V:
         """Returns an element if it hasn't expired yet in a thread-safe way."""
         with self._lock:
-            return self.__getitem(k, should_record_hits=True)
+            return self._getitem(k, should_record_hits=True)
 
     def __setitem__(
         self,
@@ -118,7 +118,7 @@ class SFDictCache(Generic[K, V]):
     ) -> None:
         """Inserts an element in a thread-safe way."""
         with self._lock:
-            self.__setitem(k, v)
+            self._setitem(k, v)
 
     def __iter__(self) -> Iterator[K]:
         return iter(self.keys())
@@ -132,8 +132,8 @@ class SFDictCache(Generic[K, V]):
             for k in list(self._cache.keys()):
                 try:
                     # TODO: this function could be further optimized by removing
-                    #  the need here to call __getitem here and call se;f._cache.keys()
-                    v = self.__getitem(k, should_record_hits=False)
+                    #  the need here to call _getitem here and call self._cache.keys()
+                    v = self._getitem(k, should_record_hits=False)
                     values.append((k, v))
                 except KeyError:
                     continue
@@ -157,7 +157,7 @@ class SFDictCache(Generic[K, V]):
             self._cache.clear()
             self._reset_telemetry()
 
-    def __delitem(
+    def _delitem(
         self,
         key: K,
     ) -> None:
@@ -174,7 +174,7 @@ class SFDictCache(Generic[K, V]):
         key: K,
     ) -> None:
         with self._lock:
-            self.__delitem(key)
+            self._delitem(key)
 
     def __contains__(
         self,
@@ -182,7 +182,7 @@ class SFDictCache(Generic[K, V]):
     ) -> bool:
         with self._lock:
             try:
-                self.__getitem(key, should_record_hits=True)
+                self._getitem(key, should_record_hits=True)
                 return True
             except KeyError:
                 # Fall through
@@ -216,7 +216,7 @@ class SFDictCache(Generic[K, V]):
         with self._lock:
             for k in self._cache.keys():
                 try:
-                    self.__getitem(k, should_record_hits=False)
+                    self._getitem(k, should_record_hits=False)
                 except KeyError:
                     continue
             self.telemetry["size"] = len(self._cache)

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -539,7 +539,11 @@ class SFDictFileCache(SFDictCache):
         return False
 
     def __del__(self) -> None:
-        self._save()
+        try:
+            self._save()
+        except Exception:
+            # At tear-down time builtins module might be already gone, ignore every error
+            pass
 
     def clear_expired_entries(self) -> None:
         super().clear_expired_entries()

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -140,12 +140,11 @@ class SFDictCache(Generic[K, V]):
     def items(self) -> list[tuple[K, V]]:
         with self._lock:
             values: list[tuple[K, V]] = []
-            for k, v in list(self._cache.items()):
-                if is_expired(v.expiry):
-                    self._expiration(k)
-                    self._delitem(k)
-                else:
-                    values.append((k, v.entry))
+            for k in list(self._cache.keys()):
+                try:
+                    values.append((k, self._getitem(k, should_record_hits=False)))
+                except KeyError:
+                    pass
         return values
 
     def values(self) -> list[V]:

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -330,6 +330,10 @@ class SFDictCache(Generic[K, V]):
 
 
 class SFDictFileCache(SFDictCache):
+
+    # This number decides the chance of saving after writing (probability: 1/n+1)
+    MAX_RAND_INT = 9
+
     def __init__(
         self,
         file_path: str | dict[str, str],
@@ -511,7 +515,7 @@ class SFDictFileCache(SFDictCache):
         This is a simple random number generator to randomize writes across processes
         that are possibly saving the same values in this cache.
         """
-        return random.randint(0, 9) == 1
+        return random.randint(0, self.MAX_RAND_INT) == 0
 
     def _should_load(self) -> bool:
         """Decide whether we should load.

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -528,7 +528,7 @@ class SFDictFileCache(SFDictCache):
                 datetime.datetime.fromtimestamp(
                     os.path.getmtime(self.file_path),
                 )
-                >= self.last_loaded
+                > self.last_loaded
             )
         return False
 

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -438,7 +438,7 @@ class SFDictFileCache(SFDictCache):
         try:
             with open(self.file_path, "rb") as r_file:
                 other = pickle.load(r_file)
-            _ = self._update(
+            self._update(
                 other,
                 update_newer_only=True,
             )

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -22,6 +22,7 @@ from typing_extensions import NamedTuple, Self
 from . import constants
 
 now = datetime.datetime.now
+getmtime = os.path.getmtime
 
 T = TypeVar("T")
 
@@ -482,7 +483,7 @@ class SFDictFileCache(SFDictCache):
                 # We write to a tmp file and then move it to have atomic write
                 os.replace(tmp_file_path, self.file_path)
                 self.last_loaded = datetime.datetime.fromtimestamp(
-                    os.path.getmtime(self.file_path),
+                    getmtime(self.file_path),
                 )
                 return True
         except Timeout:
@@ -527,7 +528,7 @@ class SFDictFileCache(SFDictCache):
                 return True
             return (
                 datetime.datetime.fromtimestamp(
-                    os.path.getmtime(self.file_path),
+                    getmtime(self.file_path),
                 )
                 > self.last_loaded
             )

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -68,13 +68,20 @@ from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.connector.time_util import DecorrelateJitterBackoff
 
 from . import constants
-from .cache import SFDictCache
+from .cache import SFDictFileCache
 
-OCSP_CACHE: SFDictCache[
+OCSP_CACHE: SFDictFileCache[
     tuple[bytes, bytes, int, str],
     tuple[Exception | None, Certificate, Certificate, CertId, bytes],
-] = SFDictCache(
+] = SFDictFileCache(
     entry_lifetime=constants.DAY_IN_SECONDS,
+    file_path={
+        "linux": os.path.join("~", ".cache", "snowflake", "ocsp_cache"),
+        "darwin": os.path.join("~", "Library", "Caches", "Snowflake", "ocsp_cache"),
+        "windows": os.path.join(
+            "~", "AppData", "Local", "Snowflake", "Caches", "ocsp_cache"
+        ),
+    },
 )
 
 logger = getLogger(__name__)

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1094,6 +1094,7 @@ def test_connection_cant_be_reused(conn_cnx):
     assert list(cursors[0])
 
 
+@pytest.mark.external
 @pytest.mark.skipolddriver
 def test_ocsp_cache_working(conn_cnx):
     """Verifies that the OCSP cache is functioning.

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -34,7 +34,6 @@ from snowflake.connector.errorcode import (
 )
 from snowflake.connector.errors import Error, ForbiddenError
 from snowflake.connector.network import APPLICATION_SNOWSQL, ReauthenticationRequest
-from snowflake.connector.ocsp_snowflake import OCSP_CACHE
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 
 try:  # pragma: no cover
@@ -1095,11 +1094,14 @@ def test_connection_cant_be_reused(conn_cnx):
     assert list(cursors[0])
 
 
+@pytest.mark.skipolddriver
 def test_ocsp_cache_working(conn_cnx):
     """Verifies that the OCSP cache is functioning.
 
     The only way we can verify this is that the number of hits and misses increase.
     """
+    from snowflake.connector.ocsp_snowflake import OCSP_CACHE
+
     original_count = OCSP_CACHE.telemetry["hit"] + OCSP_CACHE.telemetry["miss"]
     with conn_cnx() as cnx:
         assert cnx

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -34,6 +34,7 @@ from snowflake.connector.errorcode import (
 )
 from snowflake.connector.errors import Error, ForbiddenError
 from snowflake.connector.network import APPLICATION_SNOWSQL, ReauthenticationRequest
+from snowflake.connector.ocsp_snowflake import OCSP_CACHE
 from snowflake.connector.sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 
 try:  # pragma: no cover
@@ -1092,3 +1093,14 @@ def test_connection_cant_be_reused(conn_cnx):
         )
         assert len(cursors[0]._result_set.batches) > 1  # We need to have remote results
     assert list(cursors[0])
+
+
+def test_ocsp_cache_working(conn_cnx):
+    """Verifies that the OCSP cache is functioning.
+
+    The only way we can verify this is that the number of hits and misses increase.
+    """
+    original_count = OCSP_CACHE.telemetry["hit"] + OCSP_CACHE.telemetry["miss"]
+    with conn_cnx() as cnx:
+        assert cnx
+    assert OCSP_CACHE.telemetry["hit"] + OCSP_CACHE.telemetry["miss"] > original_count

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -15,181 +15,167 @@ except ImportError:
 NO_LIFETIME = datetime.timedelta(seconds=0)
 
 
-def test_simple_usage():
-    c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
-    assert 1 in c and 2 in c
-    assert c[1] == "a"
-    assert c[2] == "b"
+class TestSFDictCache:
+    def test_simple_usage(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert 1 in c and 2 in c
+        assert c[1] == "a"
+        assert c[2] == "b"
 
+    def test_expiration(self):
+        c = cache.SFDictCache.from_dict(
+            {"a": 1},
+            entry_lifetime=0,
+        )
+        with pytest.raises(KeyError):
+            c[1]
 
-def test_expiration():
-    c = cache.SFDictCache.from_dict(
-        {"a": 1},
-        entry_lifetime=0,
-    )
-    with pytest.raises(KeyError):
-        c[1]
+    def test_access_empty(self):
+        c = cache.SFDictCache()
+        with pytest.raises(KeyError):
+            c[1]
 
+    # The rest of tests test that SFDictCache acts like a regular dictionary.
 
-def test_access_empty():
-    c = cache.SFDictCache()
-    with pytest.raises(KeyError):
-        c[1]
+    def test_cast_list(self):
+        c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
+        assert list(c) == ["a", "b"]
 
+    def test_access(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        assert c["a"] == 1
+        c._entry_lifetime = NO_LIFETIME
+        c["b"] = 2
+        with pytest.raises(KeyError):
+            c["b"]
 
-# The rest of tests test that SFDictCache acts like a regular dictionary.
+    def test_delete(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        del c["a"]
+        assert len(c.keys()) == 0
 
+    def test_contains(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        assert "a" in c
+        c._entry_lifetime = NO_LIFETIME
+        c["b"] = 2
+        assert "b" not in c
+        assert "c" not in c
 
-def test_cast_list():
-    c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
-    assert list(c) == ["a", "b"]
+    def test_iter(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        counter = 1
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["a"] = 100
+        for e in iter(c):
+            assert e == counter
+            # Make sure that cache can be modified while iterating
+            del c[e]
+            counter += 1
+        assert len(c._cache) == 0
 
+    def test_clear(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert len(c.keys()) == 2
+        c.clear()
+        assert len(c.keys()) == 0
 
-def test_access():
-    c = cache.SFDictCache.from_dict({"a": 1})
-    assert c["a"] == 1
-    c._entry_lifetime = NO_LIFETIME
-    c["b"] = 2
-    with pytest.raises(KeyError):
-        c["b"]
+    def test_get(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert c.get("a", -999) == -999
+        assert c.get(1) == "a"
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.get("d") is None
 
+    def test_items(self):
+        c = cache.SFDictCache()
+        assert c.items() == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.items() == [("a", 1), ("b", 2)]
 
-def test_delete():
-    c = cache.SFDictCache.from_dict({"a": 1})
-    del c["a"]
-    assert len(c.keys()) == 0
+    def test_keys(self):
+        c = cache.SFDictCache()
+        assert list(c.keys()) == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.keys() == ["a", "b"]
 
+    def test_update(self):
+        c = cache.SFDictCache()
+        c.update({"a": 1, "b": 2})
+        c.update(cache.SFDictCache.from_dict({"c": 3}))
+        assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
 
-def test_contains():
-    c = cache.SFDictCache.from_dict({"a": 1})
-    assert "a" in c
-    c._entry_lifetime = NO_LIFETIME
-    c["b"] = 2
-    assert "b" not in c
-    assert "c" not in c
+    def test_values(self):
+        c = cache.SFDictCache()
+        assert c.values() == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.values() == [1, 2]
 
-
-def test_iter():
-    c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
-    counter = 1
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["a"] = 100
-    for e in iter(c):
-        assert e == counter
-        # Make sure that cache can be modified while iterating
-        del c[e]
-        counter += 1
-    assert len(c._cache) == 0
-
-
-def test_clear():
-    c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
-    assert len(c.keys()) == 2
-    c.clear()
-    assert len(c.keys()) == 0
-
-
-def test_get():
-    c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
-    assert c.get("a", -999) == -999
-    assert c.get(1) == "a"
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["d"] = 4
-    assert c.get("d") is None
-
-
-def test_items():
-    c = cache.SFDictCache()
-    assert c.items() == []
-    c["a"] = 1
-    c["b"] = 2
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["c"] = 3
-    assert c.items() == [("a", 1), ("b", 2)]
-
-
-def test_keys():
-    c = cache.SFDictCache()
-    assert list(c.keys()) == []
-    c["a"] = 1
-    c["b"] = 2
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["c"] = 3
-    assert c.keys() == ["a", "b"]
-
-
-def test_update():
-    c = cache.SFDictCache()
-    c.update({"a": 1, "b": 2})
-    c.update(cache.SFDictCache.from_dict({"c": 3}))
-    assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["d"] = 4
-    assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
-
-
-def test_values():
-    c = cache.SFDictCache()
-    assert c.values() == []
-    c["a"] = 1
-    c["b"] = 2
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["c"] = 3
-    assert c.values() == [1, 2]
-
-
-def test_telemetry():
-    c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
-    assert c.telemetry == {
-        "hit": 0,
-        "miss": 0,
-        "expiration": 0,
-        "size": 2,
-    }
-    c["a"] = 1
-    assert c.telemetry["hit"] == 0
-    assert c["a"] == 1
-    assert c.telemetry["hit"] == 1
-    with pytest.raises(KeyError):
-        c["c"]
-    assert c.telemetry["miss"] == 1
-    # Make sure that this filters out expired entries
-    c._entry_lifetime = NO_LIFETIME
-    c["c"] = 3
-    with pytest.raises(KeyError):
-        c["c"]
-    assert c.telemetry["expiration"] == 1
-    assert c.get("c") is None
-    assert c.telemetry["miss"] == 2
-    # These functions should not affect any numbers other than expirations
-    c["c"] = 3  # expired
-    assert c.values() == [1, 2]
-    assert c.keys() == ["a", "b"]
-    assert c.items() == [("a", 1), ("b", 2)]
-    assert c.telemetry == {
-        "hit": 1,
-        "miss": 2,
-        "expiration": 2,
-        "size": 2,
-    }
-    assert "b" in c
-    c.clear()
-    assert c.telemetry == {
-        "hit": 0,
-        "miss": 0,
-        "expiration": 0,
-        "size": 0,
-    }
-    c.update({"a": 1, "b": 2})
-    assert c.telemetry == {
-        "hit": 0,
-        "miss": 0,
-        "expiration": 0,
-        "size": 2,
-    }
+    def test_telemetry(self):
+        c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }
+        c["a"] = 1
+        assert c.telemetry["hit"] == 0
+        assert c["a"] == 1
+        assert c.telemetry["hit"] == 1
+        with pytest.raises(KeyError):
+            c["c"]
+        assert c.telemetry["miss"] == 1
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        with pytest.raises(KeyError):
+            c["c"]
+        assert c.telemetry["expiration"] == 1
+        assert c.get("c") is None
+        assert c.telemetry["miss"] == 2
+        # These functions should not affect any numbers other than expirations
+        c["c"] = 3  # expired
+        assert c.values() == [1, 2]
+        assert c.keys() == ["a", "b"]
+        assert c.items() == [("a", 1), ("b", 2)]
+        assert c.telemetry == {
+            "hit": 1,
+            "miss": 2,
+            "expiration": 2,
+            "size": 2,
+        }
+        assert "b" in c
+        c.clear()
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 0,
+        }
+        c.update({"a": 1, "b": 2})
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -336,3 +336,17 @@ class TestSFDictFileCache:
                     ).file_path
                     == tmp_file
                 )
+        # Test fallback too
+        with mock.patch(
+            "snowflake.connector.cache.platform.system",
+            return_value="BSD",
+        ):
+            assert (
+                cache.SFDictFileCache(
+                    file_path={
+                        "linux": tmp_file,
+                        "windows": non_existent_file,
+                    },
+                ).file_path
+                == tmp_file
+            )

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -192,14 +192,15 @@ class TestSFDictCache:
         }
 
 
-class AlwaysSaveSFDictFileCache(cache.SFDictFileCache):
-    def _should_save(self):
-        return True
+if cache is not None:
 
+    class AlwaysSaveSFDictFileCache(cache.SFDictFileCache):
+        def _should_save(self):
+            return True
 
-class NeverSaveSFDictFileCache(cache.SFDictFileCache):
-    def _should_save(self):
-        return False
+    class NeverSaveSFDictFileCache(cache.SFDictFileCache):
+        def _should_save(self):
+            return False
 
 
 class TestSFDictFileCache:

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -377,3 +377,14 @@ class TestSFDictFileCache:
             match=f"Cache folder is not writeable: '{tmpdir}'",
         ):
             cache.SFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
+
+    def test_clear(self, tmpdir):
+        cache_path = os.path.join(tmpdir, "cache.txt")
+        c = AlwaysSaveSFDictFileCache(file_path=cache_path)
+        c.clear()
+        assert not c._cache
+        assert os.path.exists(cache_path)
+        # Make sure not existing cache file doesn't raise Exception during cache
+        os.unlink(cache_path)
+        c["a"] = 1
+        assert os.path.exists(cache_path)

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -126,13 +126,27 @@ class TestSFDictCache:
 
     def test_update(self):
         c = cache.SFDictCache()
-        c.update({"a": 1, "b": 2})
-        c.update(cache.SFDictCache.from_dict({"c": 3}))
+        c.update({"a": 1})
+        other = cache.SFDictCache.from_dict({"b": 2, "c": 3})
+        c["b"] = 4
+        c.update(other)
         assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
         # Make sure that this filters out expired entries
         c._entry_lifetime = NO_LIFETIME
         c["d"] = 4
         assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
+
+    def test_update_newer(self):
+        c = cache.SFDictCache()
+        c.update({"a": 1})
+        other = cache.SFDictCache.from_dict({"a": 2, "b": 4, "c": 2})
+        c["b"] = 2
+        c.update_newer(other)
+        assert c.items() == [("a", 2), ("b", 2), ("c", 2)]
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.items() == [("a", 2), ("b", 2), ("c", 2)]
 
     def test_values(self):
         c = cache.SFDictCache()

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -6,9 +6,12 @@ import datetime
 import logging
 import os.path
 import pickle
+import stat
 from unittest import mock
 
 import pytest
+
+from snowflake.connector.compat import IS_WINDOWS
 
 try:
     import snowflake.connector.cache as cache
@@ -350,3 +353,10 @@ class TestSFDictFileCache:
                 ).file_path
                 == tmp_file
             )
+
+    def test_read_only(self, tmpdir):
+        if IS_WINDOWS:
+            pytest.skip("chmod does not work on Windows")
+        os.chmod(tmpdir, stat.S_IRUSR | stat.S_IXUSR)
+        with pytest.raises(PermissionError):
+            cache.SFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -7,6 +7,7 @@ import logging
 import os.path
 import pickle
 import stat
+from time import sleep
 from unittest import mock
 
 import pytest
@@ -139,7 +140,9 @@ class TestSFDictCache:
     def test_update_newer(self):
         c = cache.SFDictCache()
         c.update({"a": 1})
+        sleep(0.01)
         other = cache.SFDictCache.from_dict({"a": 2, "b": 4, "c": 2})
+        sleep(0.01)
         c["b"] = 2
         c.update_newer(other)
         assert c.items() == [("a", 2), ("b", 2), ("c", 2)]
@@ -269,6 +272,7 @@ class TestSFDictFileCache:
             {"a": 1, "b": 2}, file_path=os.path.join(tmpdir, "c.txt")
         )
         c2 = pickle.loads(pickle.dumps(c))
+        sleep(0.01)
         c2["c"] = 3
         assert c["c"] == 3
 
@@ -280,6 +284,7 @@ class TestSFDictFileCache:
         c2 = pickle.loads(pickle.dumps(c))
         c2._entry_lifetime = NO_LIFETIME
         c2["c"] = 3
+        sleep(0.01)
         c["c"] = 3
         assert c2["c"] == 3
 

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -372,5 +372,8 @@ class TestSFDictFileCache:
         if IS_WINDOWS:
             pytest.skip("chmod does not work on Windows")
         os.chmod(tmpdir, stat.S_IRUSR | stat.S_IXUSR)
-        with pytest.raises(PermissionError):
+        with pytest.raises(
+            PermissionError,
+            match=f"Cache folder is not writeable: '{tmpdir}'",
+        ):
             cache.SFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -17,13 +17,13 @@ from unittest import mock
 import pytest
 
 from snowflake.connector import OperationalError
-from snowflake.connector.cache import SFDictFileCache
 from snowflake.connector.errors import RevocationCheckError
 from snowflake.connector.ocsp_asn1crypto import SnowflakeOCSPAsn1Crypto as SFOCSP
 from snowflake.connector.ocsp_snowflake import OCSPCache, OCSPServer, SnowflakeOCSP
 from snowflake.connector.ssl_wrap_socket import _openssl_connect
 
 try:
+    from snowflake.connector.cache import SFDictFileCache
     from snowflake.connector.errorcode import (
         ER_OCSP_RESPONSE_CERT_STATUS_REVOKED,
         ER_OCSP_RESPONSE_FETCH_FAILURE,

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -12,10 +12,12 @@ import os
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from os import environ, path
+from unittest import mock
 
 import pytest
 
 from snowflake.connector import OperationalError
+from snowflake.connector.cache import SFDictFileCache
 from snowflake.connector.errors import RevocationCheckError
 from snowflake.connector.ocsp_asn1crypto import SnowflakeOCSPAsn1Crypto as SFOCSP
 from snowflake.connector.ocsp_snowflake import OCSPCache, OCSPServer, SnowflakeOCSP
@@ -27,6 +29,19 @@ try:
         ER_OCSP_RESPONSE_FETCH_FAILURE,
     )
     from snowflake.connector.ocsp_snowflake import OCSP_CACHE
+
+    @pytest.fixture(autouse=True)
+    def overwrite_ocsp_cache(tmpdir):
+        """This fixture swaps out the actual OCSP cache for a temprary one."""
+        if OCSP_CACHE is not None:
+            tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
+            with mock.patch(
+                "snowflake.connector.ocsp_snowflake.OCSP_CACHE",
+                SFDictFileCache(file_path=tmp_cache_file),
+            ):
+                yield
+            os.unlink(tmp_cache_file)
+
 except ImportError:
     ER_OCSP_RESPONSE_CERT_STATUS_REVOKED = None
     ER_OCSP_RESPONSE_FETCH_FAILURE = None
@@ -46,11 +61,6 @@ TARGET_HOSTS = [
 ]
 
 THIS_DIR = path.dirname(path.realpath(__file__))
-
-
-@pytest.fixture(autouse=True)
-def reset_ocsp_cache():
-    OCSP_CACHE.clear()
 
 
 def test_ocsp():


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-611961

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I add an extension of #1195 that adds file caching on top of in-memory caches.
   
   ## On disk save strategy:
   On every write to the in-memory cache (`__setitem__`, `update`) we generate a random number 0-9 and if it's 1 then we save to disk. This is done so if multi-processing starts multiple connectors with no cache available we distribute their writes randomly. The only other time we try to save is during tear-down.
   One caveat of save is that we try to acquire the [file-lock](https://py-filelock.readthedocs.io/en/latest/api.html#filelock.FileLock) (which is required to be able to write to the cache file) in a non-blocking manner and if we don't succeed we log this and give up. So if a rogue process held the file lock forever then no file caching would be done.
   However; after taking a look at how `filelock` is implemented this is unlikely to happen. It uses OS APIs to lock file parts to file descriptors, so if a connector held the file lock and it was SIGABORTED out of existence the OS would still clean up the open file descriptors and release those file parts. So someone would really have to hold the filelock maliciously for file caching to not work at all.
   I think this is acceptable for caches.
   
   ## On disk load strategy:
   On every miss and expiration we check whether the cache file has been modified since we last loaded it. If yes, then we load and try to turn that frown upside down!