### PR TITLE
SNOW-705498: Improve the robustness of ocsp response caching to handle error in cases of serialization and deserialization

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v2.9.2(unreleased)
+
+  - Improved the robustness of OCSP response caching to handle errors in cases of serialization and deserialization.
+
 - v2.9.1(unreleased)
 
   - Bumped pyarrow dependency from >=8.0.0,<8.1.0 to >=10.0.1,<10.1.0

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -613,11 +613,11 @@ class SFDictFileCache(SFDictCache):
     # Custom pickling implementation
 
     def __getstate__(self) -> dict:
-        state = self.__dict__.copy()
-        for k in list(state.keys()):
-            if k not in SFDictFileCache._ATTRIBUTES_TO_PICKLE:
-                del state[k]
-        return state
+        return {
+            k: v
+            for k, v in self.__dict__.items()
+            if k in SFDictFileCache._ATTRIBUTES_TO_PICKLE
+        }
 
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -346,7 +346,7 @@ class SFDictFileCache(SFDictCache):
 
     # This number decides the chance of saving after writing (probability: 1/n+1)
     MAX_RAND_INT = 9
-    _ATTRIBUTES_TO_PICKLE = [
+    _ATTRIBUTES_TO_PICKLE = (
         "_entry_lifetime",
         "_cache",
         "telemetry",
@@ -354,7 +354,7 @@ class SFDictFileCache(SFDictCache):
         "file_timeout",
         "_file_lock_path",
         "last_loaded",
-    ]
+    )
 
     def __init__(
         self,

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 9, 0, None)
+VERSION = (2, 9, 1, None)

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (2, 9, 1, None)
+VERSION = (2, 9, 2, None)

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -23,6 +23,28 @@ except ImportError:
 NO_LIFETIME = datetime.timedelta(seconds=0)
 
 
+class BrokenReadingPickleObject:
+    def __init__(self):
+        self.val = "string"
+
+    def __getstate__(self):
+        return {"val": "string"}
+
+    def __setstate__(self, state):
+        raise ModuleNotFoundError()
+
+
+class BrokenWritingPickleObject:
+    def __init__(self):
+        self.val = "string"
+
+    def __getstate__(self):
+        raise ModuleNotFoundError()
+
+    def __setstate__(self, state):
+        self.val = "string"
+
+
 class TestSFDictCache:
     def test_simple_usage(self):
         c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
@@ -325,6 +347,16 @@ class TestSFDictFileCache:
         assert c._lock is not c2._lock
         assert c._file_lock is not c2._file_lock
 
+        c.arribute_shoud_not_be_pickled = "value"
+        c2 = pickle.loads(pickle.dumps(c))
+        assert c.arribute_shoud_not_be_pickled
+        assert c is not c2
+        assert c._lock is not c2._lock
+        assert c._file_lock is not c2._file_lock
+        assert not hasattr(c2, "arribute_shoud_not_be_pickled")
+        for attr in cache.SFDictFileCache._ATTRIBUTES_TO_PICKLE:
+            assert hasattr(c2, attr) and getattr(c2, attr) == getattr(c, attr)
+
     def test_precise_save_load(self, tmpdir):
         c1 = NeverSaveSFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
         c2 = pickle.loads(pickle.dumps(c1))
@@ -428,3 +460,22 @@ class TestSFDictFileCache:
         c2._load()
 
         assert len(c2) == 1 and c2["a"] == 1 and c2._getitem_non_locking("a") == 1
+
+    def test_broken_pickle_objects(self, tmpdir):
+        cache_path = os.path.join(tmpdir, "cache.txt")
+        c1 = cache.SFDictFileCache(file_path=cache_path)
+        c1["key"] = BrokenReadingPickleObject()
+        assert c1._save()
+        assert os.path.exists(cache_path) and os.path.isfile(cache_path)
+
+        c2 = cache.SFDictFileCache(file_path=cache_path)
+        assert not c2._load()  # load should return false due to ModuleNotFound error
+
+        cache_path = os.path.join(tmpdir, "cache2.txt")
+        c1 = cache.SFDictFileCache(file_path=cache_path)
+        c1["key"] = BrokenWritingPickleObject()
+        assert not c1._save()
+        assert not os.path.exists(cache_path)
+
+        c2 = cache.SFDictFileCache(file_path=cache_path)
+        assert not c2._load()  # load should return false due to no file


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-705498

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [x] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  1. white list of attributes to pickle
  2. wrap serialization/deserialization to catch all erros
  3. move self._get_item_nonlocking out of __init__ definition to a separate method to avoid being collected