### PR TITLE
Set AUTO COMPRESS = False for content match test

### DIFF
--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -584,7 +584,7 @@ def test_put_overwrite_skip_on_content_match(
                     "~/test_put_overwrite_skip_on_content_match",
                     from_path,
                     file_stream=file_stream,
-                    sql_options="OVERWRITE = TRUE",
+                    sql_options="OVERWRITE = TRUE AUTO_COMPRESS = FALSE",
                     _skip_upload_on_content_match=False,
                 )
                 ret = cur.fetchone()
@@ -596,7 +596,7 @@ def test_put_overwrite_skip_on_content_match(
                     "~/test_put_overwrite_skip_on_content_match",
                     from_path,
                     file_stream=file_stream,
-                    sql_options="OVERWRITE = TRUE",
+                    sql_options="OVERWRITE = TRUE AUTO_COMPRESS = FALSE",
                     _skip_upload_on_content_match=True,
                 )
                 ret = cur.fetchone()
@@ -612,7 +612,7 @@ def test_put_overwrite_skip_on_content_match(
                 + os.path.basename(test_data)
                 in ret[0]
             )
-            assert test_data.name + ".gz" in ret[0]
+            assert test_data.name in ret[0]
         finally:
             if file_stream:
                 file_stream.close()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   GZip compression does not always give the same result on the same input stream which causes the test to break when the input stream is compressed. To fix the test, we are setting `AUTO_COMPRESS = FALSE`
