### PR TITLE
fixing platformdirs incompatibility

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Bumped cryptography dependency from <41.0.0,>=3.1.0 to >=3.1.0,<42.0.0.
   - Improved OCSP response caching to remove tmp cache files on Windows.
   - Added a parameter `server_session_keep_alive` in `SnowflakeConnection` that skips session deletion when client connection closes.
+  - Tightened our pinning of platformdirs, to prevent their new releases breaking us.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     typing_extensions>=4.3,<5
     filelock>=3.5,<4
     sortedcontainers>=2.4.0
-    platformdirs>=2.6.0,<4.0.0
+    platformdirs>=2.6.0,<3.7.0
     tomlkit
 include_package_data = True
 package_dir =

--- a/src/snowflake/connector/sf_dirs.py
+++ b/src/snowflake/connector/sf_dirs.py
@@ -134,3 +134,8 @@ class SFPlatformDirs(PlatformDirsABC):
     def user_videos_dir(self) -> str:
         """videos directory tied to the user"""
         return self.user_data_dir
+
+    @property
+    def user_downloads_dir(self) -> str:
+        """downloads directory tied to the user"""
+        return self.user_data_dir


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   New `platformdirs` [release](https://pypi.org/project/platformdirs/3.6.0/) has added a new property to the abstract class that we implement. Effectively blocking us to instantiate one of these classes. This has broken our unit tests everywhere. In this PR I lock down our pinning more to prevent this in the future and I update our implementation too.