### PR TITLE
SNOW-862821 [Python Connector] Update query context cache response body to align with JDBC

### DIFF
--- a/src/snowflake/connector/_query_context_cache.py
+++ b/src/snowflake/connector/_query_context_cache.py
@@ -259,6 +259,7 @@ class QueryContextCache:
                         entry.get("priority"),
                         context,
                     )
+                    
                 # Sync the priority map at the end of for loop insert.
                 self._sync_priority_map()
             except Exception as e:

--- a/src/snowflake/connector/_query_context_cache.py
+++ b/src/snowflake/connector/_query_context_cache.py
@@ -151,13 +151,13 @@ class QueryContextCache:
     def _last(self) -> QueryContextElement:
         return self._tree_set[-1]
 
-    def serialize_to_json(self) -> str:
+    def serialize_to_dict(self) -> dict:
         with self._lock:
-            logger.debug("serialize_to_json() called")
+            logger.debug("serialize_to_dict() called")
             self.log_cache_entries()
 
             if len(self._tree_set) == 0:
-                return ""
+                return {} # we should return an empty dict
 
             try:
                 data = {
@@ -166,22 +166,25 @@ class QueryContextCache:
                             "id": qce.id,
                             "timestamp": qce.read_timestamp,
                             "priority": qce.priority,
-                            "context": qce.context,
+                            "context": {"base64Data" : qce.context} if qce.context != None else {},
                         }
                         for qce in self._tree_set
                     ]
                 }
-                # Serialize the data to JSON
-                serialized_data = json.dumps(data)
+                # Because on GS side, `context` field is an object with `base64Data`  string member variable,
+                # we should serialize `context` field to an object instead of string directly to stay consistent with GS side.
+            
 
                 logger.debug(
-                    f"serialize_to_json(): data to send to server {serialized_data}"
+                    f"serialize_to_dict(): data to send to server {data}"
                 )
-
-                return serialized_data
+                
+                # query context shoule be an object field of the HTTP request body JSON and on GS side. here we should only return a dict
+                # and let the outer HTTP request body to convert the entire big dict to a single JSON.
+                return data 
             except Exception as e:
-                logger.debug(f"serialize_to_json(): Exception {e}")
-                return ""
+                logger.debug(f"serialize_to_dict(): Exception {e}")
+                return {}
 
     def deserialize_json_dict(self, data: dict) -> None:
         with self._lock:
@@ -256,7 +259,6 @@ class QueryContextCache:
                         entry.get("priority"),
                         context,
                     )
-
                 # Sync the priority map at the end of for loop insert.
                 self._sync_priority_map()
             except Exception as e:

--- a/src/snowflake/connector/_query_context_cache.py
+++ b/src/snowflake/connector/_query_context_cache.py
@@ -3,7 +3,6 @@
 #
 from __future__ import annotations
 
-import json
 from functools import total_ordering
 from hashlib import md5
 from logging import getLogger
@@ -157,7 +156,7 @@ class QueryContextCache:
             self.log_cache_entries()
 
             if len(self._tree_set) == 0:
-                return {} # we should return an empty dict
+                return {}  # we should return an empty dict
 
             try:
                 data = {
@@ -166,22 +165,21 @@ class QueryContextCache:
                             "id": qce.id,
                             "timestamp": qce.read_timestamp,
                             "priority": qce.priority,
-                            "context": {"base64Data" : qce.context} if qce.context != None else {},
+                            "context": {"base64Data": qce.context}
+                            if qce.context is not None
+                            else {},
                         }
                         for qce in self._tree_set
                     ]
                 }
                 # Because on GS side, `context` field is an object with `base64Data`  string member variable,
                 # we should serialize `context` field to an object instead of string directly to stay consistent with GS side.
-            
 
-                logger.debug(
-                    f"serialize_to_dict(): data to send to server {data}"
-                )
-                
+                logger.debug(f"serialize_to_dict(): data to send to server {data}")
+
                 # query context shoule be an object field of the HTTP request body JSON and on GS side. here we should only return a dict
                 # and let the outer HTTP request body to convert the entire big dict to a single JSON.
-                return data 
+                return data
             except Exception as e:
                 logger.debug(f"serialize_to_dict(): Exception {e}")
                 return {}
@@ -259,7 +257,7 @@ class QueryContextCache:
                         entry.get("priority"),
                         context,
                     )
-                    
+
                 # Sync the priority map at the end of for loop insert.
                 self._sync_priority_map()
             except Exception as e:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1111,7 +1111,6 @@ class SnowflakeConnection:
             queryContext = self.get_query_context()
             if(queryContext is not None):
                 data["queryContextDTO"] = queryContext
