### PR TITLE
SNOW-834415 Dont auto create config folder

### DIFF
--- a/src/snowflake/connector/sf_dirs.py
+++ b/src/snowflake/connector/sf_dirs.py
@@ -23,7 +23,6 @@ def _resolve_platform_dirs() -> PlatformDirsABC:
     platformdir_kwargs = {
         "appname": "snowflake",
         "appauthor": False,
-        "ensure_exists": True,
     }
     snowflake_home = os.path.expanduser(
         os.environ.get("SNOWFLAKE_HOME", "~/.snowflake/"),


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-834415

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We use the `ensure_exists` convenience feature of `platformdirs` this unfortunately creates our config folder at import time. Which will not work in Lambda. In this PR I remove this flag.
   Successful run: https://ci-dev-122.int.snowflakecomputing.com/job/RT-PyConnector37-PC-Lambda/186/console
