### PR TITLE
Mitigate a segfault by avoiding pickle.dump() in favor of pickle.dumps()

### DIFF
--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -531,7 +531,7 @@ class SFDictFileCache(SFDictCache):
                     # python program.
                     # thus we fall back to the approach using the normal open() method to open a file and write.
                     with open(tmp_file, "wb") as w_file:
-                        pickle.dump(self, w_file)
+                        w_file.write(pickle.dumps(self))
                     # We write to a tmp file and then move it to have atomic write
                     os.replace(tmp_file_path, self.file_path)
                     self.last_loaded = datetime.datetime.fromtimestamp(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1627 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

See the note [here](https://github.com/snowflakedb/snowflake-connector-python/issues/1627#issuecomment-1628066246) for details. It's not entirely clear that this fix is bullet-proof, but it avoids using pickle.dump(), which was shown to segfault in CPython code.