-            print(data["queryContextDTO"])
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 
         if logger.getEffectiveLevel() <= logging.DEBUG:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1107,8 +1107,11 @@ class SnowflakeConnection:
             # binding parameters. This is for qmarks paramstyle.
             data["bindings"] = binding_params
         if not _no_results:
-            # not an async query
-            data["queryContext"] = self.get_query_context()
+            # not an async query. Here queryContextDTO should be a dict object field, same with `parameters` field
+            queryContext = self.get_query_context()
+            if(queryContext is not None):
+                data["queryContextDTO"] = queryContext
+            print(data["queryContextDTO"])
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
@@ -1647,10 +1650,10 @@ class SnowflakeConnection:
         if not self.is_query_context_cache_disabled:
             self.query_context_cache = QueryContextCache(self.query_context_cache_size)
 
-    def get_query_context(self) -> str | None:
+    def get_query_context(self) -> dict | None:
         if self.is_query_context_cache_disabled:
             return None
-        return self.query_context_cache.serialize_to_json()
+        return self.query_context_cache.serialize_to_dict()
 
     def set_query_context(self, data: dict) -> None:
         if not self.is_query_context_cache_disabled:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1107,9 +1107,10 @@ class SnowflakeConnection:
             # binding parameters. This is for qmarks paramstyle.
             data["bindings"] = binding_params
         if not _no_results:
-            # not an async query. Here queryContextDTO should be a dict object field, same with `parameters` field
+            # not an async query.
             queryContext = self.get_query_context()
             if queryContext is not None:
+                #  Here queryContextDTO should be a dict object field, same with `parameters` field
                 data["queryContextDTO"] = queryContext
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1109,9 +1109,8 @@ class SnowflakeConnection:
         if not _no_results:
             # not an async query.
             queryContext = self.get_query_context()
-            if queryContext is not None:
-                #  Here queryContextDTO should be a dict object field, same with `parameters` field
-                data["queryContextDTO"] = queryContext
+            #  Here queryContextDTO should be a dict object field, same with `parameters` field
+            data["queryContextDTO"] = queryContext
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 
         if logger.getEffectiveLevel() <= logging.DEBUG:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1109,7 +1109,7 @@ class SnowflakeConnection:
         if not _no_results:
             # not an async query. Here queryContextDTO should be a dict object field, same with `parameters` field
             queryContext = self.get_query_context()
