### PR TITLE
SNOW-756493 Add param to keep server session alive

### DIFF
--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1254,3 +1254,15 @@ def test_not_found_connection_name():
         match=f"Invalid connection_name '{connection_name}', known ones are",
     ):
         snowflake.connector.connect(connection_name=connection_name)
+
+
+def test_server_session_keep_alive(conn_cnx):
+    mock_delete_session = mock.MagicMock()
+    with conn_cnx(server_session_keep_alive=True) as conn:
+        conn.rest.delete_session = mock_delete_session
+    mock_delete_session.assert_not_called()
+
+    mock_delete_session = mock.MagicMock()
+    with conn_cnx() as conn:
+        conn.rest.delete_session = mock_delete_session
+    mock_delete_session.assert_called_once()


### PR DESCRIPTION
Description

There are use cases that want to reuse the same session across different connections after closing the connection. This enables such use cases.

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-756493

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   There are use cases that want to reuse the same session across different connections after closing the connection. This enables such use cases.
