### PR TITLE
SNOW-532972 fix upload size behavior

### DIFF
--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -167,6 +167,8 @@ class SnowflakeStorageClient(ABC):
             self.encryption_metadata = SnowflakeEncryptionUtil.encrypt_stream(
                 meta.encryption_material, src_stream, encrypted_stream
             )
+            # Reset streams
+            encrypted_stream.seek(0)
             src_stream.seek(0)
             meta.upload_size = src_stream.seek(0, os.SEEK_END)
             src_stream.seek(0)

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -159,7 +159,7 @@ class SnowflakeStorageClient(ABC):
                 meta.real_src_file_name,
                 tmp_dir=self.tmp_dir,
             )
-            meta.upload_size = os.path.getsize(self.data_file)
+            meta.upload_size = os.path.getsize(meta.real_src_file_name)
         else:
             encrypted_stream = BytesIO()
             src_stream = meta.src_stream or meta.intermediate_stream
@@ -168,8 +168,8 @@ class SnowflakeStorageClient(ABC):
                 meta.encryption_material, src_stream, encrypted_stream
             )
             src_stream.seek(0)
-            meta.upload_size = encrypted_stream.seek(0, os.SEEK_END)
-            encrypted_stream.seek(0)
+            meta.upload_size = src_stream.seek(0, os.SEEK_END)
+            src_stream.seek(0)
             if meta.src_stream is not None:
                 meta.src_stream.close()
             meta.src_stream = encrypted_stream

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -696,6 +696,7 @@ def test_put_empty_file(tmp_path, conn_cnx):
             ]
 
 
+@pytest.mark.skipolddriver
 def test_put_empty_stream(conn_cnx):
     """This test makes sure that putting an empty stream outputs 0 as size."""
     tmp_stage = random_string(5, "test_put_empty_stream_")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-532972

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  	As part of the [SDKless rewrite](https://github.com/snowflakedb/snowflake-connector-python/pull/725) it seems like we uninstentionally changed behavior of uploading files. Unless you create an external unencrypted stage we always encrypt a file that the client uploads and before rewrite [it used to be that upload size was set to the file before encryption](https://github.com/snowflakedb/snowflake-connector-python/blob/498e84c974a74072f899e6e5416a0317fee9d2f7/src/snowflake/connector/file_transfer_agent.py#L629), but in the rewrite we changed it so that the upload size was the true upload size. Encrypted files are 16B padded, [source](https://github.com/snowflakedb/snowflake-connector-python/blob/498e84c974a74072f899e6e5416a0317fee9d2f7/src/snowflake/connector/encryption_util.py#L108).
  	This is why in this ticket the empty file's size became 16B instead of 0.
