### PR TITLE
SNOW-657710 Parallelize async query status check when closing connection

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1462,7 +1462,7 @@ class SnowflakeConnection:
             self._async_sfqids.pop(
                 sf_qid, None
             )  # Prevent KeyError when multiple threads try to remove the same query id
-            self._done_async_sfqids[sf_qid] = sf_qid
+            self._done_async_sfqids[sf_qid] = None
         return status_ret, status_resp
 
     def get_query_status(self, sf_qid: str) -> QueryStatus:
@@ -1544,13 +1544,13 @@ class SnowflakeConnection:
     def _all_async_queries_finished(self) -> bool:
         """Checks whether all async queries started by this Connection have finished executing."""
 
+        if not self._async_sfqids:
+            return True
+
         if sys.version_info >= (3, 8):
             queries = list(reversed(self._async_sfqids.keys()))
         else:
             queries = list(reversed(list(self._async_sfqids.keys())))
-
-        if not queries:
-            return True
 
         num_workers = min(self.client_prefetch_threads, len(queries))
         found_unfinished_query = False

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1544,7 +1544,7 @@ class SnowflakeConnection:
     def _all_async_queries_finished(self) -> bool:
         """Checks whether all async queries started by this Connection have finished executing."""
 
-        queries = reversed(list(self._async_sfqids.keys()))
+        queries = list(reversed(list(self._async_sfqids.keys())))
         if not queries:
             return True
         num_workers = min(self.client_prefetch_threads, len(queries))

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1544,7 +1544,7 @@ class SnowflakeConnection:
     def _all_async_queries_finished(self) -> bool:
         """Checks whether all async queries started by this Connection have finished executing."""
 
-        queries = list(reversed(self._async_sfqids.keys()))
+        queries = reversed(list(self._async_sfqids.keys()))
         if not queries:
             return True
         num_workers = min(self.client_prefetch_threads, len(queries))

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -12,7 +12,6 @@ import sys
 import uuid
 import warnings
 import weakref
-from collections import OrderedDict
 from concurrent.futures.thread import ThreadPoolExecutor
 from difflib import get_close_matches
 from functools import partial
@@ -268,8 +267,8 @@ class SnowflakeConnection:
         self._errorhandler = Error.default_errorhandler
         self._lock_converter = Lock()
         self.messages = []
-        self._async_sfqids = OrderedDict()
-        self._done_async_sfqids = OrderedDict()
+        self._async_sfqids = {}
+        self._done_async_sfqids = {}
         self.telemetry_enabled = False
         self._session_parameters: dict[str, str | int | bool] = {}
         logger.info(
@@ -1545,7 +1544,7 @@ class SnowflakeConnection:
     def _all_async_queries_finished(self) -> bool:
         """Checks whether all async queries started by this Connection have finished executing."""
 
-        queries = list(self._async_sfqids.keys())
+        queries = list(reversed(self._async_sfqids.keys()))
         if not queries:
             return True
         num_workers = min(self.client_prefetch_threads, len(queries))

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -772,7 +772,7 @@ class SnowflakeCursor:
                 self._connection.converter.set_parameter(param, value)
 
             if _exec_async:
-                self.connection._async_sfqids.add(self._sfqid)
+                self.connection._async_sfqids[self._sfqid] = self._sfqid
             if _no_results:
                 self._total_rowcount = (
                     ret["data"]["total"]

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -772,7 +772,7 @@ class SnowflakeCursor:
                 self._connection.converter.set_parameter(param, value)
 
             if _exec_async:
-                self.connection._async_sfqids[self._sfqid] = self._sfqid
+                self.connection._async_sfqids[self._sfqid] = None
             if _no_results:
                 self._total_rowcount = (
                     ret["data"]["total"]

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -226,3 +226,12 @@ def test_not_fetching(conn_cnx):
             cur.execute("select 2")
             assert cur._inner_cursor is None
             assert cur._prefetch_hook is None
+
+
+def test_close_connection_with_running_async_queries(conn_cnx):
+    with conn_cnx() as con:
+        with con.cursor() as cur:
+            cur.execute_async("select count(*) from table(generator(timeLimit => 10))")
+            cur.execute_async("select count(*) from table(generator(timeLimit => 5))")
+        assert not con._all_async_queries_finished()
+    assert len(con._done_async_sfqids) < 2 and con.rest is None

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -235,3 +235,13 @@ def test_close_connection_with_running_async_queries(conn_cnx):
             cur.execute_async("select count(*) from table(generator(timeLimit => 5))")
         assert not con._all_async_queries_finished()
     assert len(con._done_async_sfqids) < 2 and con.rest is None
+
+
+def test_close_connection_with_completed_async_queries(conn_cnx):
+    with conn_cnx() as con:
+        with con.cursor() as cur:
+            cur.execute_async("select 1")
+            cur.execute_async("select 2")
+        time.sleep(5)
+        assert con._all_async_queries_finished()
+    assert len(con._done_async_sfqids) == 2 and con.rest is None


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-657710

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Parallelize the status checks by running all the GET requests in a ThreadPoolExecutor.
