### PR TITLE
SNOW-799180 Do not modify statement_params from user

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,8 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
-- v3.0.3(April 20, 2023)
+- v3.0.4(TBD)
+  - Fixed a bug that cursor.execute() could change user's input statement_params object if multistatement query is used.
 
+- v3.0.3(April 20, 2023)
   - Fixed a bug that prints error in logs for GET command on GCS.
   - Added a parameter that allows users to skip file uploads to stage if file exists on stage and contents of the file match.
   - Fixed a bug that occurred when writing a Pandas DataFrame with non-default index in `snowflake.connector.pandas_tool.write_pandas`.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,7 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 - v3.0.4(TBD)
-  - Fixed a bug that cursor.execute() could change user's input statement_params object if multistatement query is used.
+  - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.
 
 - v3.0.3(April 20, 2023)
   - Fixed a bug that prints error in logs for GET command on GCS.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -749,18 +749,14 @@ class SnowflakeCursor:
             logger.warning("execute: no query is given to execute")
             return None
 
-        extra_statement_params = dict()
-        if num_statements:
-            extra_statement_params["MULTI_STATEMENT_COUNT"] = num_statements
-
-        # We should not edit the original _statement_params object passed in by the caller, because the caller might
-        # reuse the same object.
-        if extra_statement_params:
-            if _statement_params is None:
-                _statement_params = dict()
-            else:
-                _statement_params = _statement_params.copy()
-            _statement_params.update(extra_statement_params)
+        _statement_params = _statement_params or dict()
+        # If we need to add another parameter, please consider introducing a dict for all extra params
+        # See discussion in https://github.com/snowflakedb/snowflake-connector-python/pull/1524#discussion_r1174061775
+        if num_statements is not None:
+            _statement_params = {
+                **_statement_params,
+                "MULTI_STATEMENT_COUNT": num_statements,
+            }
 
         kwargs: dict[str, Any] = {
             "timeout": timeout,

--- a/test/integ/test_multi_statement.py
+++ b/test/integ/test_multi_statement.py
@@ -82,7 +82,12 @@ def test_multi_statement_basic(conn_cnx):
     """Selects fixed integer data using statement level parameters."""
     with conn_cnx() as con:
         with con.cursor() as cur:
-            cur.execute("select 1; select 2; select 'a';", num_statements=3)
+            statement_params = dict()
+            cur.execute(
+                "select 1; select 2; select 'a';",
+                num_statements=3,
+                _statement_params=statement_params,
+            )
             _check_multi_statement_results(
                 cur,
                 checks=[
@@ -91,6 +96,7 @@ def test_multi_statement_basic(conn_cnx):
                     [("a",)],
                 ],
             )
+            assert len(statement_params) == 0
 
 
 def test_insert_select_multi(conn_cnx, db_parameters):


### PR DESCRIPTION
Description

Today we are modifying statement_params provided by user if they are also a multistatement. This behavior seems awkward and could break user is they are sharing the same statement_params object between multiple queries

Testing

integ

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-799180

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Today we are modifying statement_params provided by user if they are also a multistatement. This behavior seems awkward and could break user is they are sharing the same statement_params object between multiple queries
