### PR TITLE
remove enable_parquet_filetype param

### DIFF
--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -239,9 +239,6 @@ def test_put_copy_zstd_compressed(conn_cnx, db_parameters, from_path, file_src):
         run(cnx, "drop table if exists {name}")
 
 
-@pytest.mark.skipif(
-    not CONNECTION_PARAMETERS_ADMIN, reason="Snowflake admin account is not accessible."
-)
 @pytest.mark.parametrize(
     "from_path", [True, pytest.param(False, marks=pytest.mark.skipolddriver)]
 )

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -255,7 +255,6 @@ def test_put_copy_parquet_compressed(conn_cnx, db_parameters, from_path, file_sr
         return cnx.cursor().execute(sql).fetchall()
 
     with conn_cnx() as cnx:
-        run(cnx, "alter session set enable_parquet_filetype=true")
         run(
             cnx,
             """
@@ -281,7 +280,6 @@ stage_file_format=(type='parquet')
             assert rec[1] == "LOADED"
 
         run(cnx, "drop table if exists {name}")
-        run(cnx, "alter session unset enable_parquet_filetype")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes broken regression tests.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   ENABLE_PARQUET_FILETYPE param was removed [here](https://github.com/snowflakedb/snowflake/commit/6063bbad6c9721749c4e5d849858456a15b930ab). We need to remove it from our tests to fix them.
