### PR TITLE
fix: type ResultMetaData fields as optional

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Bumped vendored library urllib3 to 1.26.15
   - Bumped vendored library requests to 2.29.0
   - Fixed a bug when `_prefetch_hook()` was not called before yielding results of `execute_async()`.
+  - Fixed a bug where some ResultMetadata fields were marked as required when they were optional.
 
 - v3.0.3(April 20, 2023)
   - Fixed a bug that prints error in logs for GET command on GCS.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -24,6 +24,7 @@ from typing import (
     Iterator,
     NamedTuple,
     NoReturn,
+    Optional,
     Sequence,
     TypeVar,
     overload,
@@ -123,10 +124,10 @@ ASYNC_RETRY_PATTERN = [1, 1, 2, 3, 4, 8, 10]
 class ResultMetadata(NamedTuple):
     name: str
     type_code: int
-    display_size: int
-    internal_size: int
-    precision: int
-    scale: int
+    display_size: Optional[int]
+    internal_size: Optional[int]
+    precision: Optional[int]
+    scale: Optional[int]
     is_nullable: bool
 
     @classmethod

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -24,7 +24,6 @@ from typing import (
     Iterator,
     NamedTuple,
     NoReturn,
-    Optional,
     Sequence,
     TypeVar,
     overload,
@@ -124,10 +123,10 @@ ASYNC_RETRY_PATTERN = [1, 1, 2, 3, 4, 8, 10]
 class ResultMetadata(NamedTuple):
     name: str
     type_code: int
-    display_size: Optional[int]
-    internal_size: Optional[int]
-    precision: Optional[int]
-    scale: Optional[int]
+    display_size: int | None
+    internal_size: int | None
+    precision: int | None
+    scale: int | None
     is_nullable: bool
 
     @classmethod


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1423

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   type ResultMetaData fields as optional where they can be `None` 
