### PR TITLE
Mask JWT tokens in logs in case of post-auth errors

### DIFF
--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -981,11 +981,12 @@ class SnowflakeRestful:
         """Handles unknown errors."""
         if data:
             try:
+                # masking the secret credentials
                 decoded_data = json.loads(data)
-                if decoded_data.get("data") and decoded_data["data"].get("PASSWORD"):
-                    # masking the password
-                    decoded_data["data"]["PASSWORD"] = "********"
-                    data = json.dumps(decoded_data)
+                for secret_name in ("PASSWORD", "TOKEN"):
+                    if decoded_data.get("data") and decoded_data["data"].get(secret_name):
+                        decoded_data["data"][secret_name] = "********"
+                        data = json.dumps(decoded_data)
             except Exception:
                 logger.info("data is not JSON")
         logger.error(


### PR DESCRIPTION
The JWT tokens are valid for 1 minute, but still can be enough to steal the tokens from logs (if a hacker has access to the log stream or the log service) and use the token to access the data, potentially to change the user's credentials — if done in an automated way.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1454

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

In case of a key-pair authentication and networking/connectivity issues, the JWT token is leaked to logs. Although the JWT tokens are valid for 1 minute, this can be enough for a hacker who can sneak into the log stream (or a log service) to access the data and potentially modify the user's credentials.

Currently (as of 3.0.1), the `PASSWORD` field of the Snowflake data is redacted before going to logs, but the `TOKEN` field is not. This PR also redacts the `TOKEN` field.

I saw there is also some `SecretDetector` class with string-to-string filtering. But it is used mostly for telemetry. I am not sure it is worth using in the error handling — especially since it processes the dicts there.

**TODO for maintainers:** However, please double-check that the same JWT tokens do not leak via the telemetry code hiddenly.