### PR TITLE
SNOW-873456 config file slicing

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,15 +9,15 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 - v3.0.5(TBD)
-  - Added a feature that lets you add connection definitions to the `config.toml` configuration file. A connection definition refers to a collection of connection parameters. The connection configuration name must begin with **connections**, similar to the following that defines the parameters for the `prod` connection:
+  - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, similar to the following that defines the parameters for the `prod` connection:
 
     ```toml
-    [connections.prod]
+    [prod]
     account = "my_account"
     user = "my_user"
     password = "my_password"
     ```
-    By default, we look for the `config.toml` file in the location specified in the `SNOWFLAKE_HOME` environment variable (default: `~/.snowflake`). If this folder does not exist, the Python connector looks for the file in the `platformdirs` location, as follows:
+    By default, we look for the `connections.toml` file in the location specified in the `SNOWFLAKE_HOME` environment variable (default: `~/.snowflake`). If this folder does not exist, the Python connector looks for the file in the `platformdirs` location, as follows:
 
     - On Linux: `~/.config/snowflake/`,  but follows XDG settings
     - On Mac: `~/Library/Application Support/snowflake/`

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -26,7 +26,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     You can determine which file is used by running the following command:
 
     ```
-    python -c "from snowflake.connector.constants import CONFIG_FILE; print(str(CONFIG_FILE))"
+    python -c "from snowflake.connector.constants import CONNECTIONS_FILE; print(str(CONNECTIONS_FILE))"
     ```
   - Bumped cryptography dependency from <41.0.0,>=3.1.0 to >=3.1.0,<42.0.0.
   - Improved OCSP response caching to remove tmp cache files on Windows.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,15 +9,14 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 - v3.0.5(TBD)
