### PR TITLE
Enable receiving variant and array types in json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,10 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
                 name="snowflake.connector.arrow_iterator",
                 sources=[os.path.join(CONNECTOR_SRC_DIR, "arrow_iterator.pyx")],
             ),
+            Extension(
+                name="snowflake.connector.json",
+                sources=[os.path.join(CONNECTOR_SRC_DIR, "cpp", "json.cpp")],
+            ),
         ],
         compile_time_env=dict(ARROW_LESS_THAN_8=pyarrow_version < (8,)),
     )

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -311,15 +311,16 @@ class SnowflakeConverter:
         return conv if scale > 6 else conv0
 
     def _VARIANT_to_python(self, _) -> Callable[[str], Any]:
-        """Try using json format to load row value"""
+        """Use a custom json decoder (accepts undefined) to load row value"""
         return partial(json.loads, cls=SnowflakeJSONDecoder)
 
     def _ARRAY_to_python(self, _) -> Callable[[str], Any]:
-        """Try using json format to load row value"""
+        """Use a custom json decoder (accepts undefined) to load row value"""
         return partial(json.loads, cls=SnowflakeJSONDecoder)
 
     def _OBJECT_to_python(self, _):
-        return None  # skip conv
+        """Use a custom json decoder (accepts undefined) to load row value"""
+        return partial(json.loads, cls=SnowflakeJSONDecoder)
 
     def _BOOLEAN_to_python(self, ctx):
         return lambda value: value in ("1", "TRUE")

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -22,6 +22,7 @@ import pytz
 from .compat import IS_BINARY, IS_NUMERIC
 from .errorcode import ER_NOT_SUPPORT_DATA_TYPE
 from .errors import ProgrammingError
+from .json_decoder import SnowflakeJSONDecoder
 from .sfbinaryformat import binary_to_python, binary_to_snowflake
 from .sfdatetime import sfdatetime_total_seconds_from_timedelta
 
@@ -309,13 +310,13 @@ class SnowflakeConverter:
 
         return conv if scale > 6 else conv0
 
-    def _VARIANT_to_python(self, _) -> Callable[[str, ...], Any]:
+    def _VARIANT_to_python(self, _) -> Callable[[str], Any]:
         """Try using json format to load row value"""
-        return json.loads
+        return partial(json.loads, cls=SnowflakeJSONDecoder)
 
-    def _ARRAY_to_python(self, _) -> Callable[[str, ...], Any]:
+    def _ARRAY_to_python(self, _) -> Callable[[str], Any]:
         """Try using json format to load row value"""
-        return json.loads
+        return partial(json.loads, cls=SnowflakeJSONDecoder)
 
     def _OBJECT_to_python(self, _):
         return None  # skip conv

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import binascii
 import decimal
+import json
 import time
 from datetime import date, datetime
 from datetime import time as dt_t
@@ -308,12 +309,16 @@ class SnowflakeConverter:
 
         return conv if scale > 6 else conv0
 
-    def _VARIANT_to_python(self, _):
+    def _VARIANT_to_python(self, _) -> Callable[[str, ...], Any]:
+        """Try using json format to load row value"""
+        return json.loads
+
+    def _ARRAY_to_python(self, _) -> Callable[[str, ...], Any]:
+        """Try using json format to load row value"""
+        return json.loads
+
+    def _OBJECT_to_python(self, _):
         return None  # skip conv
-
-    _OBJECT_to_python = _VARIANT_to_python
-
-    _ARRAY_to_python = _VARIANT_to_python
 
     def _BOOLEAN_to_python(self, ctx):
         return lambda value: value in ("1", "TRUE")

