### PR TITLE
SNOW-644849: Add telemetry about imported pacakages at runtime

### DIFF
--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 apilevel = "2.0"
 threadsafety = 2
 paramstyle = "pyformat"
-log_imported_packages_in_telemetry = True
 
 import logging
 from logging import NullHandler
@@ -91,5 +90,4 @@ __all__ = [
     "ROWID",
     # Extended data type (experimental)
     "Json",
-    "log_imported_packages_in_telemetry",
 ]

--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 apilevel = "2.0"
 threadsafety = 2
 paramstyle = "pyformat"
+log_imported_packages_in_telemetry = True
 
 import logging
 from logging import NullHandler
@@ -90,4 +91,5 @@ __all__ = [
     "ROWID",
     # Extended data type (experimental)
     "Json",
+    "log_imported_packages_in_telemetry",
 ]

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -83,7 +83,12 @@ from .network import (
     SnowflakeRestful,
 )
 from .sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS, SQLSTATE_FEATURE_NOT_SUPPORTED
-from .telemetry import TelemetryClient, TelemetryData, TelemetryField
+from .telemetry import (
+    TelemetryClient,
+    TelemetryData,
+    TelemetryField,
+    generate_telemetry_data,
+)
 from .telemetry_oob import TelemetryService
 from .time_util import HeartBeatTimer, get_time_millis
 from .util_text import construct_hostname, parse_account, split_statements
@@ -1565,12 +1570,18 @@ class SnowflakeConnection:
                 for k in sys.modules.keys()
                 if not k.startswith("_")
             }
-            obj = {
-                TelemetryField.KEY_TYPE.value: TelemetryField.IMPORTED_PACKAGES.value,
-                TelemetryField.KEY_SOURCE.value: self.application
-                if self.application
-                else CLIENT_NAME,
-                "value": str(imported_modules),
-            }
             ts = get_time_millis()
-            self._log_telemetry(TelemetryData(obj, ts))
+            self._log_telemetry(
+                TelemetryData(
+                    generate_telemetry_data(
+                        from_dict={
+                            TelemetryField.KEY_TYPE.value: TelemetryField.IMPORTED_PACKAGES.value,
+                            TelemetryField.KEY_SOURCE.value: self.application
+                            if self.application
+                            else CLIENT_NAME,
+                            TelemetryField.KEY_VALUE.value: str(imported_modules),
+                        }
+                    ),
+                    ts,
+                )
+            )

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -965,11 +965,6 @@ class SnowflakeConnection:
             )
             self._use_openssl_only = os.environ["SF_USE_OPENSSL_ONLY"] == "True"
 
-        if "log_imported_packages_in_telemetry" in kwargs:
-            self._log_imported_packages_in_telemetry = kwargs[
-                "log_imported_packages_in_telemetry"
-            ]
-
     def cmd_query(
         self,
         sql: str,

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1566,8 +1566,8 @@ class SnowflakeConnection:
                 if not k.startswith("_")
             }
             obj = {
-                TelemetryField.KEY_TYPE: TelemetryField.IMPORTED_PACKAGES.value,
-                TelemetryField.KEY_SOURCE: self.application
+                TelemetryField.KEY_TYPE.value: TelemetryField.IMPORTED_PACKAGES.value,
+                TelemetryField.KEY_SOURCE.value: self.application
                 if self.application
                 else CLIENT_NAME,
                 "value": str(imported_modules),

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -198,8 +198,8 @@ DEFAULT_CONFIGURATION: dict[str, tuple[Any, type | tuple[type, ...]]] = {
         (type(None), str),
     ),  # Path to connection diag whitelist json
     "log_imported_packages_in_telemetry": (
-        None,
-        (type(None), bool),
+        True,
+        bool,
     ),  # Whether to log imported packages in telemetry
 }
 
@@ -965,12 +965,10 @@ class SnowflakeConnection:
             )
             self._use_openssl_only = os.environ["SF_USE_OPENSSL_ONLY"] == "True"
 
-        if self._log_imported_packages_in_telemetry is None:
-            import snowflake.connector
-
-            self._log_imported_packages_in_telemetry = (
-                snowflake.connector.log_imported_packages_in_telemetry
-            )
+        if "log_imported_packages_in_telemetry" in kwargs:
+            self._log_imported_packages_in_telemetry = kwargs[
+                "log_imported_packages_in_telemetry"
+            ]
 
     def cmd_query(
         self,

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -83,7 +83,7 @@ from .network import (
     SnowflakeRestful,
 )
 from .sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS, SQLSTATE_FEATURE_NOT_SUPPORTED
-from .telemetry import TelemetryClient
+from .telemetry import TelemetryClient, TelemetryData, TelemetryField
 from .telemetry_oob import TelemetryService
 from .time_util import HeartBeatTimer, get_time_millis
 from .util_text import construct_hostname, parse_account, split_statements
@@ -192,6 +192,10 @@ DEFAULT_CONFIGURATION: dict[str, tuple[Any, type | tuple[type, ...]]] = {
         None,
         (type(None), str),
     ),  # Path to connection diag whitelist json
+    "log_imported_packages_in_telemetry": (
+        None,
+        (type(None), bool),
+    ),  # Whether to log imported packages in telemetry
 }
 
 APPLICATION_RE = re.compile(r"[\w\d_]+")
