### PR TITLE
SNOW-833713: revert try setting item when saving parameter

### DIFF
--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -489,14 +489,14 @@ class TestSFDictFileCache:
 def test_file_is_not_updated(tmpdir):
     tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
     sfcache = cache.SFDictFileCache(file_path=tmp_cache_file, entry_lifetime=1)
-    sfcache["key"] = "value"
+    sfcache.update({"key": "value"})
     assert sfcache._cache_modified
     sfcache._save()  # this save call will dump cache to file because item was added
     assert not sfcache._cache_modified
     updated_time = os.path.getmtime(tmp_cache_file)
     sfcache._save()  # this save call will be a no-op since there is no update
     assert os.path.getmtime(tmp_cache_file) == updated_time
-    sfcache["key"] = "value2"
+    sfcache.update({"key": "value2"})
     assert sfcache._cache_modified
     time.sleep(0.1)  # sleep 0.1 to avoid flushing too fast
     sfcache._save()  # this save call will dump cache to file

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -469,7 +469,7 @@ class TestSFDictFileCache:
         cache_path = os.path.join(tmpdir, "cache.txt")
         c1 = cache.SFDictFileCache(file_path=cache_path)
         c1["key"] = BrokenReadingPickleObject()
-        assert c1._save(force_flush=True)
+        assert c1._save()
         assert os.path.exists(cache_path) and os.path.isfile(cache_path)
 
         c2 = cache.SFDictFileCache(file_path=cache_path)
@@ -478,7 +478,7 @@ class TestSFDictFileCache:
         cache_path = os.path.join(tmpdir, "cache2.txt")
         c1 = cache.SFDictFileCache(file_path=cache_path)
         c1["key"] = BrokenWritingPickleObject()
-        assert not c1._save(force_flush=True)
+        assert not c1._save()
         assert not os.path.exists(cache_path)
 
         c2 = cache.SFDictFileCache(file_path=cache_path)
@@ -487,9 +487,7 @@ class TestSFDictFileCache:
 
 def test_file_is_not_updated(tmpdir):
     tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
-    sfcache = cache.SFDictFileCache(
-        file_path=tmp_cache_file, entry_lifetime=1, try_saving_when_set_item=False
-    )
+    sfcache = cache.SFDictFileCache(file_path=tmp_cache_file, entry_lifetime=1)
     sfcache["key"] = "value"
     assert sfcache._cache_modified
     sfcache._save()  # this save call will dump cache to file because item was added
@@ -521,9 +519,11 @@ def test_file_is_not_updated(tmpdir):
 
 def test_cache_do_not_write_while_set_item(tmpdir):
     tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
-    sfcache = cache.SFDictFileCache(tmp_cache_file, try_saving_when_set_item=False)
+    sfcache = cache.SFDictFileCache(tmp_cache_file)
+    to_update_dict = {}
     for i in range(1000):
-        sfcache[i] = i
+        to_update_dict[i] = i
+    sfcache.update(to_update_dict)
     # there should be no file created as setting item won't trigger creation
     assert sfcache._cache_modified
     assert not os.path.exists(tmp_cache_file)
@@ -531,7 +531,7 @@ def test_cache_do_not_write_while_set_item(tmpdir):
     assert not sfcache._cache_modified
     assert os.path.exists(tmp_cache_file)
     file_modified_time = os.path.getmtime(tmp_cache_file)
-    sfcache2 = cache.SFDictFileCache(tmp_cache_file, try_saving_when_set_item=False)
+    sfcache2 = cache.SFDictFileCache(tmp_cache_file)
     time.sleep(0.01)
     for i in range(1000):
         assert sfcache2[i] == i

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -469,7 +469,8 @@ class TestSFDictFileCache:
         cache_path = os.path.join(tmpdir, "cache.txt")
         c1 = cache.SFDictFileCache(file_path=cache_path)
         c1["key"] = BrokenReadingPickleObject()
-        assert c1._save()
+        # __setitem__ might have already saved the item, so cache is unchanged after saving, thus we force flush here
+        assert c1._save(force_flush=True)
         assert os.path.exists(cache_path) and os.path.isfile(cache_path)
 
         c2 = cache.SFDictFileCache(file_path=cache_path)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   follow upon the first PR of SNOW-833713, revert the part that introduces `try_saving_when_setting` in the commit: https://github.com/snowflakedb/snowflake-connector-python/commit/398d1ea770ebd506edef7218943f3a971b19f48f

revert unnecessary change

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