--- a/src/snowflake/connector/cpp/json.cpp
+++ b/src/snowflake/connector/cpp/json.cpp
@@ -1,0 +1,1050 @@
+//
+// Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "Python.h"
+#include "structmember.h"
+
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
+#define PyScanner_Check(op) PyObject_TypeCheck(op, &PyScannerType)
+#define PyScanner_CheckExact(op) (Py_TYPE(op) == &PyScannerType)
+
+typedef struct _PyScannerObject {
+    PyObject_HEAD
+    signed char strict;
+    PyObject *object_hook;
+    PyObject *object_pairs_hook;
+    PyObject *parse_float;
+    PyObject *parse_int;
+    PyObject *parse_constant;
+    PyObject *memo;
+} PyScannerObject;
+
+static PyMemberDef scanner_members[] = {
+    {"strict", T_BOOL, offsetof(PyScannerObject, strict), READONLY, "strict"},
+    {"object_hook", T_OBJECT, offsetof(PyScannerObject, object_hook), READONLY, "object_hook"},
+    {"object_pairs_hook", T_OBJECT, offsetof(PyScannerObject, object_pairs_hook), READONLY},
+    {"parse_float", T_OBJECT, offsetof(PyScannerObject, parse_float), READONLY, "parse_float"},
+    {"parse_int", T_OBJECT, offsetof(PyScannerObject, parse_int), READONLY, "parse_int"},
+    {"parse_constant", T_OBJECT, offsetof(PyScannerObject, parse_constant), READONLY, "parse_constant"},
+    {NULL}
+};
+
+static PyObject *
+join_list_unicode(PyObject *lst)
+{
+    /* return u''.join(lst) */
+    static PyObject *sep = NULL;
+    if (sep == NULL) {
+        sep = PyUnicode_FromStringAndSize("", 0);
+        if (sep == NULL)
+            return NULL;
+    }
+    return PyUnicode_Join(sep, lst);
+}
+
+/* Forward decls */
+void init_json(void);
+static PyObject *
+scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr);
+static PyObject *
+_build_rval_index_tuple(PyObject *rval, Py_ssize_t idx);
+static PyObject *
+scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+static void
+scanner_dealloc(PyObject *self);
+static int
+scanner_clear(PyObject *self);
+static void
+raise_errmsg(const char *msg, PyObject *s, Py_ssize_t end);
+
+#define IS_WHITESPACE(c) (((c) == ' ') || ((c) == '\t') || ((c) == '\n') || ((c) == '\r'))
+
+static void
+raise_errmsg(const char *msg, PyObject *s, Py_ssize_t end)
+{
+    /* Use JSONDecodeError exception to raise a nice looking ValueError subclass */
+    static PyObject *JSONDecodeError = NULL;
+    PyObject *exc;
+    if (JSONDecodeError == NULL) {
+        PyObject *decoder = PyImport_ImportModule("json.decoder");
+        if (decoder == NULL)
+            return;
+        JSONDecodeError = PyObject_GetAttrString(decoder, "JSONDecodeError");
+        Py_DECREF(decoder);
+        if (JSONDecodeError == NULL)
+            return;
+    }
+    exc = PyObject_CallFunction(JSONDecodeError, "zOn", msg, s, end);
+    if (exc) {
+        PyErr_SetObject(JSONDecodeError, exc);
+        Py_DECREF(exc);
+    }
+}
+
+static void
+raise_stop_iteration(Py_ssize_t idx)
+{
+    PyObject *value = PyLong_FromSsize_t(idx);
+    if (value != NULL) {
+        PyErr_SetObject(PyExc_StopIteration, value);
+        Py_DECREF(value);
+    }
+}
+
+static PyObject *
+_build_rval_index_tuple(PyObject *rval, Py_ssize_t idx) {
+    /* return (rval, idx) tuple, stealing reference to rval */
+    PyObject *tpl;
+    PyObject *pyidx;
+    /*
+    steal a reference to rval, returns (rval, idx)
+    */
+    if (rval == NULL) {
+        return NULL;
+    }
+    pyidx = PyLong_FromSsize_t(idx);
+    if (pyidx == NULL) {
+        Py_DECREF(rval);
+        return NULL;
+    }
+    tpl = PyTuple_New(2);
+    if (tpl == NULL) {
+        Py_DECREF(pyidx);
+        Py_DECREF(rval);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(tpl, 0, rval);
+    PyTuple_SET_ITEM(tpl, 1, pyidx);
+    return tpl;
+}
+
+#define APPEND_OLD_CHUNK \
+    if (chunk != NULL) { \
+        if (chunks == NULL) { \
+            chunks = PyList_New(0); \
+            if (chunks == NULL) { \
+                goto bail; \
+            } \
+        } \
+        if (PyList_Append(chunks, chunk)) { \
+            Py_CLEAR(chunk); \
+            goto bail; \
+        } \
+        Py_CLEAR(chunk); \
+    }
+
+static PyObject *
+scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next_end_ptr)
+{
+    /* Read the JSON string from PyUnicode pystr.
+    end is the index of the first character after the quote.
+    if strict is zero then literal control characters are allowed
+    *next_end_ptr is a return-by-reference index of the character
+        after the end quote
+
+    Return value is a new PyUnicode
+    */
+    PyObject *rval = NULL;
+    Py_ssize_t len;
+    Py_ssize_t begin = end - 1;
+    Py_ssize_t next /* = begin */;
+    const void *buf;
+    int kind;
+    PyObject *chunks = NULL;
+    PyObject *chunk = NULL;
+
+    if (PyUnicode_READY(pystr) == -1)
+        return 0;
+
+    len = PyUnicode_GET_LENGTH(pystr);
+    buf = PyUnicode_DATA(pystr);
+    kind = PyUnicode_KIND(pystr);
+
+    if (end < 0 || len < end) {
+        PyErr_SetString(PyExc_ValueError, "end is out of bounds");
+        goto bail;
+    }
+    while (1) {
+        /* Find the end of the string or the next escape */
+        Py_UCS4 c = 0;
+        for (next = end; next < len; next++) {
+            c = PyUnicode_READ(kind, buf, next);
+            if (c == '"' || c == '\\') {
+                break;
+            }
+            else if (c <= 0x1f && strict) {
+                raise_errmsg("Invalid control character at", pystr, next);
+                goto bail;
+            }
+        }
+        if (!(c == '"' || c == '\\')) {
+            raise_errmsg("Unterminated string starting at", pystr, begin);
+            goto bail;
+        }
+        /* Pick up this chunk if it's not zero length */
+        if (next != end) {
+            APPEND_OLD_CHUNK
+                chunk = PyUnicode_FromKindAndData(
+                    kind,
+                    (char*)buf + kind * end,
+                    next - end);
+            if (chunk == NULL) {
+                goto bail;
+            }
+        }
+        next++;
+        if (c == '"') {
+            end = next;
+            break;
+        }
+        if (next == len) {
+            raise_errmsg("Unterminated string starting at", pystr, begin);
+            goto bail;
+        }
+        c = PyUnicode_READ(kind, buf, next);
+        if (c != 'u') {
+            /* Non-unicode backslash escapes */
+            end = next + 1;
+            switch (c) {
+                case '"': break;
+                case '\\': break;
+                case '/': break;
+                case 'b': c = '\b'; break;
+                case 'f': c = '\f'; break;
+                case 'n': c = '\n'; break;
+                case 'r': c = '\r'; break;
+                case 't': c = '\t'; break;
+                default: c = 0;
+            }
+            if (c == 0) {
+                raise_errmsg("Invalid \\escape", pystr, end - 2);
+                goto bail;
+            }
+        }
+        else {
+            c = 0;
+            next++;
+            end = next + 4;
+            if (end >= len) {
+                raise_errmsg("Invalid \\uXXXX escape", pystr, next - 1);
+                goto bail;
+            }
+            /* Decode 4 hex digits */
+            for (; next < end; next++) {
+                Py_UCS4 digit = PyUnicode_READ(kind, buf, next);
+                c <<= 4;
+                switch (digit) {
+                    case '0': case '1': case '2': case '3': case '4':
+                    case '5': case '6': case '7': case '8': case '9':
+                        c |= (digit - '0'); break;
+                    case 'a': case 'b': case 'c': case 'd': case 'e':
+                    case 'f':
+                        c |= (digit - 'a' + 10); break;
+                    case 'A': case 'B': case 'C': case 'D': case 'E':
+                    case 'F':
+                        c |= (digit - 'A' + 10); break;
+                    default:
+                        raise_errmsg("Invalid \\uXXXX escape", pystr, end - 5);
+                        goto bail;
+                }
+            }
+            /* Surrogate pair */
+            if (Py_UNICODE_IS_HIGH_SURROGATE(c) && end + 6 < len &&
+                PyUnicode_READ(kind, buf, next++) == '\\' &&
+                PyUnicode_READ(kind, buf, next++) == 'u') {
+                Py_UCS4 c2 = 0;
+                end += 6;
+                /* Decode 4 hex digits */
+                for (; next < end; next++) {
+                    Py_UCS4 digit = PyUnicode_READ(kind, buf, next);
+                    c2 <<= 4;
+                    switch (digit) {
+                        case '0': case '1': case '2': case '3': case '4':
+                        case '5': case '6': case '7': case '8': case '9':
+                            c2 |= (digit - '0'); break;
+                        case 'a': case 'b': case 'c': case 'd': case 'e':
+                        case 'f':
+                            c2 |= (digit - 'a' + 10); break;
+                        case 'A': case 'B': case 'C': case 'D': case 'E':
+                        case 'F':
+                            c2 |= (digit - 'A' + 10); break;
+                        default:
+                            raise_errmsg("Invalid \\uXXXX escape", pystr, end - 5);
+                            goto bail;
+                    }
+                }
+                if (Py_UNICODE_IS_LOW_SURROGATE(c2))
+                    c = Py_UNICODE_JOIN_SURROGATES(c, c2);
+                else
+                    end -= 6;
+            }
+        }
+        APPEND_OLD_CHUNK
+        chunk = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, &c, 1);
+        if (chunk == NULL) {
+            goto bail;
+        }
+    }
+
+    if (chunks == NULL) {
+        if (chunk != NULL)
+            rval = chunk;
+        else
+            rval = PyUnicode_FromStringAndSize("", 0);
+    }
+    else {
+        APPEND_OLD_CHUNK
+        rval = join_list_unicode(chunks);
+        if (rval == NULL) {
+            goto bail;
+        }
+        Py_CLEAR(chunks);
+    }
+
+    *next_end_ptr = end;
+    return rval;
+bail:
+    *next_end_ptr = -1;
+    Py_XDECREF(chunks);
+    Py_XDECREF(chunk);
+    return NULL;
+}
+
+PyDoc_STRVAR(pydoc_scanstring,
+    "scanstring(string, end, strict=True) -> (string, end)\n"
+    "\n"
+    "Scan the string s for a JSON string. End is the index of the\n"
+    "character in s after the quote that started the JSON string.\n"
+    "Unescapes all valid JSON string escape sequences and raises ValueError\n"
+    "on attempt to decode an invalid string. If strict is False then literal\n"
+    "control characters are allowed in the string.\n"
+    "\n"
+    "Returns a tuple of the decoded string and the index of the character in s\n"
+    "after the end quote."
+);
+
+static PyObject *
+py_scanstring(PyObject* self UNUSED, PyObject *args)
+{
+    PyObject *pystr;
+    PyObject *rval;
+    Py_ssize_t end;
+    Py_ssize_t next_end = -1;
+    int strict = 1;
+    if (!PyArg_ParseTuple(args, "On|i:scanstring", &pystr, &end, &strict)) {
+        return NULL;
+    }
+    if (PyUnicode_Check(pystr)) {
+        rval = scanstring_unicode(pystr, end, strict, &next_end);
+    }
+    else {
+        PyErr_Format(PyExc_TypeError,
+                     "first argument must be a string, not %.80s",
+                     Py_TYPE(pystr)->tp_name);
+        return NULL;
+    }
+    return _build_rval_index_tuple(rval, next_end);
+}
+
+static void
+scanner_dealloc(PyObject *self)
+{
+    /* bpo-31095: UnTrack is needed before calling any callbacks */
+    PyObject_GC_UnTrack(self);
+    scanner_clear(self);
+    Py_TYPE(self)->tp_free(self);
+}
+
+static int
+scanner_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    PyScannerObject *s;
+    assert(PyScanner_Check(self));
+    s = (PyScannerObject *)self;
+    Py_VISIT(s->object_hook);
+    Py_VISIT(s->object_pairs_hook);
+    Py_VISIT(s->parse_float);
+    Py_VISIT(s->parse_int);
+    Py_VISIT(s->parse_constant);
+    return 0;
+}
+
+static int
+scanner_clear(PyObject *self)
+{
+    PyScannerObject *s;
+    assert(PyScanner_Check(self));
+    s = (PyScannerObject *)self;
+    Py_CLEAR(s->object_hook);
+    Py_CLEAR(s->object_pairs_hook);
+    Py_CLEAR(s->parse_float);
+    Py_CLEAR(s->parse_int);
+    Py_CLEAR(s->parse_constant);
+    Py_CLEAR(s->memo);
+    return 0;
+}
+
+static PyObject *
+_parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+{
+    /* Read a JSON object from PyUnicode pystr.
+    idx is the index of the first character after the opening curly brace.
+    *next_idx_ptr is a return-by-reference index to the first character after
+        the closing curly brace.
+
+    Returns a new PyObject (usually a dict, but object_hook can change that)
+    */
+    void *str;
+    int kind;
+    Py_ssize_t end_idx;
+    PyObject *val = NULL;
+    PyObject *rval = NULL;
+    PyObject *key = NULL;
+    int has_pairs_hook = (s->object_pairs_hook != Py_None);
+    Py_ssize_t next_idx;
+
+    if (PyUnicode_READY(pystr) == -1)
+        return NULL;
+
+    str = PyUnicode_DATA(pystr);
+    kind = PyUnicode_KIND(pystr);
+    end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
+
+    if (has_pairs_hook)
+        rval = PyList_New(0);
+    else
+        rval = PyDict_New();
+    if (rval == NULL)
+        return NULL;
+
+    /* skip whitespace after { */
+    while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind,str, idx))) idx++;
+
+    /* only loop if the object is non-empty */
+    if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '}') {
+        while (1) {
+            PyObject *memokey;
+
+            /* read key */
+            if (idx > end_idx || PyUnicode_READ(kind, str, idx) != '"') {
+                raise_errmsg("Expecting property name enclosed in double quotes", pystr, idx);
+                goto bail;
+            }
+            key = scanstring_unicode(pystr, idx + 1, s->strict, &next_idx);
+            if (key == NULL)
+                goto bail;
+            memokey = PyDict_GetItemWithError(s->memo, key);
+            if (memokey != NULL) {
+                Py_INCREF(memokey);
+                Py_DECREF(key);
+                key = memokey;
+            }
+            else if (PyErr_Occurred()) {
+                goto bail;
+            }
+            else {
+                if (PyDict_SetItem(s->memo, key, key) < 0)
+                    goto bail;
+            }
+            idx = next_idx;
+
+            /* skip whitespace between key and : delimiter, read :, skip whitespace */
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+            if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ':') {
+                raise_errmsg("Expecting ':' delimiter", pystr, idx);
+                goto bail;
+            }
+            idx++;
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+
+            /* read any JSON term */
+            val = scan_once_unicode(s, pystr, idx, &next_idx);
+            if (val == NULL)
+                goto bail;
+
+            if (has_pairs_hook) {
+                PyObject *item = PyTuple_Pack(2, key, val);
+                if (item == NULL)
+                    goto bail;
+                Py_CLEAR(key);
+                Py_CLEAR(val);
+                if (PyList_Append(rval, item) == -1) {
+                    Py_DECREF(item);
+                    goto bail;
+                }
+                Py_DECREF(item);
+            }
+            else {
+                if (PyDict_SetItem(rval, key, val) < 0)
+                    goto bail;
+                Py_CLEAR(key);
+                Py_CLEAR(val);
+            }
+            idx = next_idx;
+
+            /* skip whitespace before } or , */
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+
+            /* bail if the object is closed or we didn't get the , delimiter */
+            if (idx <= end_idx && PyUnicode_READ(kind, str, idx) == '}')
+                break;
+            if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ',') {
+                raise_errmsg("Expecting ',' delimiter", pystr, idx);
+                goto bail;
+            }
+            idx++;
+
+            /* skip whitespace after , delimiter */
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+        }
+    }
+
+    *next_idx_ptr = idx + 1;
+
+    if (has_pairs_hook) {
+        val = PyObject_CallFunctionObjArgs(s->object_pairs_hook, rval, NULL);
+        Py_DECREF(rval);
+        return val;
+    }
+
+    /* if object_hook is not None: rval = object_hook(rval) */
+    if (s->object_hook != Py_None) {
+        val = PyObject_CallFunctionObjArgs(s->object_hook, rval, NULL);
+        Py_DECREF(rval);
+        return val;
+    }
+    return rval;
+bail:
+    Py_XDECREF(key);
+    Py_XDECREF(val);
+    Py_XDECREF(rval);
+    return NULL;
+}
+
+static PyObject *
+_parse_array_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr) {
+    /* Read a JSON array from PyUnicode pystr.
+    idx is the index of the first character after the opening brace.
+    *next_idx_ptr is a return-by-reference index to the first character after
+        the closing brace.
+
+    Returns a new PyList
+    */
+    void *str;
+    int kind;
+    Py_ssize_t end_idx;
+    PyObject *val = NULL;
+    PyObject *rval;
+    Py_ssize_t next_idx;
+
+    if (PyUnicode_READY(pystr) == -1)
+        return NULL;
+
+    rval = PyList_New(0);
+    if (rval == NULL)
+        return NULL;
+
+    str = PyUnicode_DATA(pystr);
+    kind = PyUnicode_KIND(pystr);
+    end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
+
+    /* skip whitespace after [ */
+    while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+
+    /* only loop if the array is non-empty */
+    if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
+        while (1) {
+
+            /* read any JSON term  */
+            val = scan_once_unicode(s, pystr, idx, &next_idx);
+            if (val == NULL)
+                goto bail;
+
+            if (PyList_Append(rval, val) == -1)
+                goto bail;
+
+            Py_CLEAR(val);
+            idx = next_idx;
+
+            /* skip whitespace between term and , */
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+
+            /* bail if the array is closed or we didn't get the , delimiter */
+            if (idx <= end_idx && PyUnicode_READ(kind, str, idx) == ']')
+                break;
+            if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ',') {
+                raise_errmsg("Expecting ',' delimiter", pystr, idx);
+                goto bail;
+            }
+            idx++;
+
+            /* skip whitespace after , */
+            while (idx <= end_idx && IS_WHITESPACE(PyUnicode_READ(kind, str, idx))) idx++;
+        }
+    }
+
+    /* verify that idx < end_idx, PyUnicode_READ(kind, str, idx) should be ']' */
+    if (idx > end_idx || PyUnicode_READ(kind, str, idx) != ']') {
+        raise_errmsg("Expecting value", pystr, end_idx);
+        goto bail;
+    }
+    *next_idx_ptr = idx + 1;
+    return rval;
+bail:
+    Py_XDECREF(val);
+    Py_DECREF(rval);
+    return NULL;
+}
+
+static PyObject *
+_parse_constant(PyScannerObject *s, const char *constant, Py_ssize_t idx, Py_ssize_t *next_idx_ptr) {
+    /* Read a JSON constant.
+    constant is the constant string that was found
+        ("NaN", "Infinity", "-Infinity").
+    idx is the index of the first character of the constant
+    *next_idx_ptr is a return-by-reference index to the first character after
+        the constant.
+
+    Returns the result of parse_constant
+    */
+    PyObject *cstr;
+    PyObject *rval;
+    /* constant is "NaN", "Infinity", or "-Infinity" */
+    cstr = PyUnicode_InternFromString(constant);
+    if (cstr == NULL)
+        return NULL;
+
+    /* rval = parse_constant(constant) */
+    rval = PyObject_CallFunctionObjArgs(s->parse_constant, cstr, NULL);
+    idx += PyUnicode_GET_LENGTH(cstr);
+    Py_DECREF(cstr);
+    *next_idx_ptr = idx;
+    return rval;
+}
+
+static PyObject *
+_match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_ssize_t *next_idx_ptr) {
+    /* Read a JSON number from PyUnicode pystr.
+    idx is the index of the first character of the number
+    *next_idx_ptr is a return-by-reference index to the first character after
+        the number.
+
+    Returns a new PyObject representation of that number:
+        PyLong, or PyFloat.
+        May return other types if parse_int or parse_float are set
+    */
+    void *str;
+    int kind;
+    Py_ssize_t end_idx;
+    Py_ssize_t idx = start;
+    int is_float = 0;
+    PyObject *rval;
+    PyObject *numstr = NULL;
+    PyObject *custom_func;
+
+    if (PyUnicode_READY(pystr) == -1)
+        return NULL;
+
+    str = PyUnicode_DATA(pystr);
+    kind = PyUnicode_KIND(pystr);
+    end_idx = PyUnicode_GET_LENGTH(pystr) - 1;
+
+    /* read a sign if it's there, make sure it's not the end of the string */
+    if (PyUnicode_READ(kind, str, idx) == '-') {
+        idx++;
+        if (idx > end_idx) {
+            raise_stop_iteration(start);
+            return NULL;
+        }
+    }
+
+    /* read as many integer digits as we find as long as it doesn't start with 0 */
+    if (PyUnicode_READ(kind, str, idx) >= '1' && PyUnicode_READ(kind, str, idx) <= '9') {
+        idx++;
+        while (idx <= end_idx && PyUnicode_READ(kind, str, idx) >= '0' && PyUnicode_READ(kind, str, idx) <= '9') idx++;
+    }
+    /* if it starts with 0 we only expect one integer digit */
+    else if (PyUnicode_READ(kind, str, idx) == '0') {
+        idx++;
+    }
+    /* no integer digits, error */
+    else {
+        raise_stop_iteration(start);
+        return NULL;
+    }
+
+    /* if the next char is '.' followed by a digit then read all float digits */
+    if (idx < end_idx && PyUnicode_READ(kind, str, idx) == '.' && PyUnicode_READ(kind, str, idx + 1) >= '0' && PyUnicode_READ(kind, str, idx + 1) <= '9') {
+        is_float = 1;
+        idx += 2;
+        while (idx <= end_idx && PyUnicode_READ(kind, str, idx) >= '0' && PyUnicode_READ(kind, str, idx) <= '9') idx++;
+    }
+
+    /* if the next char is 'e' or 'E' then maybe read the exponent (or backtrack) */
+    if (idx < end_idx && (PyUnicode_READ(kind, str, idx) == 'e' || PyUnicode_READ(kind, str, idx) == 'E')) {
+        Py_ssize_t e_start = idx;
+        idx++;
+
+        /* read an exponent sign if present */
+        if (idx < end_idx && (PyUnicode_READ(kind, str, idx) == '-' || PyUnicode_READ(kind, str, idx) == '+')) idx++;
+
+        /* read all digits */
+        while (idx <= end_idx && PyUnicode_READ(kind, str, idx) >= '0' && PyUnicode_READ(kind, str, idx) <= '9') idx++;
+
+        /* if we got a digit, then parse as float. if not, backtrack */
+        if (PyUnicode_READ(kind, str, idx - 1) >= '0' && PyUnicode_READ(kind, str, idx - 1) <= '9') {
+            is_float = 1;
+        }
+        else {
+            idx = e_start;
+        }
+    }
+
+    if (is_float && s->parse_float != (PyObject *)&PyFloat_Type)
+        custom_func = s->parse_float;
+    else if (!is_float && s->parse_int != (PyObject *) &PyLong_Type)
+        custom_func = s->parse_int;
+    else
+        custom_func = NULL;
+
+    if (custom_func) {
+        /* copy the section we determined to be a number */
+        numstr = PyUnicode_FromKindAndData(kind,
+                                           (char*)str + kind * start,
+                                           idx - start);
+        if (numstr == NULL)
+            return NULL;
+        rval = PyObject_CallFunctionObjArgs(custom_func, numstr, NULL);
+    }
+    else {
+        Py_ssize_t i, n;
+        char *buf;
+        /* Straight conversion to ASCII, to avoid costly conversion of
+           decimal unicode digits (which cannot appear here) */
+        n = idx - start;
+        numstr = PyBytes_FromStringAndSize(NULL, n);
+        if (numstr == NULL)
+            return NULL;
+        buf = PyBytes_AS_STRING(numstr);
+        for (i = 0; i < n; i++) {
+            buf[i] = (char) PyUnicode_READ(kind, str, i + start);
+        }
+        if (is_float)
+            rval = PyFloat_FromString(numstr);
+        else
+            rval = PyLong_FromString(buf, NULL, 10);
+    }
+    Py_DECREF(numstr);
+    *next_idx_ptr = idx;
+    return rval;
+}
+
+static PyObject *
+scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_t *next_idx_ptr)
+{
+    /* Read one JSON term (of any kind) from PyUnicode pystr.
+    idx is the index of the first character of the term
+    *next_idx_ptr is a return-by-reference index to the first character after
+        the number.
+
+    Returns a new PyObject representation of the term.
+    */
+    PyObject *res;
+    void *str;
+    int kind;
+    Py_ssize_t length;
+
+    if (PyUnicode_READY(pystr) == -1)
+        return NULL;
+
+    str = PyUnicode_DATA(pystr);
+    kind = PyUnicode_KIND(pystr);
+    length = PyUnicode_GET_LENGTH(pystr);
+
+    if (idx < 0) {
+        PyErr_SetString(PyExc_ValueError, "idx cannot be negative");
+        return NULL;
+    }
+    if (idx >= length) {
+        raise_stop_iteration(idx);
+        return NULL;
+    }
+
+    switch (PyUnicode_READ(kind, str, idx)) {
+        case '"':
+            /* string */
+            return scanstring_unicode(pystr, idx + 1, s->strict, next_idx_ptr);
+        case '{':
+            /* object */
+            if (Py_EnterRecursiveCall(" while decoding a JSON object "
+                                      "from a unicode string"))
+                return NULL;
+            res = _parse_object_unicode(s, pystr, idx + 1, next_idx_ptr);
+            Py_LeaveRecursiveCall();
+            return res;
+        case '[':
+            /* array */
+            if (Py_EnterRecursiveCall(" while decoding a JSON array "
+                                      "from a unicode string"))
+                return NULL;
+            res = _parse_array_unicode(s, pystr, idx + 1, next_idx_ptr);
+            Py_LeaveRecursiveCall();
+            return res;
+        case 'u':
+            /* undefined */
+            if ((idx + 8 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'd' &&
+                PyUnicode_READ(kind, str, idx + 3) == 'e' &&
+                PyUnicode_READ(kind, str, idx + 4) == 'f' &&
+                PyUnicode_READ(kind, str, idx + 5) == 'i' &&
+                PyUnicode_READ(kind, str, idx + 6) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 7) == 'e' &&
+                PyUnicode_READ(kind, str, idx + 8) == 'd') {
+                *next_idx_ptr = idx + 9;
+                Py_RETURN_NONE;
+            }
+        case 'n':
+            /* null */
+            if ((idx + 3 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'u' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'l' &&
+                PyUnicode_READ(kind, str, idx + 3) == 'l') {
+                *next_idx_ptr = idx + 4;
+                Py_RETURN_NONE;
+            }
+            break;
+        case 't':
+            /* true */
+            if ((idx + 3 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'r' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'u' &&
+                PyUnicode_READ(kind, str, idx + 3) == 'e') {
+                *next_idx_ptr = idx + 4;
+                Py_RETURN_TRUE;
+            }
+            break;
+        case 'f':
+            /* false */
+            if ((idx + 4 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'a' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'l' &&
+                PyUnicode_READ(kind, str, idx + 3) == 's' &&
+                PyUnicode_READ(kind, str, idx + 4) == 'e') {
+                *next_idx_ptr = idx + 5;
+                Py_RETURN_FALSE;
+            }
+            break;
+        case 'N':
+            /* NaN */
+            if ((idx + 2 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'a' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'N') {
+                return _parse_constant(s, "NaN", idx, next_idx_ptr);
+            }
+            break;
+        case 'I':
+            /* Infinity */
+            if ((idx + 7 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'f' &&
+                PyUnicode_READ(kind, str, idx + 3) == 'i' &&
+                PyUnicode_READ(kind, str, idx + 4) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 5) == 'i' &&
+                PyUnicode_READ(kind, str, idx + 6) == 't' &&
+                PyUnicode_READ(kind, str, idx + 7) == 'y') {
+                return _parse_constant(s, "Infinity", idx, next_idx_ptr);
+            }
+            break;
+        case '-':
+            /* -Infinity */
+            if ((idx + 8 < length) &&
+                PyUnicode_READ(kind, str, idx + 1) == 'I' &&
+                PyUnicode_READ(kind, str, idx + 2) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 3) == 'f' &&
+                PyUnicode_READ(kind, str, idx + 4) == 'i' &&
+                PyUnicode_READ(kind, str, idx + 5) == 'n' &&
+                PyUnicode_READ(kind, str, idx + 6) == 'i' &&
+                PyUnicode_READ(kind, str, idx + 7) == 't' &&
+                PyUnicode_READ(kind, str, idx + 8) == 'y') {
+                return _parse_constant(s, "-Infinity", idx, next_idx_ptr);
+            }
+            break;
+    }
+    /* Didn't find a string, object, array, or named constant. Look for a number. */
+    return _match_number_unicode(s, pystr, idx, next_idx_ptr);
+}
+
+static PyObject *
+scanner_call(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    /* Python callable interface to scan_once_{str,unicode} */
+    PyObject *pystr;
+    PyObject *rval;
+    Py_ssize_t idx;
+    Py_ssize_t next_idx = -1;
+    static char *kwlist[] = {"string", "idx", NULL};
+    PyScannerObject *s;
+    assert(PyScanner_Check(self));
+    s = (PyScannerObject *)self;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "On:scan_once", kwlist, &pystr, &idx))
+        return NULL;
+
+    if (PyUnicode_Check(pystr)) {
+        rval = scan_once_unicode(s, pystr, idx, &next_idx);
+    }
+    else {
+        PyErr_Format(PyExc_TypeError,
+                 "first argument must be a string, not %.80s",
+                 Py_TYPE(pystr)->tp_name);
+        return NULL;
+    }
+    PyDict_Clear(s->memo);
+    if (rval == NULL)
+        return NULL;
+    return _build_rval_index_tuple(rval, next_idx);
+}
+
+static PyObject *
+scanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyScannerObject *s;
+    PyObject *ctx;
+    PyObject *strict;
+    static char *kwlist[] = {"context", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:make_scanner", kwlist, &ctx))
+        return NULL;
+
+    s = (PyScannerObject *)type->tp_alloc(type, 0);
+    if (s == NULL) {
+        return NULL;
+    }
+
+    s->memo = PyDict_New();
+    if (s->memo == NULL)
+        goto bail;
+
+    /* All of these will fail "gracefully" so we don't need to verify them */
+    strict = PyObject_GetAttrString(ctx, "strict");
+    if (strict == NULL)
+        goto bail;
+    s->strict = PyObject_IsTrue(strict);
+    Py_DECREF(strict);
+    if (s->strict < 0)
+        goto bail;
+    s->object_hook = PyObject_GetAttrString(ctx, "object_hook");
+    if (s->object_hook == NULL)
+        goto bail;
+    s->object_pairs_hook = PyObject_GetAttrString(ctx, "object_pairs_hook");
+    if (s->object_pairs_hook == NULL)
+        goto bail;
+    s->parse_float = PyObject_GetAttrString(ctx, "parse_float");
+    if (s->parse_float == NULL)
+        goto bail;
+    s->parse_int = PyObject_GetAttrString(ctx, "parse_int");
+    if (s->parse_int == NULL)
+        goto bail;
+    s->parse_constant = PyObject_GetAttrString(ctx, "parse_constant");
+    if (s->parse_constant == NULL)
+        goto bail;
+
+    return (PyObject *)s;
+
+bail:
+    Py_DECREF(s);
+    return NULL;
+}
+
+PyDoc_STRVAR(scanner_doc, "JSON scanner object");
+
+static
+PyTypeObject PyScannerType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "json.Scanner",       /* tp_name */
+    sizeof(PyScannerObject), /* tp_basicsize */
+    0,                    /* tp_itemsize */
+    scanner_dealloc, /* tp_dealloc */
+    0,                    /* tp_vectorcall_offset */
+    0,                    /* tp_getattr */
+    0,                    /* tp_setattr */
+    0,                    /* tp_as_async */
+    0,                    /* tp_repr */
+    0,                    /* tp_as_number */
+    0,                    /* tp_as_sequence */
+    0,                    /* tp_as_mapping */
+    0,                    /* tp_hash */
+    scanner_call,         /* tp_call */
+    0,                    /* tp_str */
+    0,/* PyObject_GenericGetAttr, */                    /* tp_getattro */
+    0,/* PyObject_GenericSetAttr, */                    /* tp_setattro */
+    0,                    /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,   /* tp_flags */
+    scanner_doc,          /* tp_doc */
+    scanner_traverse,                    /* tp_traverse */
+    scanner_clear,                    /* tp_clear */
+    0,                    /* tp_richcompare */
+    0,                    /* tp_weaklistoffset */
+    0,                    /* tp_iter */
+    0,                    /* tp_iternext */
+    0,                    /* tp_methods */
+    scanner_members,                    /* tp_members */
+    0,                    /* tp_getset */
+    0,                    /* tp_base */
+    0,                    /* tp_dict */
+    0,                    /* tp_descr_get */
+    0,                    /* tp_descr_set */
+    0,                    /* tp_dictoffset */
+    0,                    /* tp_init */
+    0,/* PyType_GenericAlloc, */        /* tp_alloc */
+    scanner_new,          /* tp_new */
+    0,/* PyObject_GC_Del, */              /* tp_free */
+};
+
+static PyMethodDef speedups_methods[] = {
+    {"scanstring",
+        (PyCFunction)py_scanstring,
+        METH_VARARGS,
+        pydoc_scanstring},
+    {NULL, NULL, 0, NULL}
+};
+
+PyDoc_STRVAR(module_doc,
+"json speedups\n");
+
+static struct PyModuleDef jsonmodule = {
+        PyModuleDef_HEAD_INIT,
+        "json",
+        module_doc,
+        -1,
+        speedups_methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyMODINIT_FUNC
+PyInit_json(void)
+{
+    PyObject *m = PyModule_Create(&jsonmodule);
+    if (!m)
+        return NULL;
+    if (PyType_Ready(&PyScannerType) < 0)
+        goto fail;
+    Py_INCREF((PyObject*)&PyScannerType);
+    if (PyModule_AddObject(m, "make_scanner", (PyObject*)&PyScannerType) < 0) {
+        Py_DECREF((PyObject*)&PyScannerType);
+        goto fail;
+    }
+    return m;
+  fail:
+    Py_DECREF(m);
+    return NULL;
+}

--- a/src/snowflake/connector/cpp/json.cpp
+++ b/src/snowflake/connector/cpp/json.cpp
@@ -808,6 +808,7 @@ scan_once_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ssize_
                 PyUnicode_READ(kind, str, idx + 7) == 'e' &&
                 PyUnicode_READ(kind, str, idx + 8) == 'd') {
                 *next_idx_ptr = idx + 9;
+                // TODO: Return a special singleton type for undefined rather than None
                 Py_RETURN_NONE;
             }
         case 'n':

