### PR TITLE
Add support for specifying 'RSAPublicKey' instance instead of raw bytes

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.1.1(TBD)
+
+  - Support `RSAPublicKey` when constructing `AuthByKeyPair` in addition to raw bytes.
+
 - v3.1.0(July 31,2023)
 
   - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, for example, if you wanted to define a connection named `prod``:

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -127,7 +127,9 @@ class AuthByKeyPair(AuthByPlugin):
         elif isinstance(self._private_key, RSAPrivateKey):
             private_key = self._private_key
         else:
-            raise TypeError(f"Expected bytes or RSAPrivateKey, got {type(self._private_key)}")
+            raise TypeError(
+                f"Expected bytes or RSAPrivateKey, got {type(self._private_key)}"
+            )
 
         public_key_fp = self.calculate_public_key_fingerprint(private_key)
 

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -129,8 +129,7 @@ class AuthByKeyPair(AuthByPlugin):
         else:
             raise TypeError(self._private_key)
 
-        public_key = private_key.public_key()
-        public_key_fp = self.calculate_public_key_fingerprint(public_key)
+        public_key_fp = self.calculate_public_key_fingerprint(private_key)
 
         self._jwt_token_exp = now + self._lifetime
         payload = {
@@ -155,9 +154,9 @@ class AuthByKeyPair(AuthByPlugin):
         return {"success": False}
 
     @staticmethod
-    def calculate_public_key_fingerprint(public_key):
+    def calculate_public_key_fingerprint(private_key):
         # get public key bytes
-        public_key_der = public_key.public_bytes(
+        public_key_der = private_key.public_key().public_bytes(
             Encoding.DER, PublicFormat.SubjectPublicKeyInfo
         )
 

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -127,7 +127,7 @@ class AuthByKeyPair(AuthByPlugin):
         elif isinstance(self._private_key, RSAPrivateKey):
             private_key = self._private_key
         else:
-            raise TypeError(self._private_key)
+            raise TypeError(f"Expected bytes or RSAPrivateKey, got {type(self._private_key)}")
 
         public_key_fp = self.calculate_public_key_fingerprint(private_key)
 

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -47,17 +47,18 @@ class AuthByKeyPair(AuthByPlugin):
 
     def __init__(
         self,
-        private_key: bytes,
+        private_key: bytes | RSAPrivateKey,
         lifetime_in_seconds: int = LIFETIME,
     ) -> None:
         """Inits AuthByKeyPair class with private key.
 
         Args:
-            private_key: a byte array of der formats of private key
+            private_key: a byte array of der formats of private key, or an
+                object that implements the `RSAPrivateKey` interface.
             lifetime_in_seconds: number of seconds the JWT token will be valid
         """
         super().__init__()
-        self._private_key: bytes | None = private_key
+        self._private_key: bytes | RSAPrivateKey | None = private_key
         self._jwt_token = ""
         self._jwt_token_exp = 0
         self._lifetime = timedelta(
@@ -102,28 +103,32 @@ class AuthByKeyPair(AuthByPlugin):
 
         now = datetime.utcnow()
 
-        try:
-            private_key = load_der_private_key(
-                data=self._private_key,
-                password=None,
-                backend=default_backend(),
-            )
-        except Exception as e:
-            raise ProgrammingError(
-                msg=f"Failed to load private key: {e}\nPlease provide a valid "
-                "unencrypted rsa private key in DER format as bytes object",
-                errno=ER_INVALID_PRIVATE_KEY,
-            )
+        if isinstance(self._private_key, bytes):
+            try:
+                private_key = load_der_private_key(
+                    data=self._private_key,
+                    password=None,
+                    backend=default_backend(),
+                )
+            except Exception as e:
+                raise ProgrammingError(
+                    msg=f"Failed to load private key: {e}\nPlease provide a valid "
+                    "unencrypted rsa private key in DER format as bytes object",
+                    errno=ER_INVALID_PRIVATE_KEY,
+                )
 
-        if not isinstance(private_key, RSAPrivateKey):
-            raise ProgrammingError(
-                msg=f"Private key type ({private_key.__class__.__name__}) not supported."
-                "\nPlease provide a valid rsa private key in DER format as bytes "
-                "object",
-                errno=ER_INVALID_PRIVATE_KEY,
-            )
+            if not isinstance(private_key, RSAPrivateKey):
+                raise ProgrammingError(
+                    msg=f"Private key type ({private_key.__class__.__name__}) not supported."
+                    "\nPlease provide a valid rsa private key in DER format as bytes "
+                    "object",
+                    errno=ER_INVALID_PRIVATE_KEY,
+                )
+        else:
+            private_key = self._private_key
 
-        public_key_fp = self.calculate_public_key_fingerprint(private_key)
+        public_key = private_key.public_key()
+        public_key_fp = self.calculate_public_key_fingerprint(public_key)
 
         self._jwt_token_exp = now + self._lifetime
         payload = {
@@ -148,9 +153,9 @@ class AuthByKeyPair(AuthByPlugin):
         return {"success": False}
 
     @staticmethod
-    def calculate_public_key_fingerprint(private_key):
+    def calculate_public_key_fingerprint(public_key):
         # get public key bytes
-        public_key_der = private_key.public_key().public_bytes(
+        public_key_der = public_key.public_bytes(
             Encoding.DER, PublicFormat.SubjectPublicKeyInfo
         )
 

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -124,8 +124,10 @@ class AuthByKeyPair(AuthByPlugin):
                     "object",
                     errno=ER_INVALID_PRIVATE_KEY,
                 )
-        else:
+        elif isinstance(self._private_key, RSAPrivateKey):
             private_key = self._private_key
+        else:
+            raise TypeError(self._private_key)
 
         public_key = private_key.public_key()
         public_key_fp = self.calculate_public_key_fingerprint(public_key)

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -25,6 +25,8 @@ from types import TracebackType
 from typing import Any, Callable, Generator, Iterable, NamedTuple, Sequence
 from uuid import UUID
 
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
 from . import errors, proxy
 from ._query_context_cache import QueryContextCache
 from .auth import (
@@ -146,7 +148,7 @@ DEFAULT_CONFIGURATION: dict[str, tuple[Any, type | tuple[type, ...]]] = {
     ),  # network timeout (infinite by default)
     "passcode_in_password": (False, bool),  # Snowflake MFA
     "passcode": (None, (type(None), str)),  # Snowflake MFA
-    "private_key": (None, (type(None), str)),
+    "private_key": (None, (type(None), str, RSAPrivateKey)),
     "token": (None, (type(None), str)),  # OAuth or JWT Token
     "authenticator": (DEFAULT_AUTHENTICATOR, (type(None), str)),
     "mfa_callback": (None, (type(None), Callable)),

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -248,8 +248,6 @@ def test_bad_private_key(db_parameters):
     )
 
     bad_private_key_test_cases = [
-        "abcd",
-        1234,
         b"abcd",
         dsa_private_key_der,
         encrypted_rsa_private_key_der,

--- a/test/unit/test_auth_keypair.py
+++ b/test/unit/test_auth_keypair.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, Mock, PropertyMock
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.serialization import load_der_private_key
 
 from snowflake.connector.auth import Auth
 from snowflake.connector.constants import OCSPMode
@@ -42,6 +44,39 @@ def test_auth_keypair():
     account = "testaccount"
     user = "testuser"
     auth_instance = AuthByKeyPair(private_key=private_key_der)
+    auth_instance.handle_timeout(
+        authenticator="SNOWFLAKE_JWT",
+        service_name=None,
+        account=account,
+        user=user,
+        password=None,
+    )
+
+    # success test case
+    rest = _init_rest(application, _create_mock_auth_keypair_rest_response())
+    auth = Auth(rest)
+    auth.authenticate(auth_instance, account, user)
+    assert not rest._connection.errorhandler.called  # not error
+    assert rest.token == "TOKEN"
+    assert rest.master_token == "MASTER_TOKEN"
+
+
+def test_auth_keypair_abc():
+    """Simple Key Pair test using abstraction layer."""
+    private_key_der, public_key_der_encoded = generate_key_pair(2048)
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+
+    private_key = load_der_private_key(
+        data=private_key_der,
+        password=None,
+        backend=default_backend(),
+    )
+
+    assert isinstance(private_key, RSAPrivateKey)
+
+    auth_instance = AuthByKeyPair(private_key=private_key)
     auth_instance.handle_timeout(
         authenticator="SNOWFLAKE_JWT",
         service_name=None,

--- a/test/unit/test_auth_keypair.py
+++ b/test/unit/test_auth_keypair.py
@@ -103,16 +103,17 @@ def test_auth_keypair_bad_type():
     class Bad:
         pass
 
-    auth_instance = AuthByKeyPair(private_key=Bad())
-    with raises(TypeError) as ex:
-        auth_instance.handle_timeout(
-            authenticator="SNOWFLAKE_JWT",
-            service_name=None,
-            account=account,
-            user=user,
-            password=None,
-        )
-    assert "Bad" in str(ex)
+    for bad_private_key in ("abcd", 1234, Bad()):
+        auth_instance = AuthByKeyPair(private_key=bad_private_key)
+        with raises(TypeError) as ex:
+            auth_instance.handle_timeout(
+                authenticator="SNOWFLAKE_JWT",
+                service_name=None,
+                account=account,
+                user=user,
+                password=None,
+            )
+        assert str(type(bad_private_key)) in str(ex)
 
 
 def _init_rest(application, post_requset):

--- a/test/unit/test_auth_keypair.py
+++ b/test/unit/test_auth_keypair.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from pytest import raises
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 from cryptography.hazmat.backends import default_backend
@@ -13,6 +12,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import load_der_private_key
+from pytest import raises
 
 from snowflake.connector.auth import Auth
 from snowflake.connector.constants import OCSPMode
@@ -99,8 +99,10 @@ def test_auth_keypair_bad_type():
     """Simple Key Pair test using abstraction layer."""
     account = "testaccount"
     user = "testuser"
+
     class Bad:
         pass
+
     auth_instance = AuthByKeyPair(private_key=Bad())
     with raises(TypeError) as ex:
         auth_instance.handle_timeout(
@@ -110,7 +112,7 @@ def test_auth_keypair_bad_type():
             user=user,
             password=None,
         )
-    assert 'Bad' in str(ex)
+    assert "Bad" in str(ex)
 
 
 def _init_rest(application, post_requset):

--- a/test/unit/test_auth_keypair.py
+++ b/test/unit/test_auth_keypair.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from pytest import raises
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 from cryptography.hazmat.backends import default_backend
@@ -92,6 +93,24 @@ def test_auth_keypair_abc():
     assert not rest._connection.errorhandler.called  # not error
     assert rest.token == "TOKEN"
     assert rest.master_token == "MASTER_TOKEN"
+
+
+def test_auth_keypair_bad_type():
+    """Simple Key Pair test using abstraction layer."""
+    account = "testaccount"
+    user = "testuser"
+    class Bad:
+        pass
+    auth_instance = AuthByKeyPair(private_key=Bad())
+    with raises(TypeError) as ex:
+        auth_instance.handle_timeout(
+            authenticator="SNOWFLAKE_JWT",
+            service_name=None,
+            account=account,
+            user=user,
+            password=None,
+        )
+    assert 'Bad' in str(ex)
 
 
 def _init_rest(application, post_requset):


### PR DESCRIPTION
This can be used to externalize the JWT encoding process (see linked issue for motivation and details).

For further motivation, see https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/ – managed keys (software- or hardware protected) are the answer to this problem.

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1276.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This change makes use of the fact that `RSAPrivateKey` is already an interface (ABC) and the [JWT library](https://pypi.org/project/jwt/) is fully compatible with a custom implementation, for example one that externalizes the signing process to a cloud-based service such as Azure Key Vault.

   Note that we do not provide any implementations of this interface, nor any new dependencies.
