### PR TITLE
SNOW-751214 pin tox<4 temporarily

### DIFF
--- a/ci/test_windows.bat
+++ b/ci/test_windows.bat
@@ -36,7 +36,7 @@ if %errorlevel% neq 0 goto :error
 call %venv_dir%\scripts\activate
 if %errorlevel% neq 0 goto :error
 
-python -m pip install -U pip tox tox-external-wheels
+python -m pip install -U pip "tox<4" tox-external-wheels
 if %errorlevel% neq 0 goto :error
 
 cd %CONNECTOR_DIR%


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Relates to the new 3.0.1 release. SNOW-751214 is used to track this

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `tox-external-wheels` uses the internals of `tox` which have changed in version 4 and above. We need to fully switch away from it before we can use the newest versions everywhere.
   See that this PR fixes tests:
   37: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector37-Win/545/
   38: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector38-Win/436/ 
   39: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector39-Win/370/
   310: https://jenkins.int.snowflakecomputing.com/job/RT-PyConnector310-Win/67/
   311: 