### PR TITLE
SNOW-460809 Attempt to add INFO level logging message regarding first chunk rowcount

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -850,6 +850,11 @@ class SnowflakeCursor:
             self, self._query_result_format, data, self._description
         )
 
+        if not (is_dml or self.is_file_transfer):
+            logger.info(
+                "Number of results in first chunk: %s", result_chunks[0].rowcount
+            )
+
         self._result_set = ResultSet(
             self,
             result_chunks,


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-460809 Improve logging to log explicit how many rows were embedded in the Snowflake query response](https://snowflakecomputing.atlassian.net/browse/SNOW-460809)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Added `INFO` level logging message in `_init_result_and_meta` to retrieve the first chunk's rowcount if the query was not `is_dml` or `is_file_transfer`