### PR TITLE
SNOW-799216 Allow nextset without fetching result for async multistat…

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.0.4(TBD)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.
+  - Fixed a bug in which we cannot call `SnowflakeCursor.nextset` before fetching the result of the first query if the cursor runs an async multistatement query.
 
 - v3.0.3(April 20, 2023)
   - Fixed a bug that prints error in logs for GET command on GCS.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1316,6 +1316,8 @@ class SnowflakeCursor:
         to any of the fetch*() methods will return rows from the next query's set of results. Returns None if no more
         query results are available.
         """
+        if self._prefetch_hook is not None:
+            self._prefetch_hook()
         self.reset()
         if self._multi_statement_resultIds:
             self.query_result(self._multi_statement_resultIds[0])

--- a/test/integ/test_multi_statement.py
+++ b/test/integ/test_multi_statement.py
@@ -33,6 +33,11 @@ except ImportError:
     from ..randomize import random_string
 
 
+@pytest.fixture(scope="module", params=[False, True])
+def skip_to_last_set(request) -> bool:
+    return request.param
+
+
 def test_multi_statement_wrong_count(conn_cnx):
     """Tries to send the wrong number of statements."""
     with conn_cnx(session_parameters={PARAMETER_MULTI_STATEMENT_COUNT: 1}) as con:
@@ -67,7 +72,7 @@ def _check_multi_statement_results(
     cur: snowflake.connector.cursor,
     checks: "list[list[tuple] | function]",
     skip_to_last_set: bool,
-):
+) -> None:
     savedIds = []
     for index, check in enumerate(checks):
         if not skip_to_last_set or index == len(checks) - 1:
@@ -82,7 +87,6 @@ def _check_multi_statement_results(
     assert cur.multi_statement_savedIds[-1 if skip_to_last_set else 0 :] == savedIds
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_multi_statement_basic(conn_cnx, skip_to_last_set: bool):
     """Selects fixed integer data using statement level parameters."""
     with conn_cnx() as con:
@@ -105,7 +109,6 @@ def test_multi_statement_basic(conn_cnx, skip_to_last_set: bool):
             assert len(statement_params) == 0
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_insert_select_multi(conn_cnx, db_parameters, skip_to_last_set: bool):
     """Naive use of multi-statement to check multiple SQL functions."""
     with conn_cnx(session_parameters={PARAMETER_MULTI_STATEMENT_COUNT: 0}) as con:
@@ -137,7 +140,6 @@ def test_insert_select_multi(conn_cnx, db_parameters, skip_to_last_set: bool):
             )
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 @pytest.mark.parametrize("style", ["pyformat", "qmark"])
 def test_binding_multi(conn_cnx, style: str, skip_to_last_set: bool):
     """Tests using pyformat and qmark style bindings with multi-statement"""
@@ -153,7 +155,6 @@ def test_binding_multi(conn_cnx, style: str, skip_to_last_set: bool):
             )
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_async_exec_multi(conn_cnx, skip_to_last_set: bool):
     """Tests whether async execution query works within a multi-statement"""
     with conn_cnx() as con:
@@ -202,7 +203,6 @@ def test_async_error_multi(conn_cnx):
             assert e1.value.errno == e2.value.errno == sync_error.value.errno
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_mix_sync_async_multi(conn_cnx, skip_to_last_set: bool):
     """Tests sending multiple multi-statement async queries at the same time."""
     with conn_cnx(
@@ -245,7 +245,6 @@ def test_mix_sync_async_multi(conn_cnx, skip_to_last_set: bool):
             )
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_done_caching_multi(conn_cnx, skip_to_last_set: bool):
     """Tests whether get status caching is working as expected."""
     with conn_cnx(session_parameters={PARAMETER_MULTI_STATEMENT_COUNT: 0}) as con:
@@ -304,7 +303,6 @@ def test_alter_session_multi(conn_cnx):
             )
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_executemany_multi(conn_cnx, skip_to_last_set: bool):
     """Tests executemany with multi-statement optimizations enabled through the num_statements parameter."""
     table1 = random_string(5, "test_executemany_multi_")
@@ -370,7 +368,6 @@ def test_executemany_multi(conn_cnx, skip_to_last_set: bool):
             )
 
 
-@pytest.mark.parametrize("skip_to_last_set", [True, False])
 def test_executmany_qmark_multi(conn_cnx, skip_to_last_set: bool):
     """Tests executemany with multi-statement optimization with qmark style."""
     table1 = random_string(5, "test_executemany_qmark_multi_")

--- a/test/integ/test_multi_statement.py
+++ b/test/integ/test_multi_statement.py
@@ -64,21 +64,26 @@ def test_multi_statement_wrong_count(conn_cnx):
 
 
 def _check_multi_statement_results(
-    cur: snowflake.connector.cursor, checks: "list[list[tuple] | function]"
+    cur: snowflake.connector.cursor,
+    checks: "list[list[tuple] | function]",
+    skip_to_last_set: bool,
 ):
     savedIds = []
     for index, check in enumerate(checks):
-        if callable(check):
-            assert check(cur.fetchall())
-        else:
-            assert cur.fetchall() == check
-        savedIds.append(cur.sfqid)
+        if not skip_to_last_set or index == len(checks) - 1:
+            if callable(check):
+                assert check(cur.fetchall())
+            else:
+                assert cur.fetchall() == check
+            savedIds.append(cur.sfqid)
         assert cur.nextset() == (cur if index < len(checks) - 1 else None)
     assert cur.fetchall() == []
-    assert cur.multi_statement_savedIds == savedIds
+
+    assert cur.multi_statement_savedIds[-1 if skip_to_last_set else 0 :] == savedIds
 
 
-def test_multi_statement_basic(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_multi_statement_basic(conn_cnx, skip_to_last_set: bool):
     """Selects fixed integer data using statement level parameters."""
     with conn_cnx() as con:
         with con.cursor() as cur:
@@ -95,11 +100,13 @@ def test_multi_statement_basic(conn_cnx):
                     [(2,)],
                     [("a",)],
                 ],
+                skip_to_last_set=skip_to_last_set,
             )
             assert len(statement_params) == 0
 
 
-def test_insert_select_multi(conn_cnx, db_parameters):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_insert_select_multi(conn_cnx, db_parameters, skip_to_last_set: bool):
     """Naive use of multi-statement to check multiple SQL functions."""
     with conn_cnx(session_parameters={PARAMETER_MULTI_STATEMENT_COUNT: 0}) as con:
         with con.cursor() as cur:
@@ -126,11 +133,13 @@ def test_insert_select_multi(conn_cnx, db_parameters):
                     [(65432,), (98765,), (123456,)],
                     [(f"{table_name} successfully dropped.",)],
                 ],
+                skip_to_last_set=skip_to_last_set,
             )
 
 
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
 @pytest.mark.parametrize("style", ["pyformat", "qmark"])
-def test_binding_multi(conn_cnx, style: str):
+def test_binding_multi(conn_cnx, style: str, skip_to_last_set: bool):
     """Tests using pyformat and qmark style bindings with multi-statement"""
     test_string = "select {s}; select {s}, {s}; select {s}, {s}, {s};"
     with conn_cnx(paramstyle=style) as con:
@@ -138,11 +147,14 @@ def test_binding_multi(conn_cnx, style: str):
             sql = test_string.format(s="%s" if style == "pyformat" else "?")
             cur.execute(sql, (10, 20, 30, "a", "b", "c"), num_statements=3)
             _check_multi_statement_results(
-                cur, checks=[[(10,)], [(20, 30)], [("a", "b", "c")]]
+                cur,
+                checks=[[(10,)], [(20, 30)], [("a", "b", "c")]],
+                skip_to_last_set=skip_to_last_set,
             )
 
 
-def test_async_exec_multi(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_async_exec_multi(conn_cnx, skip_to_last_set: bool):
     """Tests whether async execution query works within a multi-statement"""
     with conn_cnx() as con:
         with con.cursor() as cur:
@@ -160,7 +172,9 @@ def test_async_exec_multi(conn_cnx):
 
             cur.get_results_from_sfqid(q_id)
             _check_multi_statement_results(
-                cur, checks=[[(1,)], [(2,)], lambda x: x > [(0,)], [("b",)]]
+                cur,
+                checks=[[(1,)], [(2,)], lambda x: x > [(0,)], [("b",)]],
+                skip_to_last_set=skip_to_last_set,
             )
 
 
@@ -188,7 +202,8 @@ def test_async_error_multi(conn_cnx):
             assert e1.value.errno == e2.value.errno == sync_error.value.errno
 
 
-def test_mix_sync_async_multi(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_mix_sync_async_multi(conn_cnx, skip_to_last_set: bool):
     """Tests sending multiple multi-statement async queries at the same time."""
     with conn_cnx(
         session_parameters={
@@ -218,15 +233,20 @@ def test_mix_sync_async_multi(conn_cnx):
             assert cur.fetchall() == [("USELESSTABLE successfully dropped.",)]
             cur.get_results_from_sfqid(sf_qid1)
             _check_multi_statement_results(
-                cur, checks=[[(1,)], [("a",)], [("row1", 1), ("row2", 2), ("row3", 3)]]
+                cur,
+                checks=[[(1,)], [("a",)], [("row1", 1), ("row2", 2), ("row3", 3)]],
+                skip_to_last_set=skip_to_last_set,
             )
             cur.get_results_from_sfqid(sf_qid2)
             _check_multi_statement_results(
-                cur, checks=[[(2,)], [("b",)], [("row1", 1), ("row2", 2), ("row3", 3)]]
+                cur,
+                checks=[[(2,)], [("b",)], [("row1", 1), ("row2", 2), ("row3", 3)]],
+                skip_to_last_set=skip_to_last_set,
             )
 
 
-def test_done_caching_multi(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_done_caching_multi(conn_cnx, skip_to_last_set: bool):
     """Tests whether get status caching is working as expected."""
     with conn_cnx(session_parameters={PARAMETER_MULTI_STATEMENT_COUNT: 0}) as con:
         with con.cursor() as cur:
@@ -244,7 +264,9 @@ def test_done_caching_multi(conn_cnx):
             assert con.get_query_status(qid1) == QueryStatus.SUCCESS
             cur.get_results_from_sfqid(qid1)
             _check_multi_statement_results(
-                cur, checks=[[(1,)], [("a",)], lambda x: x > [(0,)]]
+                cur,
+                checks=[[(1,)], [("a",)], lambda x: x > [(0,)]],
+                skip_to_last_set=skip_to_last_set,
             )
             assert len(con._async_sfqids) == 1
             assert len(con._done_async_sfqids) == 1
@@ -253,7 +275,9 @@ def test_done_caching_multi(conn_cnx):
             assert con.get_query_status(qid2) == QueryStatus.SUCCESS
             cur.get_results_from_sfqid(qid2)
             _check_multi_statement_results(
-                cur, checks=[[(2,)], [("b",)], lambda x: x > [(0,)]]
+                cur,
+                checks=[[(2,)], [("b",)], lambda x: x > [(0,)]],
+                skip_to_last_set=skip_to_last_set,
             )
             assert len(con._async_sfqids) == 0
             assert len(con._done_async_sfqids) == 2
@@ -280,7 +304,8 @@ def test_alter_session_multi(conn_cnx):
             )
 
 
-def test_executemany_multi(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_executemany_multi(conn_cnx, skip_to_last_set: bool):
     """Tests executemany with multi-statement optimizations enabled through the num_statements parameter."""
     table1 = random_string(5, "test_executemany_multi_")
     table2 = random_string(5, "test_executemany_multi_")
@@ -309,6 +334,7 @@ def test_executemany_multi(conn_cnx):
             _check_multi_statement_results(
                 cur,
                 checks=[[(1234,), (234,), (34,), (4,)], [(4,), (34,), (234,), (1234,)]],
+                skip_to_last_set=skip_to_last_set,
             )
 
     with conn_cnx() as con:
@@ -340,10 +366,12 @@ def test_executemany_multi(conn_cnx):
                     [(12345,), (1234,), (234,), (34,), (4,)],
                     [(4,), (34,), (234,), (1234,), (12345,)],
                 ],
+                skip_to_last_set=skip_to_last_set,
             )
 
 
-def test_executmany_qmark_multi(conn_cnx):
+@pytest.mark.parametrize("skip_to_last_set", [True, False])
+def test_executmany_qmark_multi(conn_cnx, skip_to_last_set: bool):
     """Tests executemany with multi-statement optimization with qmark style."""
     table1 = random_string(5, "test_executemany_qmark_multi_")
     table2 = random_string(5, "test_executemany_qmark_multi_")
@@ -375,4 +403,5 @@ def test_executmany_qmark_multi(conn_cnx):
                     [(1234,), (234,), (34,), (4,)],
                     [(4,), (34,), (234,), (1234,)],
                 ],
+                skip_to_last_set=skip_to_last_set,
             )


### PR DESCRIPTION
…ement

Description

Prior to this change we are not able to call nextset before fetching result if the cursor executes an async multistatement query. The main reason is that we need to first wait the result by invoking _prefetch_hook, but in the async case, we will first call reset(), which clears the _prefetch_hook. This way _prefetch_hook will never be invoked and this causes failure in the connector.

This fix adds a _prefetch_hook invoke before calling reset()

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-799216

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Prior to this change we are not able to call nextset before fetching result if the cursor executes an async multistatement query. The main reason is that we need to first wait the result by invoking _prefetch_hook, but in the async case, we will first call reset(), which clears the _prefetch_hook. This way _prefetch_hook will never be invoked and this causes failure in the connector.

This fix adds a _prefetch_hook invoke before calling reset()
