### PR TITLE
SNOW-688750: OCSP test failure in FIPS mode

### DIFF
--- a/ci/test_fips.sh
+++ b/ci/test_fips.sh
@@ -11,13 +11,14 @@ CONNECTOR_WHL="$(ls $CONNECTOR_DIR/dist/*cp38*manylinux2014*.whl | sort -r | hea
 python3.8 -m venv fips_env
 source fips_env/bin/activate
 pip install -U setuptools pip
-pip install "${CONNECTOR_WHL}[pandas,secure-local-storage,development]" "cryptography<3.3.0" --force-reinstall --no-binary cryptography
+pip install "snowflake-connector-python[pandas,secure-local-storage,development]==2.7.9" "cryptography<3.3.0" --force-reinstall --no-binary cryptography
 
 echo "!!! Environment description !!!"
 echo "Default installed OpenSSL version"
 openssl version
 python -c "import ssl; print('Python openssl library: ' + ssl.OPENSSL_VERSION)"
 python -c  "from cryptography.hazmat.backends.openssl import backend;print('Cryptography openssl library: ' + backend.openssl_version_text())"
+python -c  "from cryptography.hazmat.backends import default_backend;print(default_backend())"
 pip freeze
 
 cd $CONNECTOR_DIR

--- a/ci/test_fips.sh
+++ b/ci/test_fips.sh
@@ -11,14 +11,13 @@ CONNECTOR_WHL="$(ls $CONNECTOR_DIR/dist/*cp38*manylinux2014*.whl | sort -r | hea
 python3.8 -m venv fips_env
 source fips_env/bin/activate
 pip install -U setuptools pip
-pip install "snowflake-connector-python[pandas,secure-local-storage,development]==2.7.9" "cryptography<3.3.0" --force-reinstall --no-binary cryptography
+pip install "${CONNECTOR_WHL}[pandas,secure-local-storage,development]"
 
 echo "!!! Environment description !!!"
 echo "Default installed OpenSSL version"
 openssl version
 python -c "import ssl; print('Python openssl library: ' + ssl.OPENSSL_VERSION)"
 python -c  "from cryptography.hazmat.backends.openssl import backend;print('Cryptography openssl library: ' + backend.openssl_version_text())"
-python -c  "from cryptography.hazmat.backends import default_backend;print(default_backend())"
 pip freeze
 
 cd $CONNECTOR_DIR


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-688750

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

hey @sfc-gh-mkeller , is there a reason we pin the cryptography to 3.x. and build in FIPS test? I found unpinning the version could resolve the FIPS issue. If there's no specific reason, then we could unpin it.

however, I'm still not sure about the root cause, maybe it's as you said -- the ocsp responder has changed the hash algorithm, which is not supported by the older version cryptograph.
