### PR TITLE
replace union types on cursor results by concrete types

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -51,7 +51,7 @@ from .constants import (
     QueryStatus,
 )
 from .converter import SnowflakeConverter
-from .cursor import LOG_MAX_QUERY_LENGTH, SnowflakeCursor
+from .cursor import LOG_MAX_QUERY_LENGTH, SnowflakeCursor, ListCursor
 from .description import (
     CLIENT_NAME,
     CLIENT_VERSION,
@@ -625,7 +625,7 @@ class SnowflakeConnection:
         self.cursor().execute("ROLLBACK")
 
     def cursor(
-        self, cursor_class: type[SnowflakeCursor] = SnowflakeCursor
+        self, cursor_class: type[SnowflakeCursor] = ListCursor
     ) -> SnowflakeCursor:
         """Creates a cursor object. Each statement will be executed in a new cursor object."""
         logger.debug("cursor")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1263

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency
None of the above

3. Please describe how your code solves the related issue.

   Add a new subclass ListCursor to SnowflakeCursor and make the latter abstract, so that DictCursor returns dicts and ListCursor returns a list instead of a union type