### PR TITLE
SNOW-802807 SNOWFLAKE_HOME config file resolution bug

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -14,6 +14,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Improved OCSP response caching to remove tmp cache files on Windows.
   - Added a parameter `server_session_keep_alive` in `SnowflakeConnection` that skips session deletion when client connection closes.
   - Tightened our pinning of platformdirs, to prevent their new releases breaking us.
+  - Fixed a bug where SFPlatformDirs would incorrectly append application_name/version to its path.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/src/snowflake/connector/sf_dirs.py
+++ b/src/snowflake/connector/sf_dirs.py
@@ -73,7 +73,7 @@ class SFPlatformDirs(PlatformDirsABC):
     @property
     def user_data_dir(self) -> str:
         """data directory tied to to the user"""
-        return self._append_app_name_and_version(self.single_dir)
+        return self.single_dir
 
     @property
     def site_data_dir(self) -> str:

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -273,9 +273,6 @@ def test_error_missing_fp_retrieve():
 )
 def test_sf_dirs(tmp_path, method, version):
     appname = random_string(5)
-    single_dir = tmp_path / appname
-    if version is not None:
-        single_dir = single_dir / version
     assert getattr(
         SFPlatformDirs(
             str(tmp_path),
@@ -285,8 +282,7 @@ def test_sf_dirs(tmp_path, method, version):
             ensure_exists=True,
         ),
         method,
-    ) == str(single_dir)
-    assert single_dir.exists() and not single_dir.is_file()
+    ) == str(tmp_path)
 
 
 def test_config_file_resolution_sfdirs_default():


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Relates to SNOW-802807
2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We discovered a bug where `appname` and possibly `version` was being appended to `SNOWFLAKE_HOME`.
   What this lead to is that configuration file location would become `/Users/mkeller/.snowflake/snowflake/config.toml` when `~/.snowflake` existed.
   
   In this PR I remove appending these pieces to the path and update the accompanying unit tests. I guess I knew this when I wrote this code, but it never occurred to me that this was not what we wanted