### PR TITLE
[SNOW-773047] Fix chunk-helper, issue explicit warning for non-standard Pandas index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This should help guide contributors through potential pitfalls.
 
 ### Setup a development environment
 
-What is a development environment? It's a [virtualenv](https://virtualenv.pypa.io) that has all of neccessary
+What is a development environment? It's a [virtualenv](https://virtualenv.pypa.io) that has all of necessary
 dependencies installed with `snowflake-connector-python` installed as an editable package.
 
 Setting up a development environment is super easy with this [one simple tox command](https://tox.wiki/en/latest/example/devenv.html).

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,7 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug that prints error in logs for GET command on GCS.
   - Added a parameter that allows users to skip file uploads to stage if file exists on stage and contents of the file match.
   - Fixed a bug when writing a Pandas Dataframe with non-default index.
-  - 
+
 - v3.0.2(March 23, 2023)
 
   - Fixed a memory leak in the logging module of the Cython extension.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,9 +10,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.0.3(TBD)
 
-  - Fixed a bug that prints error in logs for GET command on GCS
+  - Fixed a bug that prints error in logs for GET command on GCS.
   - Added a parameter that allows users to skip file uploads to stage if file exists on stage and contents of the file match.
-
+  - Fixed a bug when writing a Pandas Dataframe with non-default index.
+  - 
 - v3.0.2(March 23, 2023)
 
   - Fixed a memory leak in the logging module of the Cython extension.

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -39,7 +39,7 @@ def chunk_helper(lst: pd.DataFrame, n: int) -> Iterator[tuple[int, pd.DataFrame]
         yield 0, lst
         return
     for i in range(0, len(lst), n):
-        yield int(i / n), lst.iloc[i: i + n]
+        yield int(i / n), lst.iloc[i : i + n]
 
 
 def build_location_helper(
@@ -172,11 +172,13 @@ def write_pandas(
         chunk_size = len(df)
 
     if not isinstance(df.index, pd.RangeIndex) or df.index.step != 1:
-        warnings.warn(f"Pandas Dataframe has index of type {str(type(df.index))} which will not be written."
-                      f" Consider changing the index to pd.RangeIndex(...,step=1) or "
-                      f"calling reset_index() to keep index as column(s)",
-                      UserWarning,
-                      stacklevel=2)
+        warnings.warn(
+            f"Pandas Dataframe has index of type {str(type(df.index))} which will not be written."
+            f" Consider changing the index to pd.RangeIndex(...,step=1) or "
+            f"calling reset_index() to keep index as column(s)",
+            UserWarning,
+            stacklevel=2,
+        )
 
     cursor = conn.cursor()
     stage_location = build_location_helper(

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -12,7 +12,6 @@ from logging import getLogger
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Sequence, TypeVar
 
-import pandas as pd
 from typing_extensions import Literal
 
 from snowflake.connector import ProgrammingError
@@ -33,7 +32,9 @@ T = TypeVar("T", bound=collections.abc.Sequence)
 logger = getLogger(__name__)
 
 
-def chunk_helper(lst: pd.DataFrame, n: int) -> Iterator[tuple[int, pd.DataFrame]]:
+def chunk_helper(
+    lst: pandas.DataFrame, n: int
+) -> Iterator[tuple[int, pandas.DataFrame]]:
     """Helper generator to chunk a sequence efficiently with current index like if enumerate was called on sequence."""
     if len(lst) == 0:
         yield 0, lst
@@ -171,11 +172,11 @@ def write_pandas(
     if chunk_size is None:
         chunk_size = len(df)
 
-    if not isinstance(df.index, pd.RangeIndex) or df.index.step != 1:
+    if not isinstance(df.index, pandas.RangeIndex) or df.index.step != 1:
         warnings.warn(
             f"Pandas Dataframe has index of type {str(type(df.index))} which will not be written."
             f" Consider changing the index to pd.RangeIndex(...,step=1) or "
-            f"calling reset_index() to keep index as column(s)",
+            f"call reset_index() to keep index as column(s)",
             UserWarning,
             stacklevel=2,
         )

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -172,10 +172,14 @@ def write_pandas(
     if chunk_size is None:
         chunk_size = len(df)
 
-    if not isinstance(df.index, pandas.RangeIndex) or df.index.step != 1:
+    if not (
+        isinstance(df.index, pandas.RangeIndex)
+        and 1 == df.index.step
+        and 0 == df.index.start
+    ):
         warnings.warn(
-            f"Pandas Dataframe has index of type {str(type(df.index))} which will not be written."
-            f" Consider changing the index to pd.RangeIndex(...,step=1) or "
+            f"Pandas Dataframe has non-standard index of type {str(type(df.index))} which will not be written."
+            f" Consider changing the index to pd.RangeIndex(start=0,...,step=1) or "
             f"call reset_index() to keep index as column(s)",
             UserWarning,
             stacklevel=2,

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -319,15 +319,12 @@ def test_write_non_range_index_pandas(
 
             if num_of_chunks == 1:
                 # Note: since we used one chunk order is conserved
-                assert (
-                    cnx.cursor().execute(select_sql).fetchall()
-                    == pandas_df_data
-                )
+                assert cnx.cursor().execute(select_sql).fetchall() == pandas_df_data
             else:
                 # Note: since we used more than one chunk order is NOT conserved,
                 # also the index is not stored.
                 assert set(cnx.cursor().execute(select_sql).fetchall()) == set(
-                   pandas_df_data
+                    pandas_df_data
                 )
 
             # Make sure all files were loaded and no error occurred

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING, Callable, Generator
 from unittest import mock
 
 import numpy.random
-import pandas as pd
 import pytest
 
 from snowflake.connector import DictCursor
 from snowflake.connector.errors import ProgrammingError
+from snowflake.connector.options import pandas as pd
 
 try:
     from snowflake.connector.util_text import random_string
@@ -282,11 +282,7 @@ def test_write_non_range_index_pandas(
 
     num_of_chunks = math.ceil(len(pandas_df_data) / chunk_size)
 
-    with conn_cnx(
-        user=db_parameters["user"],
-        account=db_parameters["account"],
-        password=db_parameters["password"],
-    ) as cnx:
+    with conn_cnx() as cnx:
         table_name = "driver_versions"
 
         if quote_identifiers:

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -15,7 +15,6 @@ import pytest
 
 from snowflake.connector import DictCursor
 from snowflake.connector.errors import ProgrammingError
-from snowflake.connector.options import pandas as pd
 
 try:
     from snowflake.connector.util_text import random_string
@@ -269,8 +268,8 @@ def test_write_non_range_index_pandas(
 
     # use pandas dataframe with float index
     n_rows = 17
-    pandas_df = pd.DataFrame(
-        pd.DataFrame(
+    pandas_df = pandas.DataFrame(
+        pandas.DataFrame(
             numpy.random.normal(size=(n_rows, 4)),
             columns=["a", "b", "c", "d"],
             index=numpy.random.normal(size=n_rows),

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -10,6 +10,8 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Callable, Generator
 from unittest import mock
 
+import numpy.random
+import pandas as pd
 import pytest
 
 from snowflake.connector import DictCursor
@@ -28,7 +30,6 @@ try:
 except ImportError:
     pandas = None
     write_pandas = None
-
 
 if TYPE_CHECKING:
     from snowflake.connector import SnowflakeConnection
@@ -239,6 +240,100 @@ def test_write_pandas(
             assert success
             # Make sure overall as many rows were ingested as we tried to insert
             assert nrows == len(sf_connector_version_data)
+            # Make sure we uploaded in as many chunk as we wanted to
+            assert nchunks == num_of_chunks
+            # Check to see if this is a temporary or regular table if we auto-created this table
+            if auto_create_table:
+                table_info = (
+                    cnx.cursor(DictCursor)
+                    .execute(f"show tables like '{table_name}'")
+                    .fetchall()
+                )
+                assert table_info[0]["kind"] == (
+                    "TEMPORARY" if create_temp_table else "TABLE"
+                )
+        finally:
+            cnx.execute_string(drop_sql)
+
+
+def test_write_non_range_index_pandas(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
+    db_parameters: dict[str, str],
+):
+    compression = "gzip"
+    chunk_size = 3
+    quote_identifiers: bool = False
+    auto_create_table: bool = True
+    create_temp_table: bool = False
+    index: bool = False
+
+    # use pandas dataframe with float index
+    n_rows = 17
+    pandas_df = pd.DataFrame(
+        pd.DataFrame(
+            numpy.random.normal(size=(n_rows, 4)),
+            columns=["a", "b", "c", "d"],
+            index=numpy.random.normal(size=n_rows),
+        )
+    )
+
+    # convert to list of tuples to compare to received output
+    pandas_df_data = [tuple(row) for row in list(pandas_df.values)]
+
+    num_of_chunks = math.ceil(len(pandas_df_data) / chunk_size)
+
+    with conn_cnx(
+        user=db_parameters["user"],
+        account=db_parameters["account"],
+        password=db_parameters["password"],
+    ) as cnx:
+        table_name = "driver_versions"
+
+        if quote_identifiers:
+            create_sql = 'CREATE OR REPLACE TABLE "{}" ("name" STRING, "newest_version" STRING)'.format(
+                table_name
+            )
+            select_sql = f'SELECT * FROM "{table_name}"'
+            drop_sql = f'DROP TABLE IF EXISTS "{table_name}"'
+        else:
+            create_sql = "CREATE OR REPLACE TABLE {} (name STRING, newest_version STRING)".format(
+                table_name
+            )
+            select_sql = f"SELECT * FROM {table_name}"
+            drop_sql = f"DROP TABLE IF EXISTS {table_name}"
+
+        if not auto_create_table:
+            cnx.execute_string(create_sql)
+        try:
+            success, nchunks, nrows, _ = write_pandas(
+                cnx,
+                pandas_df,
+                table_name,
+                compression=compression,
+                chunk_size=chunk_size,
+                quote_identifiers=quote_identifiers,
+                auto_create_table=auto_create_table,
+                create_temp_table=create_temp_table,
+                index=index,
+            )
+
+            if num_of_chunks == 1:
+                # Note: since we used one chunk order is conserved
+                assert (
+                    cnx.cursor().execute(select_sql).fetchall()
+                    == pandas_df_data
+                )
+            else:
+                # Note: since we used more than one chunk order is NOT conserved,
+                # also the index is not stored.
+                assert set(cnx.cursor().execute(select_sql).fetchall()) == set(
+                   pandas_df_data
+                )
+
+            # Make sure all files were loaded and no error occurred
+            assert success
+            # Make sure overall as many rows were ingested as we tried to insert
+            assert nrows == len(pandas_df_data)
             # Make sure we uploaded in as many chunk as we wanted to
             assert nchunks == num_of_chunks
             # Check to see if this is a temporary or regular table if we auto-created this table


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-773047

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding a new warning
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In pandas_tools.py write_pandas tools silently assumes a RangeIndex with step size 1 as this is the default index Pandas generates for a DataFrame. Yet, the index may contain arbitrary values. For non-integer based indices the chunk_helper utility used to write data in chunks to Snowflake uses the sequence protocol, but should use iloc instead. This PR issues a warning for any index that is not a RangeIndex with step=1, but allows to still ingest the data by dropping the index via a fixed chunk_helper.
