### PR TITLE
SNOW-679732: loosen cryptography restriction

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v2.8.3(Unreleased)
+  - Bumped cryptography dependency from <39.0.0 to <41.0.0
+
 - v2.8.2(November 18,2022)
 
   - Improved performance of OCSP response caching

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find_namespace:
 install_requires =
     asn1crypto>0.24.0,<2.0.0
     cffi>=1.9,<2.0.0
-    cryptography>=3.1.0,<39.0.0
+    cryptography>=3.1.0,<41.0.0
     oscrypto<2.0.0
     pyOpenSSL>=16.2.0,<23.0.0
     pycryptodomex!=3.5.0,>=3.2,<4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -151,6 +151,8 @@ depends = py37, py38, py39, py310
 log_level = info
 addopts = -ra --strict-markers
 junit_family = legacy
+filterwarnings =
+    error::UserWarning:cryptography.*
 markers =
     # Optional dependency groups markers
     lambda: AWS lambda tests


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-679732

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

	cryptography has its own [API stability policy](https://cryptography.io/en/stable/api-stability/#deprecation) which is different from the semantic versioning, however, we have customers who like to catch up with the latest cryptography release for security fix, avoid dependency conflict etc.
	
	As a compromise, we decide to loosen the upper bound of cryptography pin to +3 version as per their API stability policy.
	
	The major reasoning for pinning the version is that customer will pin the connector version in the deployment and we want the connector to work with compatible cryptography lib if the environment is going to recover from the pinned version.