### PR TITLE
SNOW-847497: recreate session connection if reset by server

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug where `write_pandas` fails when user does not have the privilege to create stage or file format in the target schema, but has the right privilege for the current schema.
   - Remove Python 3.7 support.
   - Worked around a segfault which sometimes occurred during cache serialization in multi-threaded scenarios.
+  - Improved error handling of connection reset error.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -43,6 +43,7 @@ from snowflake.connector.network import (
 
 # We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
 try:
+    import snowflake.connector.vendored.urllib3.contrib.pyopenssl
     from snowflake.connector.vendored import requests, urllib3
 except ImportError:  # pragma: no cover
     import requests
@@ -369,3 +370,47 @@ def test_secret_masking(caplog):
     assert '"TOKEN": "****' in caplog.text
     assert '"PASSWORD": "****' in caplog.text
     assert ret == {}
+
+
+def test_retry_connection_reset_error(is_public_test, caplog):
+    if not is_public_test:
+        pytest.skip("non public test does not use pyopenssl")
+    connection = MagicMock()
+    connection.errorhandler = Mock(return_value=None)
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    data = (
+        '{"code": 12345,'
+        ' "data": {"TOKEN": "_Y1ZNETTn5/qfUWj3Jedb", "PASSWORD": "dummy_pass"}'
+        "}"
+    )
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": data,
+    }
+
+    def error_recv_into(*args, **kwargs):
+        raise OSError(104, "ECONNRESET")
+
+    with patch.object(
+        snowflake.connector.vendored.urllib3.contrib.pyopenssl.WrappedSocket,
+        "recv_into",
+        new=error_recv_into,
+    ):
+        with caplog.at_level(logging.DEBUG):
+            rest.fetch(timeout=10, **default_parameters)
+
+        assert (
+            "shutting down requests session adapter due to connection aborted"
+            in caplog.text
+        )
+        assert (
+            "Ignored error caused by closing https connection failure"
+            not in caplog.text
+        )
+        assert caplog.text.count("Starting new HTTPS connection") > 1

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -372,9 +372,7 @@ def test_secret_masking(caplog):
     assert ret == {}
 
 
-def test_retry_connection_reset_error(is_public_test, caplog):
-    if not is_public_test:
-        pytest.skip("non public test does not use pyopenssl")
+def test_retry_connection_reset_error(caplog):
     connection = MagicMock()
     connection.errorhandler = Mock(return_value=None)
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-847497

if the https connection is reset by server, we abandon the old one and let urllib3 create new connection

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
