### PR TITLE
SNOW-761256 Fix finish_download in gcs_storage_client

### DIFF
--- a/src/snowflake/connector/gcs_storage_client.py
+++ b/src/snowflake/connector/gcs_storage_client.py
@@ -217,7 +217,7 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
         # Sadly, we can only determine the src file size after we've
         # downloaded it, unlike the other cloud providers where the
         # metadata can be read beforehand.
-        self.meta.src_file_size = os.path.getsize(self.intermediate_dst_path)
+        self.meta.src_file_size = os.path.getsize(self.full_dst_file_name)
 
     def _update_presigned_url(self) -> None:
         """Updates the file metas with presigned urls if any.


### PR DESCRIPTION
Description

After super().finish_download(), self.intermediate_dst_path has either been deleted or removed. We should use the dst file name instead.

Testing

Existing test. I'm curious to learn how to test as well

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-761256

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   After super().finish_download(), self.intermediate_dst_path has either been deleted or removed. We should use the dst file name instead.
