### PR TITLE
Replace runtime dependency on setuptools with modern libraries

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.0.1(unreleased)
 
   - Improved the robustness of OCSP response caching to handle errors in cases of serialization and deserialization.
+  - Replaced dependency on setuptools in favor of packaging
 
 - v3.0.0(January 26, 2023)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,8 @@ install_requires =
     pyjwt<3.0.0
     pytz
     requests<3.0.0
-    setuptools>34.0.0
+    importlib-metadata; python_version < '3.8'
+    packaging
     charset_normalizer>=2,<3
     idna>=2.5,<4
     urllib3>=1.21.1,<1.27

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -84,19 +84,29 @@ def _import_or_missing_pandas_option() -> tuple[
 
         pyarrow = importlib.import_module("pyarrow")
         # Check whether we have the currently supported pyarrow installed
-        installed_packages = {package.metadata["Name"]: package for package in distributions()}
-        if all(k in installed_packages for k in ("snowflake-connector-python", "pyarrow")):
-            dependencies = installed_packages["snowflake-connector-python"].metadata.get_all("Requires-Dist", [])
+        installed_packages = {
+            package.metadata["Name"]: package for package in distributions()
+        }
+        if {"pyarrow", "snowflake-connector-python"} <= installed_packages.keys():
+            dependencies = installed_packages[
+                "snowflake-connector-python"
+            ].metadata.get_all("Requires-Dist", [])
             pandas_pyarrow_extra = None
             for dependency in dependencies:
                 dep = Requirement(dependency)
-                if dep.marker is not None and dep.marker.evaluate({"extra": "pandas"}) and dep.name == "pyarrow":
+                if (
+                    dep.marker is not None
+                    and dep.marker.evaluate({"extra": "pandas"})
+                    and dep.name == "pyarrow"
+                ):
                     pandas_pyarrow_extra = dep
                     break
 
             installed_pyarrow_version = installed_packages["pyarrow"].version
             if not pandas_pyarrow_extra.specifier.contains(installed_pyarrow_version):
-                warn_incompatible_dep("pyarrow", installed_pyarrow_version, pandas_pyarrow_extra)
+                warn_incompatible_dep(
+                    "pyarrow", installed_pyarrow_version, pandas_pyarrow_extra
+                )
 
         else:
             logger.info(

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -5,14 +5,20 @@
 from __future__ import annotations
 
 import importlib
+import sys
 import warnings
 from logging import getLogger
 from types import ModuleType
 from typing import Union
 
-import pkg_resources
+from packaging.requirements import Requirement
 
 from . import errors
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import distributions
+else:
+    from importlib_metadata import distributions
 
 logger = getLogger(__name__)
 
@@ -54,7 +60,7 @@ ModuleLikeObject = Union[ModuleType, MissingOptionalDependency]
 
 
 def warn_incompatible_dep(
-    dep_name: str, installed_ver: str, expected_ver: pkg_resources.Requirement
+    dep_name: str, installed_ver: str, expected_ver: Requirement
 ) -> None:
     warnings.warn(
         "You have an incompatible version of '{}' installed ({}), please install a version that "
@@ -78,31 +84,24 @@ def _import_or_missing_pandas_option() -> tuple[
 
         pyarrow = importlib.import_module("pyarrow")
         # Check whether we have the currently supported pyarrow installed
-        installed_packages = pkg_resources.working_set.by_key
-        if all(
-            k in installed_packages for k in ("snowflake-connector-python", "pyarrow")
-        ):
-            _pandas_extras = installed_packages["snowflake-connector-python"]._dep_map[
-                "pandas"
-            ]
-            _expected_pyarrow_version = [
-                dep for dep in _pandas_extras if dep.name == "pyarrow"
-            ][0]
-            _installed_pyarrow_version = installed_packages["pyarrow"]
-            if (
-                _installed_pyarrow_version
-                and _installed_pyarrow_version.version not in _expected_pyarrow_version
-            ):
-                warn_incompatible_dep(
-                    "pyarrow",
-                    _installed_pyarrow_version.version,
-                    _expected_pyarrow_version,
-                )
+        installed_packages = {package.metadata["Name"]: package for package in distributions()}
+        if all(k in installed_packages for k in ("snowflake-connector-python", "pyarrow")):
+            dependencies = installed_packages["snowflake-connector-python"].metadata.get_all("Requires-Dist", [])
+            pandas_pyarrow_extra = None
+            for dependency in dependencies:
+                dep = Requirement(dependency)
+                if dep.marker is not None and dep.marker.evaluate({"extra": "pandas"}) and dep.name == "pyarrow":
+                    pandas_pyarrow_extra = dep
+                    break
+
+            installed_pyarrow_version = installed_packages["pyarrow"].version
+            if not pandas_pyarrow_extra.specifier.contains(installed_pyarrow_version):
+                warn_incompatible_dep("pyarrow", installed_pyarrow_version, pandas_pyarrow_extra)
 
         else:
             logger.info(
                 "Cannot determine if compatible pyarrow is installed because of missing package(s) from "
-                "{}".format(installed_packages.keys())
+                "{}".format(list(installed_packages.keys()))
             )
         return pandas, pyarrow, True
     except ImportError:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1447

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The logic to detect incompatible versions of PyArrow now uses the standard library (on Python >3.7) and the fundamental library `packaging`.