### PR TITLE
Revert "Bump pypa/cibuildwheel from 2.11.4 to 2.12.0 (#1400)"

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -100,7 +100,7 @@ jobs:
           platforms: all
       - uses: actions/checkout@v3
       - name: Building wheel
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BUILD: cp${{ env.shortver }}-${{ matrix.os.id }}
           MACOSX_DEPLOYMENT_TARGET: 10.14  # Should be kept in sync with ci/build_darwin.sh


### PR DESCRIPTION
This reverts commit f3ab69e8117c7c8d47dee33e4f693a7f6cff330f.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In an effort to debug what's causing #1452 we are testing whether the `cibuildwheel` `2.11.4` -> `2.12.0` update caused the issue.