@@ -291,6 +295,9 @@ class SnowflakeConnection:
         self.__set_error_attributes()
         self.connect(**kwargs)
         self._telemetry = TelemetryClient(self._rest)
+
+        # get the imported modules from sys.modules
+        self._log_telemetry_imported_packages()
 
     def __del__(self):  # pragma: no cover
         try:
@@ -953,6 +960,13 @@ class SnowflakeConnection:
             )
             self._use_openssl_only = os.environ["SF_USE_OPENSSL_ONLY"] == "True"
 
+        if self._log_imported_packages_in_telemetry is None:
+            import snowflake.connector
+
+            self._log_imported_packages_in_telemetry = (
+                snowflake.connector.log_imported_packages_in_telemetry
+            )
+
     def cmd_query(
         self,
         sql: str,
@@ -1541,3 +1555,22 @@ class SnowflakeConnection:
             not self.is_still_running(self.get_query_status(q)) for q in queries
         )
         return all(finished_async_queries)
+
+    def _log_telemetry_imported_packages(self) -> None:
+        if self._log_imported_packages_in_telemetry:
+            # filter out duplicates caused by submodules
+            # and internal modules with names starting with an underscore
+            imported_modules = {
+                k.split(".", maxsplit=1)[0]
+                for k in sys.modules.keys()
+                if not k.startswith("_")
+            }
+            obj = {
+                TelemetryField.KEY_TYPE: TelemetryField.IMPORTED_PACKAGES.value,
+                TelemetryField.KEY_SOURCE: self.application
+                if self.application
+                else CLIENT_NAME,
+                "value": str(imported_modules),
+            }
+            ts = get_time_millis()
+            self._log_telemetry(TelemetryData(obj, ts))

--- a/src/snowflake/connector/telemetry.py
+++ b/src/snowflake/connector/telemetry.py
@@ -36,6 +36,8 @@ class TelemetryField(Enum):
     # fetch_arrow_* usage
     ARROW_FETCH_ALL = "client_fetch_arrow_all"
     ARROW_FETCH_BATCHES = "client_fetch_arrow_batches"
+    # imported packages along with client
+    IMPORTED_PACKAGES = "client_imported_packages"
     # Keys for telemetry data sent through either in-band or out-of-band telemetry
     KEY_TYPE = "type"
     KEY_SOURCE = "source"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-644849

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [x] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We would like to know what packages are imported at Python runtime along with connector, which can help us understand the user scenarios of python connector. The message will looks like this:
```
{
  "source": "PythonSnowpark",
  "type": "client_imported_packages",
  "value": "{'pdb', 'bz2', 'abc', 'ssl', 'faulthandler', 'fnmatch', 'pytest', 'shlex', 'fractions', 'enum', 'queue', 'certifi', 'traceback', 'pprint', 'pwd', 'pickle', 'ast', 'uu', 'pkg_resources', 'codecs', 'gc', 'hmac', 'copy', 'errno', 'copyreg', 'subprocess', 'snowflake', 'weakref', 'decimal', 'logging', 'dataclasses', 'typing', 'numpy', 'pytest_forked', 'ipaddress', 'operator', 'signal', 'cmd', 'email', 'gettext', 'datetime', 'importlib', 'functools', 'base64', 'calendar', 'configparser', 'codeop', 'tempfile', 'cryptography', 'distutils', 'dis', 'contextvars', 'linecache', 'uuid', 'contextlib', 'posixpath', 'unittest', 'Cryptodome', 'selectors', 'iniconfig', 'binascii', 'locale', 'grp', 'select', 'encodings', 'posix', 'plistlib', 'sre_compile', 'platform', 'pycparser', 'ntpath', 'time', 'itertools', 'textwrap', 'csv', 'zlib', 'unicodedata', 'token', 'sys', 'struct', 'reprlib', 'keyword', 'charset_normalizer', 'sysconfig', 'cffi', 'attr', 'socket', 'pyexpat', 'numbers', 'jwt', 'teamcity', 'pathlib', 'random', 'opcode', 'py', 'json', 'threading', 'zipfile', 'ctypes', 'math', 'code', 'gzip', 'marshal', 'collections', 'genericpath', 'os', 'mimetypes', 'pytz', 'xml', 'concurrent', 'bdb', 'string', 'difflib', 'argparse', 'quopri', 'http', 'inspect', 'warnings', 'pluggy', 'hashlib', 'urllib', 'zipimport', 'OpenSSL', 'bisect', 'site', 'glob', 'stat', 'html', 'multiprocessing', 'atexit', 'io', 'secrets', 'sre_constants', 'lzma', 'heapq', 'tokenize', 'pkgutil', 'sre_parse', 'shutil', 'tomli', 'webbrowser', 'asyncio', 'asn1crypto', 'stringprep', 'test', 're', 'builtins', 'cython_runtime', 'types', 'array'}"
}
```