### PR TITLE
SNOW-651560: Fix the metadata issue when `extTypeName` from the returned json result is empty

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -132,7 +132,7 @@ class ResultMetadata(NamedTuple):
             col["name"],
             FIELD_NAME_TO_ID[
                 col["extTypeName"].upper()
-                if "extTypeName" in col
+                if col.get("extTypeName")
                 else col["type"].upper()
             ],
             None,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-651560

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `extTypeName` can exist in the  returned json result but it can be empty when it's returned from table stored proc. See the jira for more details and the code path. After it's merged, I will update the SP connector as well. 
