### PR TITLE
SNOW-789627 Print warning message if downloading files with same name

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug when writing a Pandas DataFrame with non-default index in `snowflake.connector.pandas_tool.write_pandas`.
   - Fixed a bug when writing a Pandas DataFrame with column names containing double quotes in `snowflake.connector.pandas_tool.write_pandas`.
   - Improved type hint of `SnowflakeCursor.execute` method.
+  - Improved GET logging to warn when downloading multiple files with the same name.
 
 - v3.0.2(March 23, 2023)
 

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -1017,6 +1017,8 @@ class SnowflakeFileTransferAgent:
                         )
                     )
         elif self._command_type == CMD_TYPE_DOWNLOAD:
+            existing_basenames = set()
+            duplicate_basenames = set()
             for idx, file_name in enumerate(self._src_files):
                 if not file_name:
                     continue
@@ -1029,9 +1031,15 @@ class SnowflakeFileTransferAgent:
                 url = None
                 if self._presigned_urls and idx < len(self._presigned_urls):
                     url = self._presigned_urls[idx]
+
+                basename = os.path.basename(file_name)
+                if basename in existing_basenames:
+                    duplicate_basenames.add(basename)
+                existing_basenames.add(basename)
+
                 self._file_metadata.append(
                     SnowflakeFileMeta(
-                        name=os.path.basename(file_name),
+                        name=basename,
                         src_file_name=file_name,
                         dst_file_name=dst_file_name,
                         stage_location_type=self._stage_location_type,
@@ -1043,6 +1051,12 @@ class SnowflakeFileTransferAgent:
                         if file_name in self._src_file_to_encryption_material
                         else None,
                     )
+                )
+
+            # TODO: remove this warning once we support directory structure for GET
+            if duplicate_basenames:
+                logger.warning(
+                    f"Downloading multiple files with the same name could cause failures. File names with multiple entries: {duplicate_basenames}"
                 )
 
     def _process_file_compression_type(self) -> None:

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -1017,8 +1017,7 @@ class SnowflakeFileTransferAgent:
                         )
                     )
         elif self._command_type == CMD_TYPE_DOWNLOAD:
-            existing_basenames = set()
-            duplicate_basenames = set()
+            basename_counts = dict()
             for idx, file_name in enumerate(self._src_files):
                 if not file_name:
                     continue
@@ -1033,9 +1032,7 @@ class SnowflakeFileTransferAgent:
                     url = self._presigned_urls[idx]
 
                 basename = os.path.basename(file_name)
-                if basename in existing_basenames:
-                    duplicate_basenames.add(basename)
-                existing_basenames.add(basename)
+                basename_counts[basename] = basename_counts.get(basename, 0) + 1
 
                 self._file_metadata.append(
                     SnowflakeFileMeta(
@@ -1054,9 +1051,11 @@ class SnowflakeFileTransferAgent:
                 )
 
             # TODO: remove this warning once we support directory structure for GET
+            duplicate_basenames = [k for k, v in basename_counts.items() if v > 1]
             if duplicate_basenames:
                 logger.warning(
-                    f"Downloading multiple files with the same name could cause failures. File names with multiple entries: {duplicate_basenames}"
+                    f"Downloading multiple files with the same name could cause failures. "
+                    f"File names with multiple entries: {duplicate_basenames}"
                 )
 
     def _process_file_compression_type(self) -> None:

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -764,3 +764,30 @@ def test_get_file_permission(tmp_path, conn_cnx, caplog):
             assert (
                 oct(os.stat(test_file).st_mode)[-3:] == oct(0o666 & ~default_mask)[-3:]
             )
+
+
+@pytest.mark.skipolddriver
+def test_get_multiple_files_with_same_name(tmp_path, conn_cnx, caplog):
+    test_file = tmp_path / "data.csv"
+    test_file.write_text("1,2,3\n")
+    stage_name = random_string(5, "test_get_multiple_files_with_same_name_")
+    with conn_cnx() as cnx:
+        with cnx.cursor() as cur:
+            cur.execute(f"create temporary stage {stage_name}")
+            filename_in_put = str(test_file).replace("\\", "/")
+            cur.execute(
+                f"PUT 'file://{filename_in_put}' @{stage_name}/data/1/",
+            )
+            cur.execute(
+                f"PUT 'file://{filename_in_put}' @{stage_name}/data/2/",
+            )
+
+            with caplog.at_level(logging.WARNING):
+                try:
+                    cur.execute(
+                        f"GET @{stage_name} file://{tmp_path} PATTERN='.*data.csv.gz'"
+                    )
+                except OperationalError:
+                    # This is expected flakiness
+                    pass
+            assert "Downloading multiple files with the same name" in caplog.text


### PR DESCRIPTION
Description

Today GET command does not support directory structure, so if there are multiple files of the same name on the stage but different paths, downloading them in a single GET command can fail due to race condition.

We are planning to support directory structure in the near future, but it is still useful to print a warning before supporting it to make it less confusing to our users

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-789627

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In description
