### PR TITLE
SNOW-680774 Check CLIENT_LOG_DIR_PATH_DOCKER for ENABLE_TELEMETRY_LOG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,12 +61,12 @@ repos:
     hooks:
         - id: pyupgrade
           args: [--py37-plus]
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear == 20.11.1
+          - flake8-bugbear
 -   repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/src/snowflake/connector/test_util.py
+++ b/src/snowflake/connector/test_util.py
@@ -11,12 +11,13 @@ import os
 from .compat import IS_LINUX
 
 RUNNING_ON_JENKINS = os.getenv("JENKINS_HOME") is not None
-REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER", "/tmp")
-ENABLE_TELEMETRY_LOG = RUNNING_ON_JENKINS and IS_LINUX
+HAS_REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER") is not None
+ENABLE_TELEMETRY_LOG = RUNNING_ON_JENKINS and HAS_REGRESSION_TEST_LOG_DIR and IS_LINUX
 rt_plain_logger = None
 
 
 if ENABLE_TELEMETRY_LOG:
+    REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER")
     rt_plain_logger = logging.getLogger("regression.test.plain.logger")
     rt_plain_logger.setLevel(logging.DEBUG)
     ch = logging.FileHandler(

--- a/src/snowflake/connector/test_util.py
+++ b/src/snowflake/connector/test_util.py
@@ -11,13 +11,12 @@ import os
 from .compat import IS_LINUX
 
 RUNNING_ON_JENKINS = os.getenv("JENKINS_HOME") is not None
-HAS_REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER") is not None
-ENABLE_TELEMETRY_LOG = RUNNING_ON_JENKINS and HAS_REGRESSION_TEST_LOG_DIR and IS_LINUX
+REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER")
+ENABLE_TELEMETRY_LOG = RUNNING_ON_JENKINS and REGRESSION_TEST_LOG_DIR and IS_LINUX
 rt_plain_logger = None
 
 
 if ENABLE_TELEMETRY_LOG:
-    REGRESSION_TEST_LOG_DIR = os.getenv("CLIENT_LOG_DIR_PATH_DOCKER")
     rt_plain_logger = logging.getLogger("regression.test.plain.logger")
     rt_plain_logger.setLevel(logging.DEBUG)
     ch = logging.FileHandler(


### PR DESCRIPTION
Description

test_util is supposed to only be used by snowflake regression test, but currently it runs for all Jenkins linux hosts, which is not desired. A quick fix is to also check CLIENT_LOG_DIR_PATH_DOCKER, which presumbly is not used by most customers if not all.

Testing

existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
