### PR TITLE
Fix 'SOCKSProxyManager' object has no attribute 'proxy_headers' error

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Fixed a bug in retry logic for okta authentication to refresh token.
   - Support `RSAPublicKey` when constructing `AuthByKeyPair` in addition to raw bytes.
+  - Fixed a bug when connecting through SOCKS5 proxy, the attribute `proxy_header` is missing on `SOCKSProxyManager`.
 
 - v3.1.0(July 31,2023)
 

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -111,6 +111,7 @@ from .vendored.requests.exceptions import (
 )
 from .vendored.requests.utils import prepend_scheme_if_needed, select_proxy
 from .vendored.urllib3.exceptions import ProtocolError
+from .vendored.urllib3.poolmanager import ProxyManager
 from .vendored.urllib3.util.url import parse_url
 
 if TYPE_CHECKING:
@@ -268,16 +269,14 @@ class ProxySupportAdapter(HTTPAdapter):
                 )
             proxy_manager = self.proxy_manager_for(proxy)
 
-            try:
+            if isinstance(proxy_manager, ProxyManager):
                 # Add Host to proxy header SNOW-232777
                 proxy_manager.proxy_headers["Host"] = parsed_url.hostname
-            except AttributeError:
-                # log that the type proxy_manager not having attribute proxy_headers
+            else:
                 logger.debug(
                     f"Unable to set 'Host' to proxy manager of type {type(proxy_manager)} as"
                     f" it does not have attribute 'proxy_headers'."
                 )
-
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -26,6 +26,7 @@ from snowflake.connector.vendored.urllib3.connectionpool import (
     HTTPConnectionPool,
     HTTPSConnectionPool,
 )
+from snowflake.connector.vendored.urllib3.contrib.socks import SOCKSProxyManager
 
 from . import ssl_wrap_socket
 from .compat import (
@@ -268,8 +269,9 @@ class ProxySupportAdapter(HTTPAdapter):
                 )
             proxy_manager = self.proxy_manager_for(proxy)
 
-            # Add Host to proxy header SNOW-232777
-            proxy_manager.proxy_headers["Host"] = parsed_url.hostname
+            if not isinstance(proxy_manager, SOCKSProxyManager):
+                # Add Host to proxy header SNOW-232777
+                proxy_manager.proxy_headers["Host"] = parsed_url.hostname
             conn = proxy_manager.connection_from_url(url)
         else:
             # Only scheme should be lower case

--- a/test/unit/test_proxies.py
+++ b/test/unit/test_proxies.py
@@ -5,7 +5,14 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import unittest.mock
+
+import pytest
+
+import snowflake.connector
+from snowflake.connector.errors import OperationalError
 
 
 def test_set_proxies():
@@ -30,4 +37,35 @@ def test_set_proxies():
 
     # NOTE environment variable is set if the proxy parameter is specified.
     del os.environ["HTTP_PROXY"]
+    del os.environ["HTTPS_PROXY"]
+
+
+def test_socks_5_proxy_missing_proxy_header_attribute(caplog):
+    os.environ["HTTPS_PROXY"] = "socks5://localhost:8080"
+
+    class MockSOCKSProxyManager:
+        def __init__(self):
+            pass
+
+        def connection_from_url(self, url):
+            pass
+
+    def mock_proxy_manager_fox(*args, **kwargs):
+        return MockSOCKSProxyManager()
+
+    # connection
+    caplog.set_level(logging.DEBUG, "snowflake.connector")
+    with unittest.mock.patch(
+        "snowflake.connector.network.ProxySupportAdapter.proxy_manager_for",
+        mock_proxy_manager_fox,
+    ):
+        with pytest.raises(OperationalError):
+            snowflake.connector.connect(
+                account="testaccount",
+                user="testuser",
+                password="testpassword",
+                database="TESTDB",
+                warehouse="TESTWH",
+            )
+    assert "Unable to set 'Host' to proxy manager of type" in caplog.text
     del os.environ["HTTPS_PROXY"]

--- a/test/unit/test_proxies.py
+++ b/test/unit/test_proxies.py
@@ -13,7 +13,6 @@ import pytest
 
 import snowflake.connector
 from snowflake.connector.errors import OperationalError
-from snowflake.connector.vendored.urllib3.poolmanager import ProxyManager
 
 
 def test_set_proxies():
@@ -41,7 +40,10 @@ def test_set_proxies():
     del os.environ["HTTPS_PROXY"]
 
 
+@pytest.mark.skipolddriver
 def test_socks_5_proxy_missing_proxy_header_attribute(caplog):
+    from snowflake.connector.vendored.urllib3.poolmanager import ProxyManager
+
     os.environ["HTTPS_PROXY"] = "socks5://localhost:8080"
 
     class MockSOCKSProxyManager:


### PR DESCRIPTION
This fixes an error that would arise when using a SOCKS5 proxy.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1550

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This code skips setting the `proxy_headers` property of the ProxyManager if we are using a SOCKS5 proxy.

For more details, see the [related issue](https://github.com/snowflakedb/snowflake-connector-python/issues/1550).
