### PR TITLE
SNOW-733835 fix AuthByIdToken expired token auth

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Improved the robustness of OCSP response caching to handle errors in cases of serialization and deserialization.
   - Fixed a bug where `AuthByKeyPair.handle_timeout` should pass keyword arguments instead of positional arguments when calling `AuthByKeyPair.prepare`. PR #1440 (@emilhe)
+  - Fixed a bug where MFA token caching would refuse to work until restarted instead of reauthenticating
 
 - v3.0.0(January 26, 2023)
 

--- a/src/snowflake/connector/auth/__init__.py
+++ b/src/snowflake/connector/auth/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from ._auth import Auth, get_public_key_fingerprint, get_token_from_private_key
 from .by_plugin import AuthByPlugin, AuthType
 from .default import AuthByDefault
+from .idtoken import AuthByIdToken
 from .keypair import AuthByKeyPair
 from .oauth import AuthByOAuth
 from .okta import AuthByOkta
@@ -21,6 +22,7 @@ FIRST_PARTY_AUTHENTICATORS = frozenset(
         AuthByOkta,
         AuthByUsrPwdMfa,
         AuthByWebBrowser,
+        AuthByIdToken,
     )
 )
 

--- a/src/snowflake/connector/auth/idtoken.py
+++ b/src/snowflake/connector/auth/idtoken.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from ..network import ID_TOKEN_AUTHENTICATOR
-from . import AuthByWebBrowser
 from .by_plugin import AuthByPlugin, AuthType
+from .webbrowser import AuthByWebBrowser
 
 if TYPE_CHECKING:
     from ..connection import SnowflakeConnection

--- a/src/snowflake/connector/auth/idtoken.py
+++ b/src/snowflake/connector/auth/idtoken.py
@@ -5,10 +5,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..network import ID_TOKEN_AUTHENTICATOR
+from . import AuthByWebBrowser
 from .by_plugin import AuthByPlugin, AuthType
+
+if TYPE_CHECKING:
+    from ..connection import SnowflakeConnection
 
 
 class AuthByIdToken(AuthByPlugin):
@@ -25,10 +29,21 @@ class AuthByIdToken(AuthByPlugin):
     def assertion_content(self) -> str:
         return self._id_token
 
-    def __init__(self, id_token: str) -> None:
+    def __init__(
+        self,
+        id_token: str,
+        application: str,
+        protocol: str | None,
+        host: str | None,
+        port: str | None,
+    ) -> None:
         """Initialized an instance with an IdToken."""
         super().__init__()
         self._id_token: str | None = id_token
+        self._application = application
+        self._protocol = protocol
+        self._host = host
+        self._port = port
 
     def reset_secrets(self) -> None:
         self._id_token = None
@@ -36,8 +51,21 @@ class AuthByIdToken(AuthByPlugin):
     def prepare(self, **kwargs: Any) -> None:
         pass
 
-    def reauthenticate(self, **kwargs: Any) -> dict[str, bool]:
-        return {"success": False}
+    def reauthenticate(
+        self,
+        *,
+        conn: SnowflakeConnection,
+        **kwargs: Any,
+    ) -> dict[str, bool]:
+        conn.auth_class = AuthByWebBrowser(
+            application=self._application,
+            protocol=self._protocol,
+            host=self._host,
+            port=self._port,
+        )
+        conn._authenticate(conn.auth_class)
+        conn._auth_class.reset_secrets()
+        return {"success": True}
 
     def update_body(self, body: dict[Any, Any]) -> None:
         """Idtoken needs the authenticator and token attributes set."""

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -351,6 +351,7 @@ class SnowflakeConnection:
         warnings.warn(
             "Region has been deprecated and will be removed in the near future",
             PendingDeprecationWarning,
+            # Raise warning from where this property was called from
             stacklevel=2,
         )
         return self._region
@@ -874,6 +875,7 @@ class SnowflakeConnection:
                         "'{}' is an unknown connection parameter{}".format(
                             name, f", did you mean '{guess}'?" if guess else ""
                         ),
