### PR TITLE
SNOW-779375: Fix an issue when calling write_pandas on a pandas dataframe with a column name containing double quote

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,7 +12,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Fixed a bug that prints error in logs for GET command on GCS.
   - Added a parameter that allows users to skip file uploads to stage if file exists on stage and contents of the file match.
-  - Fixed a bug when writing a Pandas Dataframe with non-default index.
+  - Fixed a bug when writing a Pandas DataFrame with non-default index in `snowflake.connector.pandas_tool.write_pandas`.
+  - Fixed a bug when writing a Pandas DataFrame with column names containing double quotes in `snowflake.connector.pandas_tool.write_pandas`.
 
 - v3.0.2(March 23, 2023)
 

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -685,7 +685,6 @@ def test_autoincrement_insertion(
             cnx.execute_string(drop_sql)
 
 
-#
 @pytest.mark.parametrize("auto_create_table", [True, False])
 @pytest.mark.parametrize(
     "column_names",

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -685,19 +685,26 @@ def test_autoincrement_insertion(
             cnx.execute_string(drop_sql)
 
 
+#
 @pytest.mark.parametrize("auto_create_table", [True, False])
+@pytest.mark.parametrize(
+    "column_names",
+    [["00 name", "bAl_ance"], ['c""ol', '"col"'], ["c''ol", "'col'"], ["チリヌル", "熊猫"]],
+)
 def test_special_name_quoting(
     conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
     auto_create_table: bool,
+    column_names: list[str],
 ):
     """Tests whether special column names get quoted as expected."""
     table_name = "users"
     df_data = [("Mark", 10), ("Luke", 20)]
 
-    df = pandas.DataFrame(df_data, columns=["00name", "bAlance"])
+    df = pandas.DataFrame(df_data, columns=column_names)
+    snowflake_column_names = [c.replace('"', '""') for c in column_names]
     create_sql = (
         f'CREATE OR REPLACE TABLE "{table_name}"'
-        '("00name" STRING, "bAlance" INT, "id" INT AUTOINCREMENT)'
+        f'("{snowflake_column_names[0]}" STRING, "{snowflake_column_names[1]}" INT, "id" INT AUTOINCREMENT)'
     )
     select_sql = f'SELECT * FROM "{table_name}"'
     drop_sql = f'DROP TABLE IF EXISTS "{table_name}"'
@@ -724,8 +731,8 @@ def test_special_name_quoting(
                 if not auto_create_table:
                     assert row["id"] in (1, 2)
                 assert (
-                    row["00name"],
-                    row["bAlance"],
+                    row[column_names[0]],
+                    row[column_names[1]],
                 ) in df_data
         finally:
             cnx.execute_string(drop_sql)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   [Please write a short description of how your code change solves the related issue.
](https://docs.snowflake.com/en/sql-reference/identifiers-syntax#double-quoted-identifiers) a double quote should be replaced by two double quotes in a snowflake identifier. 