### PR TITLE
Revert "Changed log level when PyArrowIterator failed to be imported"

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -86,7 +86,7 @@ try:
 
     CAN_USE_ARROW_RESULT_FORMAT = True
 except ImportError as e:  # pragma: no cover
-    logger.warning(
+    logger.debug(
         f"Failed to import ArrowResult. No Apache Arrow result set format can be used. ImportError: {e}",
     )
     CAN_USE_ARROW_RESULT_FORMAT = False


### PR DESCRIPTION
Reverts snowflakedb/snowflake-connector-python#1272
Will merge again after fixing SnowSQL tests, which are failing because logging.warning is directed to stderr and captured as errors.