-  - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, similar to the following that defines the parameters for the `prod` connection:
-
+  - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, for example, if you wanted to define a connection named `prod``:
     ```toml
     [prod]
     account = "my_account"
     user = "my_user"
     password = "my_password"
     ```
-    By default, we look for the `connections.toml` file in the location specified in the `SNOWFLAKE_HOME` environment variable (default: `~/.snowflake`). If this folder does not exist, the Python connector looks for the file in the `platformdirs` location, as follows:
+    By default, we look for the `connections.toml` file in the location specified in the `SNOWFLAKE_HOME` environment variable (default: `~/.snowflake`). If this folder does not exist, the Python connector looks for the file in the [platformdirs](https://github.com/platformdirs/platformdirs/blob/main/README.rst) location, as follows:
 
     - On Linux: `~/.config/snowflake/`,  but follows XDG settings
     - On Mac: `~/Library/Application Support/snowflake/`

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -286,10 +286,8 @@ class ConfigManager:
                     "An unknown error happened while loading " f"'{str(filep)}'"
                 ) from e
             if section is None:
-                assert len(read_config_file) == 0
                 read_config_file = read_config_piece
             else:
-                assert section not in read_config_file
                 read_config_file[section] = read_config_piece
         self.conf_file_cache = read_config_file
 
@@ -379,7 +377,8 @@ CONFIG_PARSER = ConfigManager(
         (  # Optional connections file to read in connections from
             CONNECTIONS_FILE,
             ConfigSliceOptions(
-                check_permissions=True  # connections could live here, check permissions
+                check_permissions=True,  # connections could live here, check permissions
+                only_in_slice=True,
             ),
             "connections",
         ),

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -156,7 +156,15 @@ class ConfigOption:
                 f"Root parser '{self._root_manager.name}' is missing file_path",
             )
         for k in self._nest_path[1:]:
-            e = e[k]
+            try:
+                e = e[k]
+            except tomlkit.exceptions.NonExistentKey:
+                raise ConfigSourceError(
+                    f"Configuration option {self.option_name} is not defined anywhere, "
+                    "have you forgotten to set it in a configuration file, "
+                    "or environmental variable?"
+                )
+
         if isinstance(e, (Table, tomlkit.TOMLDocument)):
             # If we got a TOML table we probably want it in dictionary form
             return e.value

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import stat
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from operator import methodcaller
 from pathlib import Path
 from typing import Any, Callable, Literal, NamedTuple, TypeVar
@@ -215,7 +215,7 @@ class ConfigManager:
         *,
         name: str,
         file_path: Path | None = None,
-        _slices: Sequence[ConfigSlice] | None = None,
+        _slices: list[ConfigSlice] | None = None,
     ):
         """Create a new ConfigManager.
 
@@ -373,16 +373,15 @@ class ConfigManager:
 CONFIG_PARSER = ConfigManager(
     name="CONFIG_PARSER",
     file_path=CONFIG_FILE,
-    _slices=(
-        (  # Optional connections file to read in connections from
+    _slices=[
+        ConfigSlice(  # Optional connections file to read in connections from
             CONNECTIONS_FILE,
             ConfigSliceOptions(
                 check_permissions=True,  # connections could live here, check permissions
-                only_in_slice=True,
             ),
             "connections",
         ),
-    ),
+    ],
 )
 CONFIG_PARSER.add_option(
     name="connections",

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -16,7 +16,7 @@ from warnings import warn
 import tomlkit
 from tomlkit.items import Table
 
-from snowflake.connector.constants import CONFIG_FILE
+from snowflake.connector.constants import CONNECTIONS_FILES
 from snowflake.connector.errors import ConfigManagerError, ConfigSourceError
 
 _T = TypeVar("_T")
@@ -330,7 +330,7 @@ class ConfigManager:
 
 CONFIG_PARSER = ConfigManager(
     name="CONFIG_PARSER",
-    file_path=CONFIG_FILE,
+    file_path=CONNECTIONS_FILES,
 )
 CONFIG_PARSER.add_option(
     name="connections",

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -297,7 +297,7 @@ class SnowflakeConnection:
     def __init__(
         self,
         connection_name: str | None = None,
-        config_file_path: pathlib.Path | None = None,
+        connections_file_path: pathlib.Path | None = None,
         **kwargs,
     ) -> None:
         self._lock_sequence_counter = Lock()
@@ -332,10 +332,13 @@ class SnowflakeConnection:
         self.converter = None
         self.query_context_cache: QueryContextCache | None = None
         self.query_context_cache_size = 5
-        if config_file_path is not None:
+        if connections_file_path is not None:
             # Change config file path and force update cache
-            CONFIG_PARSER.file_path = config_file_path
-            CONFIG_PARSER.read_config()
+            for i, s in enumerate(CONFIG_PARSER._slices):
+                if s.section == "connections":
+                    CONFIG_PARSER._slices[i] = s._replace(path=connections_file_path)
+                    CONFIG_PARSER.read_config()
+                    break
         if connection_name is not None:
             connections = CONFIG_PARSER["connections"]
             if connection_name not in connections:
@@ -366,7 +369,8 @@ class SnowflakeConnection:
         return self._ocsp_fail_open
 
     def _ocsp_mode(self) -> OCSPMode:
-        """OCSP mode. INSECURE, FAIL_OPEN or FAIL_CLOSED."""
+        """OCSP mode. INSEC
+        URE, FAIL_OPEN or FAIL_CLOSED."""
         if self.insecure_mode:
             return OCSPMode.INSECURE
         elif self.ocsp_fail_open:

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -26,7 +26,7 @@ DIRS = _resolve_platform_dirs()
 #   * Linux: `~/.config/snowflake/config.toml` but can be updated with XDG vars
 #   * Windows: `%USERPROFILE%\AppData\Local\snowflake\config.toml`
 #   * Mac: `~/Library/Application Support/snowflake/config.toml`
-CONFIG_FILE = DIRS.user_config_path / "config.toml"
+CONNECTIONS_FILE = DIRS.user_config_path / "connections.toml"
 
 DBAPI_TYPE_STRING = 0
 DBAPI_TYPE_BINARY = 1

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -21,12 +21,13 @@ if TYPE_CHECKING:
 # defaults. Please see comments in sf_dir.py for more information.
 DIRS = _resolve_platform_dirs()
 
-# Snowflake's central configuration file. By default, platformdirs will resolve
+# Snowflake's configuration files. By default, platformdirs will resolve
 # them to these places depending on OS:
-#   * Linux: `~/.config/snowflake/config.toml` but can be updated with XDG vars
-#   * Windows: `%USERPROFILE%\AppData\Local\snowflake\config.toml`
-#   * Mac: `~/Library/Application Support/snowflake/config.toml`
+#   * Linux: `~/.config/snowflake/filename` but can be updated with XDG vars
+#   * Windows: `%USERPROFILE%\AppData\Local\snowflake\filename`
+#   * Mac: `~/Library/Application Support/snowflake/filename`
 CONNECTIONS_FILE = DIRS.user_config_path / "connections.toml"
+CONFIG_FILE = DIRS.user_config_path / "config.toml"
 
 DBAPI_TYPE_STRING = 0
 DBAPI_TYPE_BINARY = 1

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -601,6 +601,13 @@ class ConfigSourceError(Error):
     """
 
 
+class MissingConfigOptionError(ConfigSourceError):
+    """When a configuration option is missing from the final, resolved configurations.
+
+    This is a special-case of ConfigSourceError.
+    """
+
+
 class ConfigManagerError(Error):
     """Configuration parser related errors.
 

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1231,18 +1231,16 @@ def test_connection_name_loading(monkeypatch, db_parameters, tmp_path, mode):
         # If anything unexpected fails here, don't want to expose password
         for k, v in db_parameters.items():
             default_con[k] = v
+        doc["default"] = default_con
         with monkeypatch.context() as m:
             if mode == "env":
-                doc["default"] = default_con
                 m.setenv("SF_CONNECTIONS", tomlkit.dumps(doc))
             else:
-                doc["connections"] = tomlkit.table()
-                doc["connections"]["default"] = default_con
-                tmp_config_file = tmp_path / "config.toml"
+                tmp_config_file = tmp_path / "connections.toml"
                 tmp_config_file.write_text(tomlkit.dumps(doc))
             with snowflake.connector.connect(
                 connection_name="default",
-                config_file_path=tmp_config_file,
+                connections_file_path=tmp_config_file,
             ) as conn:
                 with conn.cursor() as cur:
                     assert cur.execute("select 1;").fetchall() == [

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -121,7 +121,7 @@ def test_simple_config_read(tmp_files):
     assert TEST_PARSER["settings"]["output_format"] == "yaml"
 
 
-def test_multiple_files(tmp_files):
+def test_simple_config_read_sliced(tmp_files):
     """Same test_simple_config_read, but rerads part of the config from another file."""
     tmp_folder = tmp_files(
         {
@@ -219,7 +219,7 @@ def test_missing_value(tmp_files):
         TEST_PARSER["settings"]["output_format"]
 
 
-def test_multiple_files_missing_value(tmp_files):
+def test_missing_value_sliced(tmp_files):
     """Test that we handle a missing configuration option gracefully across multiple files."""
     tmp_folder = tmp_files(
         {
@@ -412,7 +412,7 @@ def test_missing_config_file(tmp_path):
         cm["output_format"]
 
 
-def test_missing_config_files(tmp_path):
+def test_missing_config_files_sliced(tmp_path):
     config_file = tmp_path / "config.toml"
     connections_file = tmp_path / "connections.toml"
     cm = ConfigManager(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-873456

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I add a last second change to new configuration file feature. It allows us to optionally slice configuration files into multiple files. As an example consider:
   ```toml
   # config.toml
   [connections.snowflake]
   account = "snowflake"
   user = "snowball"
   password = "password"
   
   [settings]
   output_format = "json"
   ```
   Is equivalent to:
   ```toml
   # config.toml
   [settings]
   output_format = "json"
   ```
   ```toml
   # connections.toml
   [snowflake]
   account = "snowflake"
   user = "snowball"
   password = "password"
   ```