### PR TITLE
Allow cryptography up to v38

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find_namespace:
 install_requires =
     asn1crypto>0.24.0,<2.0.0
     cffi>=1.9,<2.0.0
-    cryptography>=3.1.0,<37.0.0
+    cryptography>=3.1.0,<39.0.0
     oscrypto<2.0.0
     pyOpenSSL>=16.2.0,<23.0.0
     pycryptodomex!=3.5.0,>=3.2,<4.0.0


### PR DESCRIPTION
1. Fixes #1118

2. Update dependency requirement for cryptography only.

3. Allows cryptography up to v38 so that other third party packages will not conflict when installing.
