### PR TITLE
SNOW-693548 fixing redos attack

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v2.8.2(Unreleased)
 
   - Improved performance of OCSP response caching
+  - Improved performance of regexes used for PUT/GET SQL statement detection
 
 - v2.8.1(October 30,2022)
 

--- a/src/snowflake/connector/_sql_util.py
+++ b/src/snowflake/connector/_sql_util.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import re
+
+from .constants import FileTransferType
+
+COMMENT_START_SQL_RE = re.compile(
+    r"""
+                                  ^\s*(?:
+                                      /\*[\w\W]*?\*/
+                                  )""",
+    re.VERBOSE,
+)
+
+PUT_SQL_RE = re.compile(r"^\s*put", flags=re.IGNORECASE)
+GET_SQL_RE = re.compile(r"^\s*get", flags=re.IGNORECASE)
+
+
+def remove_starting_comments(sql: str) -> str:
+    """Remove all comments from the start of a SQL statement."""
+    commentless_sql = sql
+    while True:
+        start_comment = COMMENT_START_SQL_RE.match(commentless_sql)
+        if start_comment is None:
+            break
+        commentless_sql = commentless_sql[start_comment.end() :]
+    return commentless_sql
+
+
+def get_file_transfer_type(sql: str) -> FileTransferType | None:
+    """Decide whether a SQL is a file transfer and return its type.
+
+    None is returned if the SQL isn't a file transfer so that this function can be
+    used in an if-statement.
+    """
+    commentless_sql = remove_starting_comments(sql)
+    if PUT_SQL_RE.match(commentless_sql):
+        return FileTransferType.PUT
+    elif GET_SQL_RE.match(commentless_sql):
+        return FileTransferType.GET
+
+
+def is_put_statement(sql: str) -> bool:
+    return get_file_transfer_type(sql) == FileTransferType.PUT
+
+
+def is_get_statement(sql: str) -> bool:
+    return get_file_transfer_type(sql) == FileTransferType.GET

--- a/src/snowflake/connector/gcs_storage_client.py
+++ b/src/snowflake/connector/gcs_storage_client.py
@@ -10,6 +10,7 @@ import os
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from ._sql_util import is_put_statement
 from .compat import quote
 from .constants import (
     FILE_PROTOCOL,
@@ -269,9 +270,7 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
             The local file path.
         """
         command = self._command
-        if FILE_PROTOCOL not in self._command or not self._cursor.PUT_SQL_RE.match(
-            command
-        ):
+        if FILE_PROTOCOL not in self._command or not is_put_statement(command):
             return None
 
         file_path_begin_index = command.find(FILE_PROTOCOL)

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -27,9 +27,24 @@ class FakeConnection(SnowflakeConnection):
 @pytest.mark.parametrize(
     "sql,_type",
     (
+        ("", None),
+        ("select 1;", None),
         ("PUT file:///tmp/data/mydata.csv @my_int_stage;", FileTransferType.PUT),
         ("GET @%mytable file:///tmp/data/;", FileTransferType.GET),
-        ("select 1;", None),
+        ("/**/PUT file:///tmp/data/mydata.csv @my_int_stage;", FileTransferType.PUT),
+        ("/**/ GET @%mytable file:///tmp/data/;", FileTransferType.GET),
+        pytest.param(
+            "/**/\n"
+            + "\t/*/get\t*/\t/**/\n" * 10000
+            + "\t*/get @~/test.csv file:///tmp\n",
+            None,
+            id="long_incorrect",
+        ),
+        pytest.param(
+            "/**/\n" + "\t/*/put\t*/\t/**/\n" * 10000 + "put file:///tmp/data.csv @~",
+            FileTransferType.PUT,
+            id="long_correct",
+        ),
     ),
 )
 def test_get_filetransfer_type(sql, _type):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-693548

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This fixes the CVE https://nvd.nist.gov/vuln/detail/CVE-2022-42965
   The issue comes from the greediness of the original regex. With this reworked function we have roughly linear performance. This is achieved by starting from the beginning to lazily strip away comments one-by-one instead of matching the whole SQL command with one regex. The new SQL is also better by matching more than multi-line comments.