### PR TITLE
ENGDOC-204 fix Sphinx-busting docstring

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -182,11 +182,11 @@ class SnowflakeCursor:
         connection: The connection object by which the cursor was created.
         errorhandle: The class that handles error handling.
         is_file_transfer: Whether, or not the current command is a put, or get.
-
-    TODO:
-        Most of these attributes have no reason to be properties, we could just store them in public variables.
-        Calling a function is expensive in Python and most of these getters are unnecessary.
     """
+
+    # TODO:
+    #    Most of these attributes have no reason to be properties, we could just store them in public variables.
+    #    Calling a function is expensive in Python and most of these getters are unnecessary.
 
     INSERT_SQL_RE = re.compile(r"^insert\s+into", flags=re.IGNORECASE)
     COMMENT_SQL_RE = re.compile(r"/\*.*\*/")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1570

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Moves a `TODO` comment out of a docstring in `cursor.py` so Sphinx with sphinx-immaterial theme doesn't explode when building API reference docs.
