### PR TITLE
SNOW-761004 Added URL Validator and URL escaping of strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,7 @@ repos:
                 | ssd_internal_keys
                 | test_util
                 | util_text
+                | url_util
                 | version
             ).py$
         additional_dependencies:

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Fixed a memory leak in the logging module of the Cython extension.
   - Fixed a bug where the `put` command on AWS raised `AttributeError` when the file size was larger than 200M.
+  - Validate SSO URL before accessing
+  - Add support for URL Encoding
 
 - v3.0.1(February 28, 2023)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,8 +12,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Fixed a memory leak in the logging module of the Cython extension.
   - Fixed a bug where the `put` command on AWS raised `AttributeError` when the file size was larger than 200M.
-  - Validate SSO URL before accessing
-  - Add support for URL Encoding
+  - Validate SSO URL before opening it in the browser for External browser authenticator.
+  - Add url_util module to add URL Encoding utilities.
 
 - v3.0.1(February 28, 2023)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,7 +13,6 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a memory leak in the logging module of the Cython extension.
   - Fixed a bug where the `put` command on AWS raised `AttributeError` when the file size was larger than 200M.
   - Validate SSO URL before opening it in the browser for External browser authenticator.
-  - Add url_util module to add URL Encoding utilities.
 
 - v3.0.1(February 28, 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,10 @@ try:
 
     _ABLE_TO_COMPILE_EXTENSIONS = True
 except ImportError:
-    warnings.warn("Cannot compile native C code, because of a missing build dependency")
+    warnings.warn("Cannot compile native C code, because of a missing build dependency", stacklevel=2)
     _ABLE_TO_COMPILE_EXTENSIONS = False
 
 if _ABLE_TO_COMPILE_EXTENSIONS:
-
     pyarrow_version = tuple(int(x) for x in pyarrow.__version__.split("."))
     extensions = cythonize(
         [
@@ -66,7 +65,6 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
     )
 
     class MyBuildExt(build_ext):
-
         # list of libraries that will be bundled with python connector,
         # this list should be carefully examined when pyarrow lib is
         # upgraded

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ try:
 
     _ABLE_TO_COMPILE_EXTENSIONS = True
 except ImportError:
-    warnings.warn("Cannot compile native C code, because of a missing build dependency", stacklevel=2)
+    warnings.warn(
+        "Cannot compile native C code, because of a missing build dependency",
+        stacklevel=2,
+    )
     _ABLE_TO_COMPILE_EXTENSIONS = False
 
 if _ABLE_TO_COMPILE_EXTENSIONS:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ try:
 except ImportError:
     warnings.warn(
         "Cannot compile native C code, because of a missing build dependency",
-        stacklevel=2,
+        stacklevel=1,
     )
     _ABLE_TO_COMPILE_EXTENSIONS = False
 

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import socket
 import time
 import webbrowser

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -23,6 +23,7 @@ from ..constants import (
 )
 from ..errorcode import (
     ER_IDP_CONNECTION_ERROR,
+    ER_INVALID_VALUE,
     ER_NO_HOSTNAME_FOUND,
     ER_UNABLE_TO_OPEN_BROWSER,
 )
@@ -32,6 +33,7 @@ from ..network import (
     EXTERNAL_BROWSER_AUTHENTICATOR,
     PYTHON_CONNECTOR_USER_AGENT,
 )
+from ..url_util import is_valid_url
 from . import Auth
 from .by_plugin import AuthByPlugin, AuthType
 
@@ -131,16 +133,27 @@ class AuthByWebBrowser(AuthByPlugin):
             socket_connection.listen(0)  # no backlog
             callback_port = socket_connection.getsockname()[1]
 
+            logger.debug("step 1: query GS to obtain SSO url")
+            sso_url = self._get_sso_url(
+                conn, authenticator, service_name, account, callback_port, user
+            )
+
+            logger.debug("Validate SSO URL")
+            if not is_valid_url(sso_url):
+                self._handle_failure(
+                    conn=conn,
+                    ret={
+                        "code": ER_INVALID_VALUE,
+                        "message": (f"The SSO URL provided {sso_url} is invalid"),
+                    },
+                )
+                return
+
             print(
                 "Initiating login request with your identity provider. A "
                 "browser window should have opened for you to complete the "
                 "login. If you can't see it, check existing browser windows, "
                 "or your OS settings. Press CTRL+C to abort and try again..."
-            )
-
-            logger.debug("step 1: query GS to obtain SSO url")
-            sso_url = self._get_sso_url(
-                conn, authenticator, service_name, account, callback_port, user
             )
 
             logger.debug("step 2: open a browser")

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import socket
 import time
 import webbrowser

--- a/src/snowflake/connector/snow_logging.py
+++ b/src/snowflake/connector/snow_logging.py
@@ -67,7 +67,7 @@ class SnowLogger(logging.LoggerAdapter):
         warnings.warn(
             "The 'warn' method is deprecated, " "use 'warning' instead",
             DeprecationWarning,
-            2,
+            stacklevel=2,
         )
         self.warning(msg, path_name, func_name, *args, **kwargs)
 

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -30,7 +30,7 @@ class SnowflakeURLUtil:
         Returns:
             true/ false depending on whether the URL is valid or not
         """
-        return SnowflakeURLUtil.url_validator.match(url)
+        return bool(SnowflakeURLUtil.url_validator.match(url))
 
     @staticmethod
     def url_encode_str(target: str) -> str:

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -1,18 +1,24 @@
 #
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+#
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
 from __future__ import annotations
 
-from logging import getLogger
 import re
 import urllib.parse
+from logging import getLogger
 
 logger = getLogger(__name__)
 
+
 class SnowflakeURLUtil:
     url_validator = re.compile(
-        "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$")
+        "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$"
+    )
 
     @staticmethod
     def is_valid_url(url: str) -> bool:
@@ -28,7 +34,7 @@ class SnowflakeURLUtil:
 
     @staticmethod
     def url_encode_str(target: str) -> str:
-        """ Converts a target string into escaped URL safe string
+        """Converts a target string into escaped URL safe string
 
         Args:
             target: string to be URL encoded
@@ -39,4 +45,4 @@ class SnowflakeURLUtil:
         if target is None:
             logger.debug("The string to be URL encoded is None")
             return ""
-        return urllib.parse.quote_plus(target, safe='')
+        return urllib.parse.quote_plus(target, safe="")

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def is_valid_url(url: str) -> bool:
     return bool(URL_VALIDATOR.match(url))
 
 
-def url_encode_str(target: str) -> Optional[str]:
+def url_encode_str(target: str | None) -> Optional[str]:
     """Converts a target string into escaped URL safe string
 
     Args:

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -15,31 +15,33 @@ from logging import getLogger
 logger = getLogger(__name__)
 
 
-class SnowflakeURLUtil:
-    url_validator = re.compile(
-        "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$"
-    )
+URL_VALIDATOR = re.compile(
+    "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$"
+)
 
-    @staticmethod
-    def is_valid_url(url: str) -> bool:
-        """Confirms if the provided URL is a valid HTTP/ HTTPs URL
 
-        Args:
-            url: the URL that needs to be validated
+def is_valid_url(url: str) -> bool:
+    """Confirms if the provided URL is a valid HTTP/ HTTPs URL
 
-        Returns:
-            true/ false depending on whether the URL is valid or not
-        """
-        return bool(SnowflakeURLUtil.url_validator.match(url))
+    Args:
+        url: the URL that needs to be validated
 
-    @staticmethod
-    def url_encode_str(target: str) -> str:
-        """Converts a target string into escaped URL safe string
+    Returns:
+        true/ false depending on whether the URL is valid or not
+    """
+    return bool(URL_VALIDATOR.match(url))
 
-        Args:
-            target: string to be URL encoded
 
-        Returns:
-            URL encoded string
-        """
-        return urllib.parse.quote_plus(target, safe="")
+def url_encode_str(target: str) -> str:
+    """Converts a target string into escaped URL safe string
+
+    Args:
+        target: string to be URL encoded
+
+    Returns:
+        URL encoded string
+    """
+    if target is None:
+        logger.debug("The string to be URL encoded is None")
+        return ""
+    return urllib.parse.quote_plus(target, safe="")

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -42,7 +42,4 @@ class SnowflakeURLUtil:
         Returns:
             URL encoded string
         """
-        if target is None:
-            logger.debug("The string to be URL encoded is None")
-            return ""
         return urllib.parse.quote_plus(target, safe="")

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
 #
 
-#
-# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
-#
-
 from __future__ import annotations
 
 import re

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from logging import getLogger
+import re
+import urllib.parse
+
+logger = getLogger(__name__)
+
+class SnowflakeURLUtil:
+    url_validator = re.compile(
+        "^http(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z@:])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\&\\(\\)\\/\\\\\\+&%\\$#_=@]*)?$")
+
+    @staticmethod
+    def is_valid_url(url: str) -> bool:
+        """Confirms if the provided URL is a valid HTTP/ HTTPs URL
+
+        Args:
+            url: the URL that needs to be validated
+
+        Returns:
+            true/ false depending on whether the URL is valid or not
+        """
+        return SnowflakeURLUtil.url_validator.match(url)
+
+    @staticmethod
+    def url_encode_str(target: str) -> str:
+        """ Converts a target string into escaped URL safe string
+
+        Args:
+            target: string to be URL encoded
+
+        Returns:
+            URL encoded string
+        """
+        if target is None:
+            logger.debug("The string to be URL encoded is None")
+            return ""
+        return urllib.parse.quote_plus(target, safe='')

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import re
 import urllib.parse
 from logging import getLogger
+from typing import Optional
 
 logger = getLogger(__name__)
 
@@ -28,7 +29,7 @@ def is_valid_url(url: str) -> bool:
     return bool(URL_VALIDATOR.match(url))
 
 
-def url_encode_str(target: str) -> str:
+def url_encode_str(target: str) -> Optional[str]:
     """Converts a target string into escaped URL safe string
 
     Args:

--- a/src/snowflake/connector/url_util.py
+++ b/src/snowflake/connector/url_util.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import re
 import urllib.parse
 from logging import getLogger
-from typing import Optional
 
 logger = getLogger(__name__)
 
@@ -29,7 +28,7 @@ def is_valid_url(url: str) -> bool:
     return bool(URL_VALIDATOR.match(url))
 
 
-def url_encode_str(target: str | None) -> Optional[str]:
+def url_encode_str(target: str | None) -> str:
     """Converts a target string into escaped URL safe string
 
     Args:

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -324,7 +324,6 @@ def test_idtoken_reauth():
 def test_auth_webbrowser_invalid_sso(monkeypatch):
     """Authentication by WebBrowser with failed to start web browser case."""
     rest = _init_rest(INVALID_SSO_URL, REF_PROOF_KEY)
-    ref_token = "MOCK_TOKEN"
 
     # mock webbrowser
     mock_webbrowser = MagicMock()

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -6,19 +6,19 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from snowflake.connector.url_util import SnowflakeURLUtil
+from snowflake.connector.url_util import is_valid_url, url_encode_str
 
 
 def test_url_validator():
-    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com")
-    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com:8080")
-    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com/testpathvalue")
+    assert is_valid_url("https://ssoTestURL.okta.com")
+    assert is_valid_url("https://ssoTestURL.okta.com:8080")
+    assert is_valid_url("https://ssoTestURL.okta.com/testpathvalue")
 
-    assert not SnowflakeURLUtil.is_valid_url("-a Calculator")
-    assert not SnowflakeURLUtil.is_valid_url("This is a random text")
-    assert not SnowflakeURLUtil.is_valid_url("file://TestForFile")
+    assert not is_valid_url("-a Calculator")
+    assert not is_valid_url("This is a random text")
+    assert not is_valid_url("file://TestForFile")
 
 
 def test_encoder():
-    assert SnowflakeURLUtil.url_encode_str("Hello @World") == "Hello+%40World"
-    assert SnowflakeURLUtil.url_encode_str("Test//String") == "Test%2F%2FString"
+    assert url_encode_str("Hello @World") == "Hello+%40World"
+    assert url_encode_str("Test//String") == "Test%2F%2FString"

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -1,4 +1,8 @@
 #
+# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+#
+
+#
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
@@ -16,5 +20,5 @@ def test_url_validator():
 
 
 def test_encoder():
-    assert SnowflakeURLUtil.url_encode_str('Hello @World') == 'Hello+%40World'
-    assert SnowflakeURLUtil.url_encode_str('Test//String') == 'Test%2F%2FString'
+    assert SnowflakeURLUtil.url_encode_str("Hello @World") == "Hello+%40World"
+    assert SnowflakeURLUtil.url_encode_str("Test//String") == "Test%2F%2FString"

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
 #
 
-#
-# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
-#
-
 from snowflake.connector.url_util import is_valid_url, url_encode_str
 
 

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.connector.url_util import SnowflakeURLUtil
+
+
+def test_url_validator():
+    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com")
+    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com:8080")
+    assert SnowflakeURLUtil.is_valid_url("https://ssoTestURL.okta.com/testpathvalue")
+
+    assert not SnowflakeURLUtil.is_valid_url("-a Calculator")
+    assert not SnowflakeURLUtil.is_valid_url("This is a random text")
+    assert not SnowflakeURLUtil.is_valid_url("file://TestForFile")
+
+
+def test_encoder():
+    assert SnowflakeURLUtil.url_encode_str('Hello @World') == 'Hello+%40World'
+    assert SnowflakeURLUtil.url_encode_str('Test//String') == 'Test%2F%2FString'

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2021 Snowflake Computing Inc. All rights reserved.
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
 from snowflake.connector.url_util import is_valid_url, url_encode_str

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -2,7 +2,12 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from snowflake.connector.url_util import is_valid_url, url_encode_str
+try:
+    from snowflake.connector.url_util import is_valid_url, url_encode_str
+except ImportError:
+
+    def is_valid_url(s):
+        return False
 
 
 def test_url_validator():

--- a/test/unit/test_url_util.py
+++ b/test/unit/test_url_util.py
@@ -18,3 +18,4 @@ def test_url_validator():
 def test_encoder():
     assert url_encode_str("Hello @World") == "Hello+%40World"
     assert url_encode_str("Test//String") == "Test%2F%2FString"
+    assert url_encode_str(None) == ""


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-761004

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Currently Python connector does not ensure the validity of the SSO URL and just opens it in the browser. The connector should ensure that the URL is a valid HTTP / HTTPS URL before passing it to the Browser. This PR also adds support for URL encoding strings. This will be used later for encoding Base64 OCSP requests before sending them to the OCSP Responder. 