### PR TITLE
SNOW-670921 fail fast on login request with 403 response

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug when writing a Pandas DataFrame with column names containing double quotes in `snowflake.connector.pandas_tool.write_pandas`.
   - Fixed a bug when writing a Pandas DataFrame with binary data in `snowflake.connector.pandas_tool.write_pandas`.
   - Improved type hint of `SnowflakeCursor.execute` method.
+  - Fail instantly upon receiving `403: Forbidden` HTTP response for a login-request.
 
 - v3.0.2(March 23, 2023)
 

--- a/src/snowflake/connector/auth/by_plugin.py
+++ b/src/snowflake/connector/auth/by_plugin.py
@@ -210,12 +210,13 @@ class AuthByPlugin(ABC):
         del authenticator, service_name, account, user, password
         logger.debug("Default timeout handler invoked for authenticator")
         if not self._retry_ctx.should_retry():
-            self._retry_ctx.reset()
-            raise OperationalError(
+            error = OperationalError(
                 msg=f"Could not connect to Snowflake backend after {self._retry_ctx.get_current_retry_count()} attempt(s)."
                 "Aborting",
                 errno=ER_FAILED_TO_CONNECT_TO_DB,
             )
+            self._retry_ctx.reset()
+            raise error
         else:
             logger.debug(
                 f"Hit connection timeout, attempt number {self._retry_ctx.get_current_retry_count()}."

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1064,9 +1064,10 @@ class SnowflakeRestful:
                         ret = raw_ret.json()
                     return ret
 
-                if is_retryable_http_code(raw_ret.status_code) and not (
-                    is_login_request(full_url) and raw_ret.status_code == FORBIDDEN
-                ):
+                if is_login_request(full_url) and raw_ret.status_code == FORBIDDEN:
+                    raise ForbiddenError()
+
+                elif is_retryable_http_code(raw_ret.status_code):
                     error = get_http_retryable_error(raw_ret.status_code)
                     logger.debug(f"{error}. Retrying...")
                     # retryable server exceptions

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -11,7 +11,6 @@ import gzip
 import itertools
 import json
 import logging
-import re
 import time
 import traceback
 import uuid
@@ -183,10 +182,6 @@ OAUTH_AUTHENTICATOR = "OAUTH"
 ID_TOKEN_AUTHENTICATOR = "ID_TOKEN"
 USR_PWD_MFA_AUTHENTICATOR = "USERNAME_PASSWORD_MFA"
 
-LOGIN_REQUEST_PATTERN = re.compile(
-    r"/session/v1/login-request\?request_id=[a-zA-Z0-9-]+&request_guid=[a-zA-Z0-9-]+"
-)
-
 
 def is_retryable_http_code(code: int) -> bool:
     """Decides whether code is a retryable HTTP issue."""
@@ -248,7 +243,7 @@ def raise_failed_request_error(
 
 
 def is_login_request(url: str) -> bool:
-    return LOGIN_REQUEST_PATTERN.search(url) is not None
+    return "/session/v1/login-request" in url
 
 
 class ProxySupportAdapter(HTTPAdapter):
@@ -1065,7 +1060,7 @@ class SnowflakeRestful:
                     return ret
 
                 if is_login_request(full_url) and raw_ret.status_code == FORBIDDEN:
-                    raise ForbiddenError()
+                    raise ForbiddenError
 
                 elif is_retryable_http_code(raw_ret.status_code):
                     error = get_http_retryable_error(raw_ret.status_code)

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -109,7 +109,7 @@ def test_request_exec():
             session=session, catch_okta_unauthorized_error=True, **default_parameters
         )
 
-    # forbidden on login-request raises InterfaceError
+    # forbidden on login-request raises ForbiddenError
     type(request_mock).status_code = PropertyMock(return_value=FORBIDDEN)
     with pytest.raises(ForbiddenError):
         rest._request_exec(session=session, **login_parameters)

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -58,6 +58,11 @@ def test_request_exec():
         "token": None,
     }
 
+    login_parameters = {
+        **default_parameters,
+        "full_url": "https://bad_id.snowflakecomputing.com:443/session/v1/login-request?request_id=s0m3-r3a11Y-rAnD0m-reqID&request_guid=s0m3-r3a11Y-rAnD0m-reqGUID",
+    }
+
     # request mock
     output_data = {"success": True, "code": 12345}
     request_mock = MagicMock()
@@ -102,6 +107,11 @@ def test_request_exec():
         rest._request_exec(
             session=session, catch_okta_unauthorized_error=True, **default_parameters
         )
+
+    # forbidden on login-request raises InterfaceError
+    type(request_mock).status_code = PropertyMock(return_value=FORBIDDEN)
+    with pytest.raises(InterfaceError):
+        rest._request_exec(session=session, **login_parameters)
 
     class IncompleteReadMock(IncompleteRead):
         def __init__(self):

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -28,6 +28,7 @@ from snowflake.connector.compat import (
 )
 from snowflake.connector.errors import (
     DatabaseError,
+    ForbiddenError,
     InterfaceError,
     OtherHTTPRetryableError,
 )
@@ -110,7 +111,7 @@ def test_request_exec():
 
     # forbidden on login-request raises InterfaceError
     type(request_mock).status_code = PropertyMock(return_value=FORBIDDEN)
-    with pytest.raises(InterfaceError):
+    with pytest.raises(ForbiddenError):
         rest._request_exec(session=session, **login_parameters)
 
     class IncompleteReadMock(IncompleteRead):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1269 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403; when we receive a 403 for login-request, re-authenticating does not make a difference. This change fails instantly when 403 http response is received on a login-request.