+                        # Raise warning from where class was initiated
                         stacklevel=4,
                     )
                 elif not isinstance(value, DEFAULT_CONFIGURATION[name][1]):
@@ -888,6 +890,7 @@ class SnowflakeConnection:
                             else accepted_types.__name__,
                             type(value).__name__,
                         ),
+                        # Raise warning from where class was initiated
                         stacklevel=4,
                     )
             setattr(self, "_" + name, value)

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -351,6 +351,7 @@ class SnowflakeConnection:
         warnings.warn(
             "Region has been deprecated and will be removed in the near future",
             PendingDeprecationWarning,
+            stacklevel=2,
         )
         return self._region
 
@@ -872,7 +873,8 @@ class SnowflakeConnection:
                     warnings.warn(
                         "'{}' is an unknown connection parameter{}".format(
                             name, f", did you mean '{guess}'?" if guess else ""
-                        )
+                        ),
+                        stacklevel=4,
                     )
                 elif not isinstance(value, DEFAULT_CONFIGURATION[name][1]):
                     accepted_types = DEFAULT_CONFIGURATION[name][1]
@@ -885,7 +887,8 @@ class SnowflakeConnection:
                             if isinstance(accepted_types, tuple)
                             else accepted_types.__name__,
                             type(value).__name__,
-                        )
+                        ),
+                        stacklevel=4,
                     )
             setattr(self, "_" + name, value)
 

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import pytest
 
 from snowflake.connector import SnowflakeConnection
-from snowflake.connector.auth.idtoken import AuthByIdToken
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
 from snowflake.connector.network import (
@@ -290,6 +289,8 @@ def test_idtoken_reauth():
     This happens when the initial connection fails. Such as when the saved ID
     token has expired.
     """
+    from snowflake.connector.auth.idtoken import AuthByIdToken
+
     auth_inst = AuthByIdToken(
         id_token="token",
         application="application",

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -5,13 +5,20 @@
 
 from __future__ import annotations
 
+from unittest import mock
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
 
+from snowflake.connector import SnowflakeConnection
+from snowflake.connector.auth.idtoken import AuthByIdToken
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
-from snowflake.connector.network import EXTERNAL_BROWSER_AUTHENTICATOR, SnowflakeRestful
+from snowflake.connector.network import (
+    EXTERNAL_BROWSER_AUTHENTICATOR,
+    ReauthenticationRequest,
+    SnowflakeRestful,
+)
 
 try:  # pragma: no cover
     from snowflake.connector.auth import AuthByWebBrowser
@@ -275,3 +282,38 @@ def _init_rest(ref_sso_url, ref_proof_key, success=True, message=None):
     rest._post_request = post_request
     connection._rest = rest
     return rest
+
+
+def test_idtoken_reauth():
+    """This test makes sure that AuthByIdToken reverts to AuthByWebBrowser.
+
+    This happens when the initial connection fails. Such as when the saved ID
+    token has expired.
+    """
+    auth_inst = AuthByIdToken(
+        id_token="token",
+        application="application",
+        protocol="protocol",
+        host="host",
+        port="port",
+    )
+
+    # We'll use this Exception to make sure AuthByWebBrowser authentication
+    #  flow is called as expected
+    class StopExecuting(Exception):
+        pass
+
+    with mock.patch(
+        "snowflake.connector.auth.idtoken.AuthByIdToken.prepare",
+        side_effect=ReauthenticationRequest(Exception()),
+    ):
+        with mock.patch(
+            "snowflake.connector.auth.webbrowser.AuthByWebBrowser.prepare",
+            side_effect=StopExecuting(),
+        ):
+            with pytest.raises(StopExecuting):
+                SnowflakeConnection(
+                    user="user",
+                    account="account",
+                    auth_class=auth_inst,
+                )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-733835
2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We made a bug when we introduced custom auth to the connector. When an ID token expires in storage (i.e. keychain in MacOS) then when we fail to connect we remove the expired token from storage and then propagate the Exception instead of initiating a new externalbrowser auth. In this PR I fix this bug 