### PR TITLE
SNOW-761669: fix memory leak in c logging

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.0.2(Unreleased)
+
+  - Fixed a memory leak in the logging module of the Cython extension
+
 - v3.0.1(February 28, 2023)
 
   - Improved the robustness of OCSP response caching to handle errors in cases of serialization and deserialization.

--- a/src/snowflake/connector/cpp/Logging/logging.cpp
+++ b/src/snowflake/connector/cpp/Logging/logging.cpp
@@ -46,11 +46,17 @@ void Logger::log(int level, const char *path_name, const char *func_name, int li
   py::UniqueRef call_log(PyObject_GetAttrString(logger, "log"));
 
   // prepare keyword args for snow_logger
-  PyDict_SetItemString(keywords.get(), "level", Py_BuildValue("i", level));
-  PyDict_SetItemString(keywords.get(), "path_name", Py_BuildValue("s", path_name));
-  PyDict_SetItemString(keywords.get(), "func_name", Py_BuildValue("s", func_name));
-  PyDict_SetItemString(keywords.get(), "line_num", Py_BuildValue("i", line_num));
-  PyDict_SetItemString(keywords.get(), "msg", Py_BuildValue("s", msg));
+  py::UniqueRef level_ref(Py_BuildValue("i", level));
+  py::UniqueRef path_name_ref(Py_BuildValue("s", path_name));
+  py::UniqueRef func_name_ref(Py_BuildValue("s", func_name));
+  py::UniqueRef line_num_ref(Py_BuildValue("i", line_num));
+  py::UniqueRef msg_ref(Py_BuildValue("s", msg));
+
+  PyDict_SetItemString(keywords.get(), "level", level_ref.get());
+  PyDict_SetItemString(keywords.get(), "path_name", path_name_ref.get());
+  PyDict_SetItemString(keywords.get(), "func_name", func_name_ref.get());
+  PyDict_SetItemString(keywords.get(), "line_num", line_num_ref.get());
+  PyDict_SetItemString(keywords.get(), "msg", msg_ref.get());
 
   // call snow_logging.SnowLogger.log()
   PyObject_Call(call_log.get(), Py_BuildValue("()"), keywords.get());

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (3, 0, 1, None)
+VERSION = (3, 0, 2, None)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-761669

we have encountered the same memleak issue before: https://github.com/snowflakedb/snowflake/pull/8226/files

root cause explained: https://stackoverflow.com/questions/5508904/c-extension-in-python-return-py-buildvalue-memory-leak-problem

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
