### PR TITLE
SNOW-673771 Print SSO URL before attempting to open window

### DIFF
--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -144,7 +144,7 @@ class AuthByWebBrowser(AuthByPlugin):
             )
 
             logger.debug("step 2: open a browser")
-            print(f"URL: {sso_url}")
+            print(f"Going to open: {sso_url} to authenticate...")
             if not self._webbrowser.open_new(sso_url):
                 print(
                     "We were unable to open a browser window for you, "

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -144,13 +144,13 @@ class AuthByWebBrowser(AuthByPlugin):
             )
 
             logger.debug("step 2: open a browser")
+            print(f"URL: {sso_url}")
             if not self._webbrowser.open_new(sso_url):
                 print(
                     "We were unable to open a browser window for you, "
-                    "please open the following url manually then paste the "
+                    "please open the url above manually then paste the "
                     "URL you are redirected to into the terminal."
                 )
-                print(f"URL: {sso_url}")
                 url = input("Enter the URL the SSO URL redirected you to: ")
                 self._process_get_url(url)
                 if not self._token:

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -183,9 +183,9 @@ def test_auth_webbrowser_fail_webbrowser(
         "Initiating login request with your identity provider. A browser window "
         "should have opened for you to complete the login. If you can't see it, "
         "check existing browser windows, or your OS settings. Press CTRL+C to "
-        f"abort and try again...\nURL: {REF_SSO_URL}\nWe were unable to open a browser window for "
+        f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\nWe were unable to open a browser window for "
         "you, please open the url above manually then paste the URL you "
-        f"are redirected to into the terminal.\n"
+        "are redirected to into the terminal.\n"
     )
     if expected_error:
         assert rest._connection.errorhandler.called  # an error
@@ -237,7 +237,7 @@ def test_auth_webbrowser_fail_webserver(capsys):
         "Initiating login request with your identity provider. A browser window "
         "should have opened for you to complete the login. If you can't see it, "
         "check existing browser windows, or your OS settings. Press CTRL+C to "
-        f"abort and try again...\nURL: {REF_SSO_URL}\n"
+        f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\n"
     )
     assert rest._connection.errorhandler.called  # an error
     assert auth.assertion_content is None

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -183,9 +183,9 @@ def test_auth_webbrowser_fail_webbrowser(
         "Initiating login request with your identity provider. A browser window "
         "should have opened for you to complete the login. If you can't see it, "
         "check existing browser windows, or your OS settings. Press CTRL+C to "
-        "abort and try again...\nWe were unable to open a browser window for "
-        "you, please open the following url manually then paste the URL you "
-        f"are redirected to into the terminal.\nURL: {REF_SSO_URL}\n"
+        f"abort and try again...\nURL: {REF_SSO_URL}\nWe were unable to open a browser window for "
+        "you, please open the url above manually then paste the URL you "
+        f"are redirected to into the terminal.\n"
     )
     if expected_error:
         assert rest._connection.errorhandler.called  # an error
@@ -237,7 +237,7 @@ def test_auth_webbrowser_fail_webserver(capsys):
         "Initiating login request with your identity provider. A browser window "
         "should have opened for you to complete the login. If you can't see it, "
         "check existing browser windows, or your OS settings. Press CTRL+C to "
-        "abort and try again...\n"
+        f"abort and try again...\nURL: {REF_SSO_URL}\n"
     )
     assert rest._connection.errorhandler.called  # an error
     assert auth.assertion_content is None


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   A workaround for when browser doesn't open in webbrowser authentication, e.g.  #SNOW-673771

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