--- a/src/snowflake/connector/json_decoder.py
+++ b/src/snowflake/connector/json_decoder.py
@@ -44,6 +44,7 @@ def py_make_scanner(context: json.JSONDecoder) -> Callable[[str, int], Any]:
         elif nextchar == "[":
             return parse_array((string, idx + 1), _scan_once)
         elif nextchar == "u" and string[idx : idx + 9] == "undefined":
+            # TODO: Return a special singleton type for undefined rather than None
             return None, idx + 9
         elif nextchar == "n" and string[idx : idx + 4] == "null":
             return None, idx + 4

--- a/src/snowflake/connector/json_decoder.py
+++ b/src/snowflake/connector/json_decoder.py
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+try:
+    from snowflake.connector.json import make_scanner as c_make_scanner
+except ImportError:
+    c_make_scanner = None
+
+
+def py_make_scanner(context: json.JSONDecoder) -> Callable[[str, int], Any]:
+    # some references for the _scan_once function below
+    parse_object = context.parse_object
+    parse_array = context.parse_array
+    parse_string = context.parse_string
+    match_number = json.scanner.NUMBER_RE.match
+    strict = context.strict
+    parse_float = context.parse_float
+    parse_int = context.parse_int
+    parse_constant = context.parse_constant
+    object_hook = context.object_hook
+    object_pairs_hook = context.object_pairs_hook
+    memo = context.memo
+
+    # customized _scan_once
+    def _scan_once(string: str, idx: int) -> Any:
+        try:
+            nextchar = string[idx]
+        except IndexError:
+            raise StopIteration(idx) from None
+
+        # override some parse_** calls with the correct _scan_once
+        if nextchar == '"':
+            return parse_string(string, idx + 1, strict)
+        elif nextchar == "{":
+            return parse_object(
+                (string, idx + 1), strict, _scan_once, object_hook, object_pairs_hook
+            )
+        elif nextchar == "[":
+            return parse_array((string, idx + 1), _scan_once)
+        elif nextchar == "u" and string[idx : idx + 9] == "undefined":
+            return None, idx + 9
+        elif nextchar == "n" and string[idx : idx + 4] == "null":
+            return None, idx + 4
+        elif nextchar == "t" and string[idx : idx + 4] == "true":
+            return True, idx + 4
+        elif nextchar == "f" and string[idx : idx + 5] == "false":
+            return False, idx + 5
+
+        m = match_number(string, idx)
+        if m is not None:
+            integer, frac, exp = m.groups()
+            if frac or exp:
+                res = parse_float(integer + (frac or "") + (exp or ""))
+            else:
+                res = parse_int(integer)
+            return res, m.end()
+        elif nextchar == "N" and string[idx : idx + 3] == "NaN":
+            return parse_constant("NaN"), idx + 3
+        elif nextchar == "I" and string[idx : idx + 8] == "Infinity":
+            return parse_constant("Infinity"), idx + 8
+        elif nextchar == "-" and string[idx : idx + 9] == "-Infinity":
+            return parse_constant("-Infinity"), idx + 9
+        else:
+            raise StopIteration(idx)
+
+    def scan_once(string, idx):
+        try:
+            return _scan_once(string, idx)
+        finally:
+            memo.clear()
+
+    return scan_once
+
+
+make_scanner = c_make_scanner or py_make_scanner
+
+
+class SnowflakeJSONDecoder(json.JSONDecoder):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # override scanner
+        self.scan_once = make_scanner(self)

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import random
 from datetime import datetime, timedelta
 
