### PR TITLE
Make file_transfer_agent and pkg_resources imports lazy

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -58,7 +58,6 @@ from .errors import (
     NotSupportedError,
     ProgrammingError,
 )
-from .file_transfer_agent import SnowflakeFileTransferAgent
 from .options import installed_pandas, pandas
 from .sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 from .telemetry import TelemetryData, TelemetryField
@@ -742,6 +741,8 @@ class SnowflakeCursor:
 
             logger.debug("PUT OR GET: %s", self.is_file_transfer)
             if self.is_file_transfer:
+                from .file_transfer_agent import SnowflakeFileTransferAgent
+
                 # Decide whether to use the old, or new code path
                 sf_file_transfer_agent = SnowflakeFileTransferAgent(
                     self,

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -8,11 +8,13 @@ import importlib
 import warnings
 from logging import getLogger
 from types import ModuleType
-from typing import Union
-
-import pkg_resources
+from typing import TYPE_CHECKING, Union
 
 from . import errors
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pkg_resources
+
 
 logger = getLogger(__name__)
 
@@ -77,6 +79,9 @@ def _import_or_missing_pandas_option() -> tuple[
         from pandas import DataFrame  # NOQA
 
         pyarrow = importlib.import_module("pyarrow")
+
+        import pkg_resources
+
         # Check whether we have the currently supported pyarrow installed
         installed_packages = pkg_resources.working_set.by_key
         if all(


### PR DESCRIPTION
Fixes #1253

I noticed that two modules take up a significant portion of import time but aren't necessary for many use cases. For instance `pkg_resources` doesn't have to be imported if pandas isn't used. Similarly `file_transfer_agent` isn't going to be used if only executing get requests. 

Moving these imports from the top level to the function they are used in can improve import time from:
```console
$ hyperfine 'python -c "import snowflake.connector"'
Benchmark 1: python -c "import snowflake.connector"
  Time (mean ± σ):     466.0 ms ±  56.2 ms    [User: 434.9 ms, System: 29.1 ms]
  Range (min … max):   427.6 ms … 616.1 ms    10 runs
```
to:
```console
$ hyperfine 'python -c "import snowflake.connector"'
Benchmark 1: python -c "import snowflake.connector"
  Time (mean ± σ):     255.3 ms ±   4.9 ms    [User: 233.8 ms, System: 21.8 ms]
  Range (min … max):   248.9 ms … 264.9 ms    11 runs
```

This is of course the best case. If pandas is used `pkg_resources` will get imported and no time will be saved there and if file transfer is used the time to import file transfer module will be paid on the first usage instead of the import time.