### PR TITLE
SNOW-802807 adding missing reference to config_manager.py __all__

### DIFF
--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -339,6 +339,7 @@ CONFIG_PARSER.add_option(
 )
 
 __all__ = [
+    "ConfigOption",
     "ConfigManager",
     "CONFIG_PARSER",
 ]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Complements SNOW-802807 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It was brought to my attention that I forgot to add this one reference to `config_manager.py`'s `__all__`. Correcting my mistake here.