### PR TITLE
SNOW-676736: get file results in change of file permissions does not inherit parent folder permission

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v2.8.2(November 18,2022)
 
   - Improved performance of OCSP response caching
+  - Fixed a bug where the permission of the file downloaded via GET is changed
 
 - v2.8.1(October 30,2022)
 

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from .compat import PKCS5_OFFSET, PKCS5_PAD, PKCS5_UNPAD
 from .constants import UTF8, EncryptionMetadata, MaterialDescriptor, kilobyte
+from .util_text import random_string
 
 block_size = int(algorithms.AES.block_size / 8)  # in bytes
 
@@ -238,12 +239,13 @@ class SnowflakeEncryptionUtil:
         Returns:
             The decrypted file's location.
         """
-        temp_output_fd, temp_output_file = tempfile.mkstemp(
-            text=False, dir=tmp_dir, prefix=os.path.basename(in_filename) + "#"
+        temp_output_file = os.path.join(
+            tmp_dir, f"{os.path.basename(in_filename)}#{random_string()}"
         )
+
         logger.debug("encrypted file: %s, tmp file: %s", in_filename, temp_output_file)
         with open(in_filename, "rb") as infile:
-            with os.fdopen(temp_output_fd, "wb") as outfile:
+            with open(temp_output_file, "wb") as outfile:
                 SnowflakeEncryptionUtil.decrypt_stream(
                     metadata, encryption_material, infile, outfile, chunk_size
                 )

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -239,9 +239,9 @@ class SnowflakeEncryptionUtil:
         Returns:
             The decrypted file's location.
         """
-        temp_output_file = os.path.join(
-            tmp_dir, f"{os.path.basename(in_filename)}#{random_string()}"
-        )
+        temp_output_file = f"{os.path.basename(in_filename)}#{random_string()}"
+        if tmp_dir:
+            temp_output_file = os.path.join(tmp_dir, temp_output_file)
 
         logger.debug("encrypted file: %s, tmp file: %s", in_filename, temp_output_file)
         with open(in_filename, "rb") as infile:

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -687,8 +687,11 @@ def test_get_file_permission(tmp_path, conn_cnx):
             )
 
             cur.execute(f"GET @{stage_name}/data.csv file://{tmp_path}")
-            # get the default mask
+            # get the default mask, usually it is 0o022
             default_mask = os.umask(0)
             os.umask(default_mask)
             # files by default are given the permission 644 (Octal)
-            assert oct(os.stat(test_file).st_mode)[-3:] == oct(0o666 & ~default_mask)[-3:]
+            # umask is for denial, we need to negate
+            assert (
+                oct(os.stat(test_file).st_mode)[-3:] == oct(0o666 & ~default_mask)[-3:]
+            )

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -671,3 +671,24 @@ def test_get_empty_file(tmp_path, conn_cnx):
             with pytest.raises(OperationalError, match=".*the file does not exist.*$"):
                 cur.execute(f"GET @{stage_name}/foo.csv file://{tmp_path}")
             assert not empty_file.exists()
+
+
+@pytest.mark.skipolddriver
+def test_get_file_permission(tmp_path, conn_cnx):
+    test_file = tmp_path / "data.csv"
+    test_file.write_text("1,2,3\n")
+    stage_name = random_string(5, "test_get_empty_file_")
+    with conn_cnx() as cnx:
+        with cnx.cursor() as cur:
+            cur.execute(f"create temporary stage {stage_name}")
+            filename_in_put = str(test_file).replace("\\", "/")
+            cur.execute(
+                f"PUT 'file://{filename_in_put}' @{stage_name}",
+            )
+
+            cur.execute(f"GET @{stage_name}/data.csv file://{tmp_path}")
+            # get the default mask
+            default_mask = os.umask(0)
+            os.umask(default_mask)
+            # 438 Decimal  == 666 Octal, files by default are given the permission 644 (Octal)
+            assert oct(os.stat(test_file).st_mode)[-3:] == oct(438 & ~default_mask)[-3:]

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -690,5 +690,5 @@ def test_get_file_permission(tmp_path, conn_cnx):
             # get the default mask
             default_mask = os.umask(0)
             os.umask(default_mask)
-            # 438 Decimal  == 666 Octal, files by default are given the permission 644 (Octal)
-            assert oct(os.stat(test_file).st_mode)[-3:] == oct(438 & ~default_mask)[-3:]
+            # files by default are given the permission 644 (Octal)
+            assert oct(os.stat(test_file).st_mode)[-3:] == oct(0o666 & ~default_mask)[-3:]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-676736

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

mkstemp creates a temporary file in the most secure manner possible -- which is only given permission to the current user, not to `group` or `other` which is not expected.

change to use `open` which will inherit the default file permission.
