### PR TITLE
SNOW-754627 fix priority switch corner case error

### DIFF
--- a/src/snowflake/connector/query_context_cache.py
+++ b/src/snowflake/connector/query_context_cache.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from logging import DEBUG, getLogger
 from threading import Lock
 import json
+import copy
 
 from sortedcontainers import SortedSet
 
@@ -89,6 +90,7 @@ class QueryContextCache:
         self._capacity = capacity
         self._id_map: dict[int, QueryContextElement] = {}
         self._priority_map: dict[int, QueryContextElement] = {}
+        self._intermediate_priority_map: dict[int, QueryContextElement] = {}
 
         # stores elements sorted by priority. Element with
         # least priority value has the highest priority
@@ -101,9 +103,9 @@ class QueryContextCache:
         return self._capacity
 
     def _add_qce(self, qce: QueryContextElement) -> None:
-        self._id_map[qce.id] = qce
-        self._priority_map[qce.priority] = qce
         self._tree_set.add(qce)
+        self._id_map[qce.id] = copy.deepcopy(qce)
+        self._intermediate_priority_map[qce.priority] = copy.deepcopy(qce)
 
     def _remove_qce(self, qce: QueryContextElement) -> None:
         self._id_map.pop(qce.id)
@@ -115,23 +117,26 @@ class QueryContextCache:
     ) -> None:
         self._remove_qce(old_qce)
         self._add_qce(new_qce)
+        
+    def sync_priority_map(self):
+        """
+        Sync the _intermediate_priority_map with the _priority_map at the end of the current round of merges.
+        """
+        logger.debug(f"syncPriorityMap called priority_map size = {len(self._priority_map)}, new_priority_map size = {len(self._intermediate_priority_map)}")
+        
+        for key, value in self._intermediate_priority_map.items():
+            self._priority_map[key] = value
+
+        # Clear the _intermediate_priority_map for the next round of QCC merge (a round consists of multiple entries)
+        self._intermediate_priority_map.clear()
 
     def merge(
         self, id: int, read_timestamp: int, priority: int, context: str
     ) -> None:
         if id in self._id_map:
             qce = self._id_map[id]
-            # when id if found in cache and we are operating on a more recent timestamp
-            if read_timestamp > qce.read_timestamp:
-                if qce.priority == priority:
-                    # same priority updates the current context object
-                    qce.read_timestamp = read_timestamp
-                    qce.context = context
-                else:
-                    # change in priority caused replacement of query context
-                    new_qce = QueryContextElement(id, read_timestamp, priority, context)
-                    self._replace_qce(qce, new_qce)
-            elif read_timestamp == qce.read_timestamp and priority != qce.priority:
+            if((read_timestamp > qce.read_timestamp) or (read_timestamp == qce.read_timestamp and priority != qce.priority)):
+                # when id if found in cache and we are operating on a more recent timestamp. We do not update in-place here.
                 new_qce = QueryContextElement(id, read_timestamp, priority, context)
                 self._replace_qce(qce, new_qce)
         else:
@@ -267,6 +272,9 @@ class QueryContextCache:
                         entry.get("priority"),
                         context, 
                     )
+                
+                # Sync the priority map at the end of for loop merge.
+                self.sync_priority_map()
             except Exception as e:
                 logger.debug(f"deserialize_json_dict: Exception = {e}")
                 # clear cache due to incomplete merge

