### PR TITLE
SNOW-856569 making save actions thread-safe

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -39,6 +39,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Remove Python 3.7 support.
   - Worked around a segfault which sometimes occurred during cache serialization in multi-threaded scenarios.
   - Improved error handling of connection reset error.
+  - Fixed a bug where pickle.dump segfaults during cache serialization in multi-threaded scenarios.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -211,6 +211,11 @@ class SFDictCache(Generic[K, V]):
         other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
         update_newer_only: bool = False,
     ) -> bool:
+        """Non-locking version of update.
+
+        This should only be used by internal functions when already
+        holding self._lock and other._lock.
+        """
         assert (
             self._lock.locked()
         ), "The mutex self._lock should be locked by this thread"
@@ -253,6 +258,7 @@ class SFDictCache(Generic[K, V]):
     def update(
         self,
         other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
+        update_newer_only: bool = False,
     ) -> bool:
         """Insert multiple values at the same time, if self could learn from the other.
 
@@ -270,7 +276,7 @@ class SFDictCache(Generic[K, V]):
         into the other caches.
         """
         with self._lock:
-            return self._update(other)
+            return self._update(other, update_newer_only)
 
     def update_newer(
         self,

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -104,14 +104,8 @@ class SFDictCache(Generic[K, V]):
             self._hit(k)
         return v
 
-    def _getitem_non_locking(
-        self,
-        k: K,
-        *,
-        should_record_hits: bool = True,
-    ) -> V:
-        # aliasing _getitem to unify the api with SFDictFileCache
-        return self._getitem(k, should_record_hits=should_record_hits)
+    # aliasing _getitem to unify the api with SFDictFileCache
+    _getitem_non_locking = _getitem
 
     def _setitem(self, k: K, v: V) -> None:
         """Non-locking version of __setitem__.

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -75,8 +75,7 @@ class SFDictCache(Generic[K, V]):
         the dictionary provided.
         """
         cache = cls(**kw)
-        for k, v in _dict.items():
-            cache[k] = v
+        cache.update(_dict)
         return cache
 
     def _getitem(

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -536,6 +536,8 @@ class SFDictFileCache(SFDictCache):
             self._cache_modified = cache_file_learnt
             self.last_loaded = now()
             return True
+        except AssertionError:
+            raise
         except Exception as e:
             logger.debug("Fail to read cache from disk due to error: %s", e)
             return False
@@ -608,6 +610,8 @@ class SFDictFileCache(SFDictCache):
             logger.debug(
                 f"acquiring {self._file_lock_path} timed out, skipping saving..."
             )
+        except AssertionError:
+            raise
         except Exception as e:
             logger.debug("Fail to write cache to disk due to error: %s", e)
         return False

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -257,6 +257,7 @@ class SFDictCache(Generic[K, V]):
         self._cache.update(to_insert)
         if to_insert:
             self._add_or_remove()
+        # TODO: this should really save_if_should
         return len(to_insert) > 0
 
     def update(

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -90,6 +90,9 @@ class SFDictCache(Generic[K, V]):
         This should only be used by internal functions when already
         holding self._lock.
         """
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         try:
             t, v = self._cache[k]
         except KeyError:
@@ -116,6 +119,9 @@ class SFDictCache(Generic[K, V]):
         This should only be used by internal functions when already
         holding self._lock.
         """
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         self._cache[k] = CacheEntry(
             expiry=now() + self._entry_lifetime,
             entry=v,
@@ -182,6 +188,9 @@ class SFDictCache(Generic[K, V]):
         This should only be used by internal functions when already
         holding self._lock.
         """
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         del self._cache[key]
         self._add_or_remove()
 
@@ -209,6 +218,9 @@ class SFDictCache(Generic[K, V]):
         other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
         update_newer_only: bool = False,
     ) -> bool:
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         to_insert: dict[K, CacheEntry[V]]
         self._clear_expired_entries()
         if isinstance(other, (list, dict)):
@@ -219,6 +231,9 @@ class SFDictCache(Generic[K, V]):
                 g = iter(other.items())
             to_insert = {k: CacheEntry(expiry=expiry, entry=v) for k, v in g}
         elif isinstance(other, SFDictCache):
+            assert (
+                other._lock.locked()
+            ), "The mutex other._lock should be locked by this thread"
             other._clear_expired_entries()
             others_items = list(other._cache.items())
             # Only accept values from another cache if their key is not in self,
@@ -276,6 +291,9 @@ class SFDictCache(Generic[K, V]):
             )
 
     def _clear_expired_entries(self) -> None:
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         cache_updated = False
         for k in list(self._cache.keys()):
             try:
@@ -523,6 +541,9 @@ class SFDictFileCache(SFDictCache):
 
         This function is non-locking when it comes to self._lock.
         """
+        assert (
+            self._lock.locked()
+        ), "The mutex self._lock should be locked by this thread"
         self._clear_expired_entries()
         if not self._cache_modified and not force_flush:
             # cache is not updated, so there is no need to dump cache to file, we just return

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -662,15 +662,6 @@ class SFDictFileCache(SFDictCache):
         with self._lock:
             self._save(load_first=False, force_flush=True)
 
-    def _update(
-        self,
-        other: dict[K, V] | list[tuple[K, V]] | SFDictCache[K, V],
-        update_newer_only: bool = False,
-    ) -> bool:
-        updated = super()._update(other, update_newer_only=update_newer_only)
-        self._save_if_should()
-        return updated
-
     # Custom pickling implementation
 
     def __getstate__(self) -> dict:

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -527,7 +527,7 @@ class SFDictFileCache(SFDictCache):
         """Load cache from disk if possible, returns whether it was able to load."""
         try:
             with open(self.file_path, "rb") as r_file:
-                other = pickle.load(r_file)
+                other: SFDictFileCache = pickle.load(r_file)
             # Since we want to know whether we are dirty after loading
             #  we have to know whether the file could learn anything from self
             #  so instead of calling self.update we call other.update and swap
@@ -539,7 +539,7 @@ class SFDictFileCache(SFDictCache):
             )
             self._lock.acquire()
             self._cache, other._cache = other._cache, self._cache
-            self.telemetry.update(other.telemetry)
+            self.telemetry["size"] = other.telemetry["size"]
             self._cache_modified = cache_file_learnt
             self.last_loaded = now()
             return True

--- a/src/snowflake/connector/cache.py
+++ b/src/snowflake/connector/cache.py
@@ -236,8 +236,7 @@ class SFDictCache(Generic[K, V]):
                 g = iter(other.items())
             to_insert = {k: CacheEntry(expiry=expiry, entry=v) for k, v in g}
         elif isinstance(other, SFDictCache):
-            with other._lock:
-                other._clear_expired_entries()
+            other.clear_expired_entries()
             others_items = list(other._cache.items())
             # Only accept values from another cache if their key is not in self,
             #  or if expiry is later the self known one

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -323,3 +323,4 @@ DAY_IN_SECONDS = 60 * 60 * 24
 
 # TODO: all env variables definitions should be here
 ENV_VAR_PARTNER = "SF_PARTNER"
+ENV_VAR_TEST_MODE = "SNOWFLAKE_TEST_MODE"

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -587,7 +587,7 @@ class OCSPCache:
         """
         if OCSPCache.CACHE_UPDATED:
             if isinstance(OCSP_RESPONSE_VALIDATION_CACHE, SFDictFileCache):
-                OCSP_RESPONSE_VALIDATION_CACHE._save()
+                OCSP_RESPONSE_VALIDATION_CACHE.save()
             OCSPCache.update_ocsp_response_cache_file(
                 ocsp, OCSPCache.OCSP_RESPONSE_CACHE_URI
             )

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1618,7 +1618,7 @@ class SnowflakeOCSP:
                             self, cert_id, cache_key=cache_key, lock_cache=False
                         )
             if new_cache_dict:
-                OCSP_RESPONSE_VALIDATION_CACHE._update(new_cache_dict)
+                OCSP_RESPONSE_VALIDATION_CACHE.update(new_cache_dict)
                 OCSPCache.CACHE_UPDATED = True
         except Exception as ex:
             logger.debug("Caught here - %s", ex)

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -468,21 +468,21 @@ class TestSFDictFileCache:
 
     def test_broken_pickle_objects(self, tmpdir):
         cache_path = os.path.join(tmpdir, "cache.txt")
-        c1 = cache.SFDictFileCache(file_path=cache_path)
+        c1 = NeverSaveSFDictFileCache(file_path=cache_path)
         c1["key"] = BrokenReadingPickleObject()
         assert c1.save()
         assert os.path.exists(cache_path) and os.path.isfile(cache_path)
 
-        c2 = cache.SFDictFileCache(file_path=cache_path)
+        c2 = NeverSaveSFDictFileCache(file_path=cache_path)
         assert not c2._load()  # load should return false due to ModuleNotFound error
 
         cache_path = os.path.join(tmpdir, "cache2.txt")
-        c1 = cache.SFDictFileCache(file_path=cache_path)
+        c1 = NeverSaveSFDictFileCache(file_path=cache_path)
         c1["key"] = BrokenWritingPickleObject()
         assert not c1.save()
         assert not os.path.exists(cache_path)
 
-        c2 = cache.SFDictFileCache(file_path=cache_path)
+        c2 = NeverSaveSFDictFileCache(file_path=cache_path)
         assert not c2.load()  # load should return false due to no file
 
 

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -306,24 +306,6 @@ class TestSFDictFileCache:
         assert c2["a"] == 2
         assert c["a"] == 2
 
-    def test_expiration2(self, tmpdir):
-        tmp_file = os.path.join(tmpdir, "c.txt")
-        c = AlwaysSaveSFDictFileCache.from_dict(
-            {"a": 1},
-            entry_lifetime=0,
-            file_path=tmp_file,
-        )
-        with pytest.raises(KeyError):
-            c["a"]
-        c2 = AlwaysSaveSFDictFileCache.from_dict(
-            {"a": 2},
-            file_path=tmp_file,
-        )
-        c["a"] = 1
-        c2["a"] = 2
-        assert c2["a"] == 2
-        assert c["a"] == 2
-
     # The rest of the tests test the file cache portion
 
     def test_simple_miss(self, tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ setenv =
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
     SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.connector --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=
     SNOWFLAKE_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_OPTS:} {env:SNOWFLAKE_PYTEST_COV_CMD}
+    SNOWFLAKE_TEST_MODE = true
 passenv =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1627 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I hopefully fix the underlying issue causing `pickle.dump` segfaults.
   The just of what I found is that calls calling `_save` did not hold `self._lock` which could lead to other threads modifying the data in the cache while dumping was going on and more issues were found later. I verified this with `assert` statements.
    I also updated all the unsafe call places that I could find. I left in the assert statements for now to catch other unsafe calls.
    I included a draw.io graph for how the different functions call each other, note that control flow goes left to right.
    [SFDictCache control flow.drawio.zip](https://github.com/snowflakedb/snowflake-connector-python/files/12089342/SFDictCache.control.flow.drawio.zip)