-            if(queryContext is not None):
+            if queryContext is not None:
                 data["queryContextDTO"] = queryContext
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -408,7 +408,7 @@ def test_serialization_deserialization_with_null_context(
 
     qcc_with_data_null_context.clear_cache()
     assert len(qcc_with_data_null_context) == 0
-    
+
     data = json.loads(data)  # convert JSON to dict
     qcc_with_data_null_context.deserialize_json_dict(data)
     assert_cache_with_data(qcc_with_data_null_context, expected_data_with_null_context)
@@ -422,7 +422,7 @@ def test_serialization_deserialization(
     data = serialize_to_json(qcc_with_data)
     qcc_with_data.clear_cache()
     assert len(qcc_with_data) == 0
-    
+
     data = json.loads(data)  # convert JSON to dict
     qcc_with_data.deserialize_json_dict(data)
     assert_cache_with_data(qcc_with_data, expected_data)

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -50,6 +50,7 @@ class ExpectedQCCData:
         self.timestamps = [BASE_READ_TIMESTAMP + i for i in range(self.capacity)]
         self.priorities = [BASE_PRIORITY + i for i in range(self.capacity)]
 
+
 # This function is used for testing the deserialize_to_dict function is correct. Note that `QueryContextCache::serialize_to_dict` function is used in sending the query context back to GS.
 # It has slight difference with this function on `context` field.
 def serialize_to_json(qcc: QueryContextCache) -> str:

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -51,9 +51,11 @@ class ExpectedQCCData:
         self.priorities = [BASE_PRIORITY + i for i in range(self.capacity)]
 
 
-# This function is used for testing the deserialize_to_dict function is correct. Note that `QueryContextCache::serialize_to_dict` function is used in sending the query context back to GS.
-# It has slight difference with this function on `context` field.
 def serialize_to_json(qcc: QueryContextCache) -> str:
+    """
+    This function is used for testing the deserialize_to_dict function is correct. Note that `QueryContextCache::serialize_to_dict` function is used in sending the query context back to GS.
+    It has slight difference with this function on `context` field.
+    """
     with qcc._lock:
         qcc.log_cache_entries()
 
@@ -76,7 +78,7 @@ def serialize_to_json(qcc: QueryContextCache) -> str:
             serialized_data = json.dumps(data)
 
             return serialized_data
-        except Exception as e:
+        except Exception:
             return ""
 
 

--- a/test/unit/test_query_context_cache.py
+++ b/test/unit/test_query_context_cache.py
@@ -50,6 +50,34 @@ class ExpectedQCCData:
         self.timestamps = [BASE_READ_TIMESTAMP + i for i in range(self.capacity)]
         self.priorities = [BASE_PRIORITY + i for i in range(self.capacity)]
 
+# This function is used for testing the deserialize_to_dict function is correct. Note that `QueryContextCache::serialize_to_dict` function is used in sending the query context back to GS.
+# It has slight difference with this function on `context` field.
+def serialize_to_json(qcc: QueryContextCache) -> str:
+    with qcc._lock:
+        qcc.log_cache_entries()
+
+        if len(qcc._tree_set) == 0:
+            return ""
+
+        try:
+            data = {
+                "entries": [
+                    {
+                        "id": qce.id,
+                        "timestamp": qce.read_timestamp,
+                        "priority": qce.priority,
+                        "context": qce.context,
+                    }
+                    for qce in qcc._tree_set
+                ]
+            }
+            # Serialize the data to JSON
+            serialized_data = json.dumps(data)
+
+            return serialized_data
+        except Exception as e:
+            return ""
+
 
 @pytest.fixture()
 def expected_data() -> ExpectedQCCData:
@@ -376,10 +404,11 @@ def test_serialization_deserialization_with_null_context(
 ):
     assert_cache_with_data(qcc_with_data_null_context, expected_data_with_null_context)
 
-    data = qcc_with_data_null_context.serialize_to_json()
+    data = serialize_to_json(qcc_with_data_null_context)
+
     qcc_with_data_null_context.clear_cache()
     assert len(qcc_with_data_null_context) == 0
-
+    
     data = json.loads(data)  # convert JSON to dict
     qcc_with_data_null_context.deserialize_json_dict(data)
     assert_cache_with_data(qcc_with_data_null_context, expected_data_with_null_context)
@@ -390,10 +419,10 @@ def test_serialization_deserialization(
 ):
     assert_cache_with_data(qcc_with_data, expected_data)
 
-    data = qcc_with_data.serialize_to_json()
+    data = serialize_to_json(qcc_with_data)
     qcc_with_data.clear_cache()
     assert len(qcc_with_data) == 0
-
+    
     data = json.loads(data)  # convert JSON to dict
     qcc_with_data.deserialize_json_dict(data)
     assert_cache_with_data(qcc_with_data, expected_data)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-862821

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When I was helping ODBC team to debug their query context related issue. I found that both ODBC and python connector have an inconsistent query context JSON serialization behavior for HTTP response. To be precise:
   
   1. The json field name should be `queryContextDTO` instead of `queryContext` to keep consistent with JDBC/GS.
   2. The entire `queryContextDTO` field is also not a string, it should be an object (dict in python).
   3. The `context` subfield is not a string, but an `OpaqueContextDTO` object in JDBC, and this object contains a string field which is the context base64 encoded value. 
`JSON: {"sqlText":"insert into t1 values (1, 2), (2, 3), (3, 4)","sequenceId":10,"bindings":{},"bindStage":null,"describeOnly":false,"parameters":{"NEW_SQL_FORMAT":false,"CLIENT_RESULT_CHUNK_SIZE":96},"queryContextDTO":{"entries":[{"id":0,"timestamp":6645635168985,"priority":0,"context":{}}]},"describedJobId":"01ad95f6-0000-0154-0000-0004011a4be2","querySubmissionTime":1689200068021,"isInternal":false,"asyncExec":false} `
    for example, here when context is empty, the value is {}. for string type context, the empty context will be serialized to "". This could cause GS side unable to convert the JSON back to java query context object.
    
    
For references:
1. JDBC https://github.com/snowflakedb/snowflake-jdbc/blob/9d625df285cc9896f3d14c6e1e6eed80cdd30d1b/src/main/java/net/snowflake/client/core/QueryContextDTO.java#L8
2. GS: https://github.com/snowflakedb/snowflake/blob/70d3da634cc30f7a653bf6e6463c63155e7dc786/GlobalServices/src/main/java/com/snowflake/api/monitoring/QueryContextDTO.java#L12

