### PR TITLE
SNOW-668660: Inefficient file lock for OCSP cache mechanism

### DIFF
--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -14,7 +14,7 @@ import string
 import tempfile
 from collections.abc import Iterator
 from threading import Lock
-from typing import Generic, NoReturn, TypeVar
+from typing import Any, Generic, NoReturn, TypeVar
 
 from filelock import FileLock, Timeout
 from typing_extensions import NamedTuple, Self
@@ -100,11 +100,7 @@ class SFDictCache(Generic[K, V]):
             self._hit(k)
         return v
 
-    def _setitem(
-        self,
-        k: K,
-        v: V,
-    ) -> None:
+    def _setitem(self, k: K, v: V, **kwargs: Any) -> None:
         """Non-locking version of __setitem__.
 
         This should only be used by internal functions when already
@@ -482,9 +478,10 @@ class SFDictFileCache(SFDictCache):
             if currently_holding:
                 self._lock.release()
 
-    def _setitem(self, k: K, v: V) -> None:
+    def _setitem(self, k: K, v: V, *, try_saving_cache: bool = True) -> None:
         super()._setitem(k, v)
-        self._save_if_should()
+        if try_saving_cache:
+            self._save_if_should()
 
     def _load(self) -> bool:
         """Load cache from disk if possible, returns whether it was able to load."""

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -86,7 +86,6 @@ class SFDictCache(Generic[K, V]):
         should_record_hits: bool = True,
     ) -> V:
         """Non-locking version of __getitem__.
-
         This should only be used by internal functions when already
         holding self._lock.
         """
@@ -187,17 +186,27 @@ class SFDictCache(Generic[K, V]):
         with self._lock:
             self._delitem(key)
 
+    def _contains(
+        self,
+        key: K,
+    ) -> bool:
+        """non-locking version of __contains__
+        This should only be used by internal functions when already
+        holding self._lock.
+        """
+        try:
+            self._getitem(key, should_record_hits=True)
+            return True
+        except KeyError:
+            # Fall through
+            return False
+
     def __contains__(
         self,
         key: K,
     ) -> bool:
         with self._lock:
-            try:
-                self._getitem(key, should_record_hits=True)
-                return True
-            except KeyError:
-                # Fall through
-                return False
+            return self._contains(key)
 
     def _update(
         self,
@@ -406,6 +415,34 @@ class SFDictFileCache(SFDictCache):
         self.last_loaded: datetime.datetime | None = None
         if os.path.exists(self.file_path):
             self._load()
+
+    def _getitem(
+        self,
+        k: K,
+        *,
+        should_record_hits: bool = True,
+    ) -> V:
+        """non-locking version of __getitem__
+        This should only be used by internal functions when already
+        holding self._lock.
+        """
+        if k not in self._cache:
+            loaded = self._load_if_should()
+            if (not loaded) or k not in self._cache:
+                self._miss(k)
+                raise KeyError
+        t, v = self._cache[k]
+        if is_expired(t):
+            loaded = self._load_if_should()
+            expire_item = True
+            if loaded:
+                t, v = self._cache[k]
+                expire_item = is_expired(t)
+            if expire_item:
+                # Raises KeyError
+                self._expire(k)
+        self._hit(k)
+        return v
 
     def __getitem__(self, k: K) -> V:
         """Returns an element if it hasn't expired yet in a thread-safe way."""

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -703,7 +703,7 @@ class OCSPCache:
         cache_key: tuple[bytes, bytes, bytes] = kwargs.get(
             "cache_key", ocsp.decode_cert_id_key(cert_id)
         )
-        lock_cache = kwargs.get("lock_cache", True)
+        lock_cache: bool = kwargs.get("lock_cache", True)
         try:
             ocsp_response_validation_result = (
                 OCSP_RESPONSE_VALIDATION_CACHE[cache_key]
@@ -738,7 +738,7 @@ class OCSPCache:
         cache_key: tuple[bytes, bytes, bytes] = kwargs.get(
             "cache_key", ocsp.decode_cert_id_key(cert_id)
         )
-        lock_cache = kwargs.get("lock_cache", True)
+        lock_cache: bool = kwargs.get("lock_cache", True)
         try:
             if lock_cache:
                 del OCSP_RESPONSE_VALIDATION_CACHE[cache_key]
@@ -1602,12 +1602,13 @@ class SnowflakeOCSP:
                             ts=current_time,
                             validated=False,
                         )
-                        OCSPCache.CACHE_UPDATED = True
                     elif found:
                         OCSPCache.delete_cache(
                             self, cert_id, cache_key=cache_key, lock_cache=False
                         )
-                    OCSP_RESPONSE_VALIDATION_CACHE._update(new_cache_dict)
+            if new_cache_dict:
+                OCSP_RESPONSE_VALIDATION_CACHE._update(new_cache_dict)
+                OCSPCache.CACHE_UPDATED = True
         except Exception as ex:
             logger.debug("Caught here - %s", ex)
             ermsg = "Exception raised while decoding OCSP Response Cache {}".format(

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -730,7 +730,7 @@ class OCSPCache:
             OCSPCache.CACHE_UPDATED = True
         except KeyError:
             if subject_name:
-                logger.debug("not hit cache for subject: %s", subject_name)
+                logger.debug(f"cache miss for subject: '{subject_name}'")
         return False, None
 
     @staticmethod

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1587,7 +1587,8 @@ class SnowflakeOCSP:
                     ocsp_response,
                 ) in ocsp_response_cache_json.items():
                     cert_id = self.decode_cert_id_base64(cert_id_base64)
-                    if not self.is_valid_time(cert_id, b64decode(ocsp_response)):
+                    b64decoded_ocsp_response = b64decode(ocsp_response)
+                    if not self.is_valid_time(cert_id, b64decoded_ocsp_response):
                         continue
                     current_time = int(time.time())
                     cache_key: tuple[bytes, bytes, bytes] = self.decode_cert_id_key(
@@ -1598,7 +1599,7 @@ class SnowflakeOCSP:
                     )
                     if OCSPCache.is_cache_fresh(current_time, ts):
                         new_cache_dict[cache_key] = OCSPResponseValidationResult(
-                            ocsp_response=ocsp_response,
+                            ocsp_response=b64decoded_ocsp_response,
                             ts=current_time,
                             validated=False,
                         )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-668660

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [x] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Reduce the number of lock and writing operations when parsing the `ocsp_response_cache.json`.
`ocsp_response_cache.json` contains nearly ~200 items, previously we perform at least 2 times of lock acquisition/release on each item for finding/deleting/updating cache.
This is unnecessary and could be optimized by batching the operations -- we acquire the lock at the beginning, then updating all the entries, then release the lock and write the cache back to file.
