### PR TITLE
SNOW-706773 adding back extras tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox tox-external-wheels
       - name: Run tests
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-{unit,integ,pandas,sso}-ci"
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-{extras,unit,integ,pandas,sso}-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/test/extras/README.md
+++ b/test/extras/README.md
@@ -1,0 +1,9 @@
+# Extra tests that should run separately
+
+## Running tests
+
+These are tests that test weird edge cases when we need a standalone Python environment
+and process.
+
+Run only these tests with `tox`, for example: `tox -e py38-extras` from the
+top directory.

--- a/test/extras/__init__.py
+++ b/test/extras/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#

--- a/test/extras/run.py
+++ b/test/extras/run.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+import pathlib
+import subprocess
+import sys
+
+# This script run every Python file in this directory other than this
+#  one in a subprocess and checks their exit codes
+
+
+file_ignore_list = ["run.py", "__init__.py"]
+
+for test_file in pathlib.Path(__file__).parent.glob("*.py"):
+    if test_file.name not in file_ignore_list:
+        print(f"Running {test_file}")
+        sub_process = subprocess.run(
+            [
+                sys.executable if sys.executable else "python",
+                "-m",
+                f"test.extras.{test_file.name[:-3]}",
+            ]
+        )
+        sub_process.check_returncode()

--- a/test/extras/simple_select1.py
+++ b/test/extras/simple_select1.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.connector import connect
+
+from ..parameters import CONNECTION_PARAMETERS
+
+with connect(**CONNECTION_PARAMETERS) as conn:
+    with conn.cursor() as cur:
+        assert cur.execute("select 1;").fetchall() == [
+            (1,),
+        ]

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,6 @@ extras =
     development
     pandas: pandas
     sso: secure-local-storage
-deps =
-    pip >= 19.3.1
 install_command = python -m pip install -U {opts} {packages}
 external_wheels =
     py37-ci: dist/*cp37*.whl
@@ -98,7 +96,7 @@ commands =
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report
 ;              generates a diff coverage against origin/master (can be changed by setting DIFF_AGAINST env var)
-deps = {[testenv]deps}
+deps =
        coverage
 ;       diff_cover
 skip_install = True
@@ -133,7 +131,6 @@ description = format the code base to adhere to our styles, and complain about w
 passenv =
     PROGRAMDATA
 deps =
-    {[testenv]deps}
     pre-commit >= 2.9.0
 skip_install = True
 commands = pre-commit run --all-files
@@ -142,7 +139,6 @@ commands = pre-commit run --all-files
 [testenv:dependency]
 description = Check if there is conflicting dependency
 deps =
-    {[testenv]deps}
     pip-tools
 skip_install = True
 commands = pip-compile setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ source = src/snowflake/connector
 [tox]
 minversion = 3.7
 envlist = fix_lint,
-          py{37,38,39,310}-{unit-parallel,integ,pandas,sso},
+          py{37,38,39,310}-{extras,unit-parallel,integ,pandas,sso},
           coverage
 skip_missing_interpreters = true
 requires =
@@ -68,10 +68,11 @@ passenv =
 commands =
     # Test environments
     # Note: make sure to have a default env and all the other special ones
-    !pandas-!sso-!lambda: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and not sso and not pandas and not lambda" {posargs:} test
+    !pandas-!sso-!lambda-!extras: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and not sso and not pandas and not lambda" {posargs:} test
     pandas: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and pandas" {posargs:} test
     sso: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and sso" {posargs:} test
     lambda: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and lambda" {posargs:} test
+    extras: python -m test.extras.run {posargs:}
 
 [testenv:olddriver]
 basepython = python3.7


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-706773

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I add back `extras` tests (originally added in #380 and then removed in #981 ), the only one of which will now test that we can simply log into Snowflake and execute `select 1;`. This should catch adding dangling import statements that aren't dependencies.
