### PR TITLE
SNOW-851522: pin pre-commit to use py38 as isort in precommit doesn't support py37 anymore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,6 +129,7 @@ deps = flake8
 commands = flake8 {posargs}
 
 [testenv:fix_lint]
+basepython = python3.8
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
 passenv =
     PROGRAMDATA


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
