### PR TITLE
Specify min MacOS SDK version for build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,8 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
                     if "std=" not in os.environ.get("CXXFLAGS", ""):
                         ext.extra_compile_args.append("-std=c++17")
                         ext.extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+                    if sys.platform == "darwin":
+                        ext.extra_compile_args.append("-mmacosx-version-min=10.13")
 
                 ext.library_dirs.append(
                     os.path.join(current_dir, self.build_lib, "snowflake", "connector")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1397 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
 Local builds on MacOS are failing because the PyArrow upgrade we merged last week requires MacOS SDK to have version > 10.13.  However, `build`/`pip` is building the wheel against a [platform](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_platform) potentially different than the operating system's [platform](https://docs.python.org/3/library/platform.html#platform.platform). I.e. if your Python distribution (via downloaded installer) is built with MacOSX10.9 SDK, `build`/`pip` will try to build the wheel using that regardless of your machine's current OS.
This fix attempts to address this problem by specifying a minimum version of gcc's Mac OS X deployment target to be `10.13` in `setup.py`.
**Reference**: https://github.com/pypa/wheel/blob/8dfef1355a8f19e773a08630613bd2da6c636c37/src/wheel/bdist_wheel.py#L274
