### PR TITLE
SNOW-669945 Bump cryptography version to <39.0.0

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,6 +53,13 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
       - name: Install pip-tools
         run: python -m pip install pip-tools
       - name: Compile setup.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,6 +46,25 @@ jobs:
       - name: Run fix_lint
         run: python -m tox -e fix_lint
 
+  dependency:
+    name: Check dependency
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install tox
+        run: python -m pip install tox tox-external-wheels
+      - name: Run tests
+        run: python -m tox -e dependency
+
   build:
     needs: lint
     strategy:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,25 +46,6 @@ jobs:
       - name: Run fix_lint
         run: python -m tox -e fix_lint
 
-  dependency:
-    name: Check dependency
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-      - name: Install pip-tools
-        run: python -m pip install pip-tools
-      - name: Compile setup.py
-        run: pip-compile setup.py
-
   build:
     needs: lint
     strategy:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Run fix_lint
         run: python -m tox -e fix_lint
 
+  dependency:
+    name: Check dependency
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    steps:
+      - name: Install pip-tools
+        run: python -m pip install pip-tools
+      - name: Compile setup.py
+        run: pip-compile setup.py
+
   build:
     needs: lint
     strategy:

--- a/ci/test_fips.sh
+++ b/ci/test_fips.sh
@@ -11,8 +11,7 @@ CONNECTOR_WHL="$(ls $CONNECTOR_DIR/dist/*cp38*manylinux2014*.whl | sort -r | hea
 python3.8 -m venv fips_env
 source fips_env/bin/activate
 pip install -U setuptools pip
-pip install "${CONNECTOR_WHL}[pandas,secure-local-storage,development]"
-pip install "cryptography<3.3.0" --force-reinstall --no-binary cryptography
+pip install "${CONNECTOR_WHL}[pandas,secure-local-storage,development]" "cryptography<3.3.0" --force-reinstall --no-binary cryptography
 
 echo "!!! Environment description !!!"
 echo "Default installed OpenSSL version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find_namespace:
 install_requires =
     asn1crypto>0.24.0,<2.0.0
     cffi>=1.9,<2.0.0
-    cryptography>=3.1.0,<37.0.0
+    cryptography>=3.1.0,<39.0.0
     oscrypto<2.0.0
     pyOpenSSL>=16.2.0,<23.0.0
     pycryptodomex!=3.5.0,>=3.2,<4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -138,6 +138,15 @@ skip_install = True
 commands = pre-commit run --all-files
            python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
 
+[testenv:dependency]
+description = Check if there is conflicting dependency
+deps =
+    {[testenv]deps}
+    pip-tools
+skip_install = True
+commands = pip-compile setup.py
+depends = py37, py38, py39, py310
+
 [pytest]
 log_level = info
 addopts = -ra --strict-markers


### PR DESCRIPTION
Description

This version bump is to avoid version conflict with pyOpenSSL

Testing

Added a new workflow test to run pip-compile

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1265 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Bumping `cryptography` to `<39.0.0` makes it compatible with `pyOpenSSL` that requires `>=38.0.0`