@@ -12,6 +13,7 @@ import numpy
 import pytest
 
 import snowflake.connector
+from snowflake.connector.json_decoder import SnowflakeJSONDecoder
 
 pytestmark = pytest.mark.skipolddriver  # old test driver tests won't run this module
 
@@ -641,6 +643,10 @@ def iterate_over_test_chunk(
                             and eps is not None
                         ):
                             assert abs(json_res[j] - arrow_res[j]) <= eps
+                        elif test_name == "struct":
+                            assert json_res[j] == json.loads(
+                                arrow_res[j], cls=SnowflakeJSONDecoder
+                            )
                         else:
                             assert json_res[j] == arrow_res[j]
             else:

--- a/test/integ/test_converter.py
+++ b/test/integ/test_converter.py
@@ -11,9 +11,15 @@ import pytest
 import pytz
 
 from snowflake.connector.compat import IS_WINDOWS
-from snowflake.connector.constants import PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT
 from snowflake.connector.converter import ZERO_EPOCH, _generate_tzinfo_from_tzoffset
 from snowflake.connector.converter_snowsql import SnowflakeConverterSnowSQL
+
+try:
+    from snowflake.connector.constants import (
+        PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT,
+    )
+except ImportError:
+    PARAMETER_PYTHON_CONNECTOR_QUERY_RESULT_FORMAT = None
 
 
 def _compose_tz(dt, tzinfo):

