### PR TITLE
SNOW-770678: Fix incorrect date conversion in bulk insertion

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -17,6 +17,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug when `_prefetch_hook()` was not called before yielding results of `execute_async()`.
   - Fixed a bug where some ResultMetadata fields were marked as required when they were optional.
   - Bumped pandas dependency from <1.6.0,>=1.0.0 to >=1.0.0,<2.1.0
+  - Fixed a bug where bulk insert converts date incorrectly.
 
 - v3.0.3(April 20, 2023)
   - Fixed a bug that prints error in logs for GET command on GCS.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -57,7 +57,7 @@ from .constants import (
     OCSPMode,
     QueryStatus,
 )
-from .converter import SnowflakeConverter
+from .converter import SnowflakeConverter, _adjust_bind_type
 from .cursor import LOG_MAX_QUERY_LENGTH, SnowflakeCursor
 from .description import (
     CLIENT_NAME,
@@ -1261,13 +1261,13 @@ class SnowflakeConnection:
                 if all(param_data.type == first_type for param_data in all_param_data):
                     snowflake_type = first_type
                 processed_params[str(idx + 1)] = {
-                    "type": snowflake_type,
+                    "type": _adjust_bind_type(snowflake_type),
                     "value": [param_data.binding for param_data in all_param_data],
                 }
             else:
                 snowflake_type, snowflake_binding = get_type_and_binding(v)
                 processed_params[str(idx + 1)] = {
-                    "type": snowflake_type,
+                    "type": _adjust_bind_type(snowflake_type),
                     "value": snowflake_binding,
                 }
         if logger.getEffectiveLevel() <= logging.DEBUG:

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -101,10 +101,6 @@ def _convert_datetime_to_epoch_nanoseconds(dt: datetime) -> str:
     return f"{convert_datetime_to_epoch(dt):f}".replace(".", "") + "000"
 
 
-def _convert_date_to_epoch_milliseconds(dt: datetime) -> str:
-    return f"{(dt - ZERO_EPOCH_DATE).total_seconds():.3f}".replace(".", "")
-
-
 def _convert_time_to_epoch_nanoseconds(tm: dt_t) -> str:
     return (
         str(tm.hour * 3600 + tm.minute * 60 + tm.second)
@@ -367,7 +363,7 @@ class SnowflakeConverter:
 
     def _date_to_snowflake_bindings(self, _, value: date) -> str:
         # we are binding "TEXT" value for DATE, check function _adjust_bind_type
-        return value.strftime("%Y-%m-%d")
+        return value.isoformat()
 
     def _time_to_snowflake_bindings(self, _, value: dt_t) -> str:
         # nanoseconds

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -366,8 +366,7 @@ class SnowflakeConverter:
         return None
 
     def _date_to_snowflake_bindings(self, _, value: date) -> str:
-        # milliseconds
-        return _convert_date_to_epoch_milliseconds(value)
+        return value.strftime("%Y-%m-%d")
 
     def _time_to_snowflake_bindings(self, _, value: dt_t) -> str:
         # nanoseconds


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-770678

with the integer representation, the date can only be represented at maximal `31536000000 ` seconds which is `May 3, 2969 12:00:00 AM`. Any date beyond the date will be taken as milliseconds/nanoseconds. leading to incorrect date.

In the PR, we use the simple string form the represent the date

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
