### PR TITLE
SNOW-870322 Allow pass type_mapper to arrow to_pandas()

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -39,6 +39,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Remove Python 3.7 support.
   - Worked around a segfault which sometimes occurred during cache serialization in multi-threaded scenarios.
   - Improved error handling of connection reset error.
+  - Allowed to pass `type_mapper` to `fetch_pandas_batches()` and `fetch_pandas_all()`.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -178,19 +178,23 @@ class ResultSet(Iterable[list]):
         Snowflake's back-end.
         """
         self._can_create_arrow_iter()
-        return self._create_iter(iter_unit=IterUnit.TABLE_UNIT, structure="pandas")
+        return self._create_iter(
+            iter_unit=IterUnit.TABLE_UNIT, structure="pandas", **kwargs
+        )
 
     def _fetch_pandas_all(self, **kwargs) -> DataFrame:
         """Fetches a single Pandas dataframe."""
-        dataframes = list(self._fetch_pandas_batches())
+        dataframes = list(self._fetch_pandas_batches(**kwargs))
         if dataframes:
+            concat_kwargs = kwargs
+            concat_kwargs.pop("types_mapper", None)
             return pandas.concat(
                 dataframes,
                 ignore_index=True,  # Don't keep in result batch indexes
-                **kwargs,
+                **concat_kwargs,
             )
         # Empty dataframe
-        return self.batches[0].to_pandas()
+        return self.batches[0].to_pandas(**kwargs)
 
     def _get_metrics(self) -> dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""

--- a/src/snowflake/connector/result_set.py
+++ b/src/snowflake/connector/result_set.py
@@ -187,18 +187,15 @@ class ResultSet(Iterable[list]):
         """Fetches a single Pandas dataframe."""
         concat_args = list(inspect.signature(pandas.concat).parameters)
         concat_kwargs = {k: kwargs.pop(k) for k in dict(kwargs) if k in concat_args}
-        to_pandas_kwargs = dict(kwargs.items() - concat_kwargs.items())
-        dataframes = list(self._fetch_pandas_batches(**to_pandas_kwargs))
+        dataframes = list(self._fetch_pandas_batches(**kwargs))
         if dataframes:
-            # concat_kwargs = kwargs
-            # concat_kwargs.pop("types_mapper", None)
             return pandas.concat(
                 dataframes,
                 ignore_index=True,  # Don't keep in result batch indexes
                 **concat_kwargs,
             )
         # Empty dataframe
-        return self.batches[0].to_pandas(**to_pandas_kwargs)
+        return self.batches[0].to_pandas(**kwargs)
 
     def _get_metrics(self) -> dict[str, int]:
         """Sum up all the chunks' metrics and show them together."""


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-870322 Allow pass type_mapper to arrow to_pandas()

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

This PR allows fetch_pandas_batches() and fetch_pandas_all() to bypass kwargs to arrow.to_pandas(), e.g., we can pass type_mapper to it.