### PR TITLE
Add Python 3.11 wheels to the CI builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ timestamps {
           'Test Python 38': { build job: 'RT-PyConnector38-PC',parameters: params},
           'Test Python 39': { build job: 'RT-PyConnector39-PC',parameters: params},
           'Test Python 310': { build job: 'RT-PyConnector310-PC',parameters: params},
+          'Test Python 311': { build job: 'RT-PyConnector311-PC',parameters: params},
           'Test Python Lambda 37': { build job: 'RT-PyConnector37-PC-Lambda',parameters: params}
           )
         }

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -3,7 +3,7 @@
 # Build Snowflake Python Connector on Mac
 # NOTES:
 #   - To compile only a specific version(s) pass in versions like: `./build_darwin.sh "3.7 3.8"`
-PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10}"
+PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10 3.11}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="$CONNECTOR_DIR/dist"

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -7,7 +7,7 @@
 set -o pipefail
 
 U_WIDTH=16
-PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10}"
+PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10 3.11}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="${CONNECTOR_DIR}/dist"

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -6,7 +6,7 @@
 SET SCRIPT_DIR=%~dp0
 SET CONNECTOR_DIR=%~dp0\..\
 
-set python_versions= 3.7 3.8 3.9 3.10
+set python_versions= 3.7 3.8 3.9 3.10 3.11
 
 cd %CONNECTOR_DIR%
 

--- a/ci/docker/connector_build/Dockerfile
+++ b/ci/docker/connector_build/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /home/user
 RUN chmod 777 /home/user
 RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout bfc6d8b82d8c37b8ca1e386081fd800e81c6ab4a
 
-ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin"
+ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -5,7 +5,7 @@
 #   - Versions to be tested should be passed in as the first argument, e.g: "3.7 3.8". If omitted 3.7-3.10 will be assumed.
 #   - This script uses .. to download the newest wheel files from S3
 
-PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10}"
+PYTHON_VERSIONS="${1:-3.7 3.8 3.9 3.10 3.11}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 PARAMETERS_DIR="${CONNECTOR_DIR}/.github/workflows/parameters/public"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: SQL
     Topic :: Database
     Topic :: Scientific/Engineering :: Information Analysis

--- a/tested_requirements/requirements_311.reqs
+++ b/tested_requirements/requirements_311.reqs
@@ -1,0 +1,18 @@
+# Generated on: Python 3.10.6
+asn1crypto==1.5.1
+certifi==2022.9.14
+cffi==1.15.1
+charset-normalizer==2.1.1
+cryptography==36.0.2
+filelock==3.8.0
+idna==3.4
+oscrypto==1.3.0
+pycparser==2.21
+pycryptodomex==3.15.0
+PyJWT==2.5.0
+pyOpenSSL==22.0.0
+pytz==2022.2.1
+requests==2.28.1
+typing_extensions==4.3.0
+urllib3==1.26.12
+snowflake-connector-python==2.8.0


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1289 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR adds Python 3.11 to the CI builds. The `pyarrow` [wheels are missing](https://issues.apache.org/jira/browse/ARROW-17487) at the moment, and we'll have to wait until it gets resolved
