### PR TITLE
SNOW-698526: Python connector 2.8.2 infinite loop in OCSP cache validation

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v2.8.3(Unreleased)
   - Bumped cryptography dependency from <39.0.0 to <41.0.0
   - Fixed a bug where the permission of the file downloaded via GET command is changed
+  - Fixed a bug where expired OCSP response cache caused infinite recursion during cache loading
 
 - v2.8.2(November 18,2022)
 

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -708,7 +708,7 @@ class OCSPCache:
             ocsp_response_validation_result = (
                 OCSP_RESPONSE_VALIDATION_CACHE[cache_key]
                 if lock_cache
-                else OCSP_RESPONSE_VALIDATION_CACHE._getitem(cache_key)
+                else OCSP_RESPONSE_VALIDATION_CACHE._getitem_non_locking(cache_key)
             )
             try:
                 # is_valid_time can raise exception if the cache

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 8, 2, None)
+VERSION = (2, 8, 3, None)

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -8,7 +8,6 @@ import os
 import os.path
 import pickle
 import stat
-import time
 from unittest import mock
 
 import pytest
@@ -418,11 +417,12 @@ class TestSFDictFileCache:
         c1._save()
 
         # load cache
-        c2 = cache.SFDictFileCache(file_path=cache_path, entry_lifetime=1)
+        c2 = cache.SFDictFileCache(
+            file_path=cache_path, entry_lifetime=int(NO_LIFETIME.total_seconds())
+        )
         c2["b"] = 2
         c2["c"] = 3
         # let the cache expire so that when loading again, clearning cache logic will be triggered
-        time.sleep(1)
         # load will trigger clear expired entries, and then further call _getitem
         c2._load()
 

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -422,7 +422,8 @@ class TestSFDictFileCache:
         )
         c2["b"] = 2
         c2["c"] = 3
-        # let the cache expire so that when loading again, clearning cache logic will be triggered
+        # cache will expire immediately due to the NO_LIFETIME setting
+        # when loading again, clearing cache logic will be triggered
         # load will trigger clear expired entries, and then further call _getitem
         c2._load()
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-698526

`_getitem` should not be overwritten in SFDictFileCache as `_getitem` is used by load to clean up in-memory expired cache. To resolve the issue, introduce a new non-locking get method in SFDictFileCache to segregate the functionality

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [x] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