--- a/src/snowflake/connector/query_context_cache.py
+++ b/src/snowflake/connector/query_context_cache.py
@@ -124,9 +124,7 @@ class QueryContextCache:
         """
         logger.debug(f"syncPriorityMap called priority_map size = {len(self._priority_map)}, new_priority_map size = {len(self._intermediate_priority_map)}")
         
-        for key, value in self._intermediate_priority_map.items():
-            self._priority_map[key] = value
-
+        self._priority_map.update(self._intermediate_priority_map)
         # Clear the _intermediate_priority_map for the next round of QCC merge (a round consists of multiple entries)
         self._intermediate_priority_map.clear()
 
@@ -135,7 +133,7 @@ class QueryContextCache:
     ) -> None:
         if id in self._id_map:
             qce = self._id_map[id]
-            if((read_timestamp > qce.read_timestamp) or (read_timestamp == qce.read_timestamp and priority != qce.priority)):
+            if (read_timestamp > qce.read_timestamp) or (read_timestamp == qce.read_timestamp and priority != qce.priority):
                 # when id if found in cache and we are operating on a more recent timestamp. We do not update in-place here.
                 new_qce = QueryContextElement(id, read_timestamp, priority, context)
                 self._replace_qce(qce, new_qce)

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -69,6 +69,7 @@ def qcc_with_data(
             expected_data.priorities[i],
             expected_data.contexts[i],
         )
+    qcc_with_no_data.sync_priority_map()
     yield qcc_with_no_data
     qcc_with_no_data.clear_cache()
 
@@ -86,6 +87,7 @@ def qcc_with_data_random_order(
             expected_data.priorities[i],
             expected_data.contexts[i],
         )
+    qcc_with_no_data.sync_priority_map()
     yield qcc_with_no_data
     qcc_with_no_data.clear_cache()
 
@@ -102,6 +104,7 @@ def qcc_with_data_null_context(
             expected_data_with_null_context.priorities[i],
             expected_data_with_null_context.contexts[i],
         )
+    qcc_with_no_data.sync_priority_map()
     yield qcc_with_no_data
     qcc_with_no_data.clear_cache()
 
@@ -221,6 +224,7 @@ def test_check_cache_capacity(
         BASE_PRIORITY + MAX_CAPACITY,
         CONTEXT,
     )
+    qcc_with_data.sync_priority_map()
     qcc_with_data.check_cache_capacity()
 
     assert_cache_with_data(qcc_with_data, expected_data)
@@ -236,6 +240,7 @@ def test_update_timestamp(
         BASE_PRIORITY + update_id,
         CONTEXT,
     )
+    qcc_with_data.sync_priority_map()
     expected_data.timestamps[update_id] = BASE_READ_TIMESTAMP + update_id + 10
     assert_cache_with_data(qcc_with_data, expected_data)
 
@@ -248,6 +253,7 @@ def test_update_priority(
     qcc_with_data.merge(
         BASE_ID + update_id, BASE_READ_TIMESTAMP + update_id, updated_priority, CONTEXT
     )
+    qcc_with_data.sync_priority_map()
 
     for i in range(update_id, MAX_CAPACITY - 1):
         expected_data.ids[i] = expected_data.ids[i + 1]
@@ -266,6 +272,7 @@ def test_add_same_priority(
     i = MAX_CAPACITY
     updated_priority = BASE_PRIORITY + 1
     qcc_with_data.merge(BASE_ID + i, BASE_READ_TIMESTAMP + i, updated_priority, CONTEXT)
+    qcc_with_data.sync_priority_map()
 
     expected_data.ids[1] = BASE_ID + i
     expected_data.timestamps[1] = BASE_READ_TIMESTAMP + i
@@ -279,6 +286,7 @@ def test_same_id_with_stale_timestamp(
     qcc_with_data.merge(
         BASE_ID + i, BASE_READ_TIMESTAMP + i - 10, BASE_PRIORITY + i, CONTEXT
     )
+    qcc_with_data.sync_priority_map()
     qcc_with_data.check_cache_capacity()
 
     assert_cache_with_data(qcc_with_data, expected_data)
@@ -343,6 +351,7 @@ def test_eviction_order():
     qcc = QueryContextCache(5)
     for qce in qce_list:
         qcc.merge(qce.id, qce.read_timestamp, qce.priority, qce.context)
+    qcc.sync_priority_map()
 
     assert qcc.get_size() == 3
     assert qcc._last() == qce3

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -278,6 +278,41 @@ def test_add_same_priority(
     expected_data.timestamps[1] = BASE_READ_TIMESTAMP + i
     assert_cache_with_data(qcc_with_data, expected_data)
 
+# helper function to shuffle priorities in all entries
+def random_priority_shuffle(num_entries: int):
+    id_list = list(range(BASE_ID, BASE_ID + num_entries))
+    priority_list = list(range(BASE_PRIORITY, BASE_PRIORITY + num_entries))
+    # Shuffle priorities randomly
+    shuffle(priority_list)
+
+    # Create a dictionary mapping IDs to their new random priorities
+    id_to_priority = dict(zip(id_list, priority_list))
+    return id_to_priority
+
+def test_priority_switch_randomized(qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData):
+    num_retry = MAX_CAPACITY * 5
+    for i in range(num_retry):
+        # for each iteration, we simulate randomized priority switch for the batch of QCEs.
+        id_to_priority = random_priority_shuffle(MAX_CAPACITY)
+
+        # Update priorities using the random shuffle
+        for idx, (id, priority) in enumerate(id_to_priority.items()):
+            qcc_with_data.merge(id, BASE_READ_TIMESTAMP + MAX_CAPACITY + 10, priority, CONTEXT)
+
+        qcc_with_data.sync_priority_map()
+
+        # Check if the inner priority map has been correctly updated
+        for id, priority in id_to_priority.items():
+            assert qcc_with_data._priority_map[priority]._id == id
+        # Check if the inner id map has been correctly updated
+        for id in range(MAX_CAPACITY):
+            assert qcc_with_data._id_map[id]._id == id
+        # Update expected_data
+        for idx, id in enumerate(sorted(id_to_priority.keys(), key=lambda x: id_to_priority[x])):
+            expected_data.ids[idx] = id
+            expected_data.timestamps[idx] = BASE_READ_TIMESTAMP + MAX_CAPACITY + 10
+
+        assert_cache_with_data(qcc_with_data, expected_data)
 
 def test_same_id_with_stale_timestamp(
     qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   This PR is a follow-up fix for SNOW-754627.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   As stated in the JDBC PR side https://github.com/snowflakedb/snowflake-jdbc/pull/1366
   
   Consider a simple situation :

```
current state:
<id, priority, timestamp, context>
<1, 1, 1, None>
<2,2,2, None>
incoming changes:

merge <1, 2,1, None> 
   call remove QCE(<1,1,1, None>) -> remove priorityMap(1, <1,1,1, None>)
   call add QCE(<1,2,1, None>) -> add priorityMap(2, <1,2,1, None>) this map insertion will fail due to collision of priority key(there are two priority keys of 2)
merge <2,1,1, None>
```

Although this bug does not affect the contents in treeSet in this simple example (this is also why I thought I fixed the issue before, I only checked the final QCC entries embedded into the HTTP request, and found the previous multi-db missing query context issue was gone. However, the priorityMap contents are not correctly maintained), it can trigger inconsistent QCC treeSet and priorityMap contents in following rounds.

I also find another bug in python implementation:

Basically, in my end-to-end test, when I want to
```
def _remove_qce(self, qce: QueryContextElement) -> None:
        self._id_map.pop(qce.id)
        self._priority_map.pop(qce.priority)
        self._tree_set.remove(qce)
```
even if there is an element in tree_set with all the same field values(id, ts, priority, context), the remove API can not find the entry to remove. I checked the _hash_  values are the same. If i do
```
for ele in self._tree_set:
   if(ele.__eq__(qce)):
       self._tree_set.remove(ele)
```
This can work. 

This reason could be that the python QueryContextElement object in 
```
        self._id_map: dict[int, QueryContextElement] = {}
        self._priority_map: dict[int, QueryContextElement] = {}
        self._tree_set: set[QueryContextElement] = SortedSet()
```
are referencing the same underlying object. I use `copy.deepcopy` when adding a QCE to each map/set to avoid this tricky bug. In this way, we also can not do in-place update in `merge` function. The overhead should be very small since the QCC capacity is usually a small number. If you have any better solution, please let me know.
