### PR TITLE
SNOW-749141: Fix uploading a file > 200M when the same filename already exists in a stage

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,7 +10,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.0.2(Unreleased)
 
-  - Fixed a memory leak in the logging module of the Cython extension
+  - Fixed a memory leak in the logging module of the Cython extension.
+  - Fixed a bug where the `put` command on AWS raised `AttributeError` when the file size was larger than 200M.
 
 - v3.0.1(February 28, 2023)
 

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -185,7 +185,7 @@ class SnowflakeStorageClient(ABC):
     def preprocess(self) -> None:
         meta = self.meta
         logger.debug(f"Preprocessing {meta.src_file_name}")
-
+        self.get_digest()
         if not meta.overwrite:
             self.get_file_header(meta.dst_file_name)  # Check if file exists on remote
             if meta.result_status == ResultStatus.UPLOADED:
@@ -201,7 +201,6 @@ class SnowflakeStorageClient(ABC):
         # Uploading
         if meta.require_compress:
             self.compress()
-        self.get_digest()
 
         self.preprocessed = True
 

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -185,8 +185,8 @@ class SnowflakeStorageClient(ABC):
     def preprocess(self) -> None:
         meta = self.meta
         logger.debug(f"Preprocessing {meta.src_file_name}")
-        self.get_digest()
         if not meta.overwrite:
+            self.get_digest()  # self.get_file_header needs digest for multiparts upload when aws is used.
             self.get_file_header(meta.dst_file_name)  # Check if file exists on remote
             if meta.result_status == ResultStatus.UPLOADED:
                 # Skipped
@@ -201,7 +201,7 @@ class SnowflakeStorageClient(ABC):
         # Uploading
         if meta.require_compress:
             self.compress()
-
+        self.get_digest()
         self.preprocessed = True
 
     def prepare_upload(self) -> None:

--- a/test/integ/test_large_put.py
+++ b/test/integ/test_large_put.py
@@ -61,12 +61,13 @@ ratio number(6,2))
                 )
                 assert mocked_file_agent.agent._multipart_threshold == 10000
 
-                # Upload again. There was a bug when a large file is uploaded again while it aready exists in a stage.
+                # Upload again. There was a bug when a large file is uploaded again while it already exists in a stage.
                 # Refer to preprocess(self) of storage_client.py.
                 # self.get_digest() needs to be called before self.get_file_header(meta.dst_file_name)
+                # SNOW-749141
                 cnx.cursor().execute(
                     f"put 'file://{files}' @%{db_parameters['name']} auto_compress=False",
-                )
+                )  # do not add `overwrite=True` because overwrite will skip the code path to extract file header.
 
             c = cnx.cursor()
             try:

--- a/test/integ/test_large_put.py
+++ b/test/integ/test_large_put.py
@@ -56,6 +56,14 @@ ratio number(6,2))
                 "snowflake.connector.cursor.SnowflakeFileTransferAgent",
                 side_effect=mocked_file_agent,
             ):
+                # upload with auto compress = True
+                cnx.cursor().execute(
+                    f"put 'file://{files}' @%{db_parameters['name']} auto_compress=True",
+                )
+                assert mocked_file_agent.agent._multipart_threshold == 10000
+                cnx.cursor().execute(f"remove @%{db_parameters['name']}")
+
+                # upload with auto compress = False
                 cnx.cursor().execute(
                     f"put 'file://{files}' @%{db_parameters['name']} auto_compress=False",
                 )
@@ -63,7 +71,7 @@ ratio number(6,2))
 
                 # Upload again. There was a bug when a large file is uploaded again while it already exists in a stage.
                 # Refer to preprocess(self) of storage_client.py.
-                # self.get_digest() needs to be called before self.get_file_header(meta.dst_file_name)
+                # self.get_digest() needs to be called before self.get_file_header(meta.dst_file_name).
                 # SNOW-749141
                 cnx.cursor().execute(
                     f"put 'file://{files}' @%{db_parameters['name']} auto_compress=False",

--- a/test/integ/test_large_put.py
+++ b/test/integ/test_large_put.py
@@ -57,9 +57,16 @@ ratio number(6,2))
                 side_effect=mocked_file_agent,
             ):
                 cnx.cursor().execute(
-                    f"put 'file://{files}' @%{db_parameters['name']}",
+                    f"put 'file://{files}' @%{db_parameters['name']} auto_compress=False",
                 )
                 assert mocked_file_agent.agent._multipart_threshold == 10000
+
+                # Upload again. There was a bug when a large file is uploaded again while it aready exists in a stage.
+                # Refer to preprocess(self) of storage_client.py.
+                # self.get_digest() needs to be called before self.get_file_header(meta.dst_file_name)
+                cnx.cursor().execute(
+                    f"put 'file://{files}' @%{db_parameters['name']} auto_compress=False",
+                )
 
             c = cnx.cursor()
             try:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-749141. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
Call get_digest even when the file already exists on a stage. The current code skips calling get_digest so the digest is None.