### PR TITLE
SNOW-752200 reverting incorrect type-hint changes

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1205,7 +1205,7 @@ class SnowflakeCursor:
         except StopIteration:
             return None
 
-    def fetchmany(self, size: int | None = None) -> list[dict | tuple | None]:
+    def fetchmany(self, size: int | None = None) -> list[tuple] | list[dict]:
         """Fetches the number of specified rows."""
         if size is None:
             size = self.arraysize
@@ -1231,7 +1231,7 @@ class SnowflakeCursor:
 
         return ret
 
-    def fetchall(self) -> list[dict | tuple | None]:
+    def fetchall(self) -> list[tuple] | list[dict]:
         """Fetches all of the results."""
         ret = []
         while True:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-752200
   Fixes #1464

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   There's no testing for this, `mypy` isn't covering `cursor.py` yet. However; the old type-hints were manually written by me and I suspect it was overwritten by an automated tool in https://github.com/snowflakedb/snowflake-connector-python/commit/eee76d15c6d957f1683440f2152eeabd518ce814.