### PR TITLE
SNOW-733718 Fix remove_comments when comments are at end of line

### DIFF
--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -146,6 +146,8 @@ def split_statements(
                     if not remove_comments:
                         # keep the comment
                         statement.append((line[col:], False))
+                    else:
+                        statement.append(("\n", True))
                     col = len_line + 1
                     col0 = col
                 elif line[col:].startswith("/*") and not line[col0:].startswith(


### PR DESCRIPTION
Description

Before the fix, the remove_comments operation will swallow the final line break, which breaks user query if there is no spaces between two lines.

Testing

Added a new unit test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-733718

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
