### PR TITLE
SNOW-364424: Exposed to_parquet kwargs parameter in write_pandas

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -54,6 +54,7 @@ def write_pandas(
     create_temp_table: bool = False,
     overwrite: bool = False,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
+    **kwargs,
 ) -> tuple[
     bool,
     int,
@@ -184,7 +185,7 @@ def write_pandas(
         for i, chunk in chunk_helper(df, chunk_size):
             chunk_path = os.path.join(tmp_folder, f"file{i}.txt")
             # Dump chunk into parquet file
-            chunk.to_parquet(chunk_path, compression=compression)
+            chunk.to_parquet(chunk_path, compression=compression, **kwargs)
             # Upload parquet file
             upload_sql = (
                 "PUT /* Python:snowflake.connector.pandas_tools.write_pandas() */ "

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -12,7 +12,7 @@ import warnings
 from functools import partial
 from logging import getLogger
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Sequence, TypeVar
 
 from typing_extensions import Literal
 
@@ -54,7 +54,7 @@ def write_pandas(
     create_temp_table: bool = False,
     overwrite: bool = False,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
-    **kwargs,
+    **kwargs: Any,
 ) -> tuple[
     bool,
     int,

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -45,14 +45,12 @@ sf_connector_version_df = LazyVar(
 
 @pytest.mark.parametrize("quote_identifiers", [True, False])
 @pytest.mark.parametrize("auto_create_table", [True, False])
-@pytest.mark.parametrize("index", [True, False])
-@pytest.mark.parametrize("engine", ["auto", "pyarrow"])
+@pytest.mark.parametrize("index", [False])
 def test_write_pandas_with_overwrite(
     conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
     quote_identifiers: bool,
     auto_create_table: bool,
     index: bool,
-    engine: str,
 ):
     """Tests whether overwriting table using a Pandas DataFrame works as expected."""
     random_table_name = random_string(5, "userspoints_")
@@ -93,7 +91,6 @@ def test_write_pandas_with_overwrite(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 overwrite=True,
-                engine=engine,
                 index=index,
             )
             # Write dataframe with 1 row
@@ -104,7 +101,6 @@ def test_write_pandas_with_overwrite(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 overwrite=True,
-                engine=engine,
                 index=index,
             )
             # Check write_pandas output
@@ -124,7 +120,6 @@ def test_write_pandas_with_overwrite(
                     quote_identifiers=quote_identifiers,
                     auto_create_table=auto_create_table,
                     overwrite=True,
-                    engine=engine,
                     index=index,
                 )
                 # Check write_pandas output
@@ -152,8 +147,7 @@ def test_write_pandas_with_overwrite(
 @pytest.mark.parametrize("quote_identifiers", [True, False])
 @pytest.mark.parametrize("auto_create_table", [True, False])
 @pytest.mark.parametrize("create_temp_table", [True, False])
-@pytest.mark.parametrize("index", [True, False])
-@pytest.mark.parametrize("engine", ["auto", "pyarrow"])
+@pytest.mark.parametrize("index", [False])
 def test_write_pandas(
     conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
     db_parameters: dict[str, str],
@@ -163,7 +157,6 @@ def test_write_pandas(
     auto_create_table: bool,
     create_temp_table: bool,
     index: bool,
-    engine: str,
 ):
     num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
 
@@ -199,7 +192,6 @@ def test_write_pandas(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 create_temp_table=create_temp_table,
-                engine=engine,
                 index=index,
             )
 

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -45,10 +45,14 @@ sf_connector_version_df = LazyVar(
 
 @pytest.mark.parametrize("quote_identifiers", [True, False])
 @pytest.mark.parametrize("auto_create_table", [True, False])
+@pytest.mark.parametrize("index", [True, False])
+@pytest.mark.parametrize("engine", ["auto", "pyarrow"])
 def test_write_pandas_with_overwrite(
     conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
     quote_identifiers: bool,
     auto_create_table: bool,
+    index: bool,
+    engine: str,
 ):
     """Tests whether overwriting table using a Pandas DataFrame works as expected."""
     random_table_name = random_string(5, "userspoints_")
@@ -89,6 +93,8 @@ def test_write_pandas_with_overwrite(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 overwrite=True,
+                engine=engine,
+                index=index,
             )
             # Write dataframe with 1 row
             success, nchunks, nrows, _ = write_pandas(
@@ -98,6 +104,8 @@ def test_write_pandas_with_overwrite(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 overwrite=True,
+                engine=engine,
+                index=index,
             )
             # Check write_pandas output
             assert success
@@ -116,6 +124,8 @@ def test_write_pandas_with_overwrite(
                     quote_identifiers=quote_identifiers,
                     auto_create_table=auto_create_table,
                     overwrite=True,
+                    engine=engine,
+                    index=index,
                 )
                 # Check write_pandas output
                 assert success
@@ -142,6 +152,8 @@ def test_write_pandas_with_overwrite(
 @pytest.mark.parametrize("quote_identifiers", [True, False])
 @pytest.mark.parametrize("auto_create_table", [True, False])
 @pytest.mark.parametrize("create_temp_table", [True, False])
+@pytest.mark.parametrize("index", [True, False])
+@pytest.mark.parametrize("engine", ["auto", "pyarrow"])
 def test_write_pandas(
     conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
     db_parameters: dict[str, str],
@@ -150,6 +162,8 @@ def test_write_pandas(
     quote_identifiers: bool,
     auto_create_table: bool,
     create_temp_table: bool,
+    index: bool,
+    engine: str,
 ):
     num_of_chunks = math.ceil(len(sf_connector_version_data) / chunk_size)
 
@@ -185,6 +199,8 @@ def test_write_pandas(
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
                 create_temp_table=create_temp_table,
+                engine=engine,
+                index=index,
             )
 
             if num_of_chunks == 1:


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-364424: Support for providing kwargs to to_parquet when using write_pandas](https://snowflakecomputing.atlassian.net/browse/SNOW-364424)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
        - It's a small 2 line change. The use of `**kwargs` in the `df.to_parquet` function seems very niche so if we could get some idea of how the customer uses the functionality, I could write a test for it. Just as a sanity check, does the user just want access to the non-exposed parameters of `to_parquet` (including `engine`, `index`, `partition_cols`, `storage_options`), or actually `**kwargs`?
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

4. Please describe how your code solves the related issue.

   Added `**kwargs` to `write_pandas` arguments and passed the parameter to the `to_parquet` call in the function.
