### PR TITLE
SNOW-735220 Do not capitalize table name in pd_writer

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -402,8 +402,7 @@ def pd_writer(
     write_pandas(
         conn=sf_connection,
         df=df,
-        # Note: Our sqlalchemy connector creates tables case insensitively
-        table_name=table.name.upper(),
+        table_name=table.name,
         schema=table.schema,
         **kwargs,
     )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1420 (SNOW-735220)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Do not capitalize table name in pd_writer. Table created by snowflake-sqlalchemy is now name case sensitive by default.