--- a/test/integ/test_converter.py
+++ b/test/integ/test_converter.py
@@ -596,8 +596,9 @@ def test_receive_array_json(conn_cnx):
                 select array_construct(10, 20, 30);
                 select array_construct(-1, parse_json('[1.2, 28.9, 2.188]'), false);
                 select array_construct(parse_json('{"x": "abc"}'), parse_json('{"y": false}'), parse_json('{"z": 10}'));
+                select array_construct(null, parse_json('null'));
                 """,
-                num_statements=4,
+                num_statements=5,
             )
             array1 = c.fetchall()[0][0]
             _check_result_types(array1, types=[str, float, int, int])
@@ -610,3 +611,5 @@ def test_receive_array_json(conn_cnx):
             assert isinstance(array4[0].get("x"), str)
             assert isinstance(array4[1].get("y"), bool)
             assert isinstance(array4[2].get("z"), int)
+            array5 = c.nextset().fetchall()[0][0]
+            _check_result_types(array5, types=[type(None), type(None)])


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-703036](https://snowflakecomputing.atlassian.net/browse/SNOW-703036)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use `json.loads` to try to load array and variant types in the connector. Some observed behaviors:
   - If `parse_json` is used on a list ending with a comma, for example `[1, 2, 3,]`, Snowflake stores it as `[1, 2, 3, undefined]`
   - If `null` is passed to `array_construct`, it is stored as undefined in the array.
   - `json.loads` cannot parse `undefined` elements in VARIANT or ARRAY types.
