### PR TITLE
SNOW-862388: improve okta authentication retry logic

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -42,6 +42,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug about deleting the temporary files happened when running PUT command.
   - Allowed to pass `type_mapper` to `fetch_pandas_batches()` and `fetch_pandas_all()`.
   - Fixed a bug where pickle.dump segfaults during cache serialization in multi-threaded scenarios.
+  - Improved retry logic for okta authentication to refresh token if authentication gets throttled.
 
 - v3.0.4(May 23,2023)
   - Fixed a bug in which `cursor.execute()` could modify the argument statement_params dictionary object when executing a multistatement query.

--- a/src/snowflake/connector/auth/okta.py
+++ b/src/snowflake/connector/auth/okta.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+import time
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable
 
 from ..compat import unescape, urlencode, urlsplit
 from ..constants import (
@@ -17,7 +19,7 @@ from ..constants import (
     HTTP_HEADER_USER_AGENT,
 )
 from ..errorcode import ER_IDP_CONNECTION_ERROR, ER_INCORRECT_DESTINATION
-from ..errors import DatabaseError, Error
+from ..errors import DatabaseError, Error, RefreshToken
 from ..network import CONTENT_TYPE_APPLICATION_JSON, PYTHON_CONNECTOR_USER_AGENT
 from ..sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 from . import Auth
@@ -133,8 +135,11 @@ class AuthByOkta(AuthByPlugin):
             user,
         )
         self._step2(conn, authenticator, sso_url, token_url)
-        one_time_token = self._step3(conn, headers, token_url, user, password)
-        response_html = self._step4(conn, one_time_token, sso_url)
+        response_html = self._step4(
+            conn,
+            partial(self._step3, conn, headers, token_url, user, password),
+            sso_url,
+        )
         self._step5(conn, response_html)
 
     def reauthenticate(self, **kwargs: Any) -> dict[str, bool]:
@@ -266,26 +271,37 @@ class AuthByOkta(AuthByPlugin):
     @staticmethod
     def _step4(
         conn: SnowflakeConnection,
-        one_time_token: str,
+        generate_one_time_token: Callable,
         sso_url: str,
     ):
         logger.debug("step 4: query IDP URL snowflake app to get SAML " "response")
-        url_parameters = {
-            "RelayState": "/some/deep/link",
-            "onetimetoken": one_time_token,
-        }
-        sso_url = sso_url + "?" + urlencode(url_parameters)
-        headers = {
-            HTTP_HEADER_ACCEPT: "*/*",
-        }
-        response_html = conn._rest.fetch(
-            "get",
-            sso_url,
-            headers,
-            timeout=conn.login_timeout,
-            socket_timeout=conn.login_timeout,
-            is_raw_text=True,
-        )
+        one_time_token = generate_one_time_token()
+        timeout_time = time.time() + conn.login_timeout if conn.login_timeout else None
+        response_html = {}
+        while timeout_time is None or time.time() < timeout_time:
+            try:
+                url_parameters = {
+                    "RelayState": "/some/deep/link",
+                    "onetimetoken": one_time_token,
+                }
+                sso_url = sso_url + "?" + urlencode(url_parameters)
+                headers = {
+                    HTTP_HEADER_ACCEPT: "*/*",
+                }
+                remaining_timeout = timeout_time - time.time() if timeout_time else None
+                response_html = conn._rest.fetch(
+                    "get",
+                    sso_url,
+                    headers,
+                    timeout=remaining_timeout,
+                    socket_timeout=remaining_timeout,
+                    is_raw_text=True,
+                    is_okta_authentication=True,
+                )
+                break
+            except RefreshToken:
+                logger.debug("step4: refresh token for re-authentication")
+                one_time_token = generate_one_time_token()
         return response_html
 
     def _step5(

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -549,6 +549,17 @@ class TooManyRequests(Error):
         )
 
 
+class RefreshToken(Error):
+    def __init__(self, **kwargs) -> None:
+        Error.__init__(
+            self,
+            msg=kwargs.get("msg") or "Token Refresh Required",
+            errno=kwargs.get("errno"),
+            sqlstate=kwargs.get("sqlstate"),
+            sfqid=kwargs.get("sfqid"),
+        )
+
+
 class OtherHTTPRetryableError(Error):
     """Exception for other HTTP error for retry."""
 

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -549,7 +549,7 @@ class TooManyRequests(Error):
         )
 
 
-class RefreshToken(Error):
+class RefreshTokenError(Error):
     def __init__(self, **kwargs) -> None:
         Error.__init__(
             self,

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -81,6 +81,7 @@ from .errors import (
     OperationalError,
     OtherHTTPRetryableError,
     ProgrammingError,
+    RefreshToken,
     ServiceUnavailableError,
     TooManyRequests,
 )
@@ -1054,6 +1055,7 @@ class SnowflakeRestful:
         is_raw_binary: bool = False,
         binary_data_handler=None,
         socket_timeout=DEFAULT_SOCKET_CONNECT_TIMEOUT,
+        is_okta_authentication: bool = False,
     ):
         if socket_timeout > DEFAULT_SOCKET_CONNECT_TIMEOUT:
             # socket timeout should not be more than the default.
@@ -1104,6 +1106,10 @@ class SnowflakeRestful:
                     error = get_http_retryable_error(raw_ret.status_code)
                     logger.debug(f"{error}. Retrying...")
                     # retryable server exceptions
+                    if is_okta_authentication:
+                        raise RefreshToken(
+                            msg="OKTA authentication requires token refresh."
+                        )
                     raise RetryRequest(error)
 
                 elif (

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -81,7 +81,7 @@ from .errors import (
     OperationalError,
     OtherHTTPRetryableError,
     ProgrammingError,
-    RefreshToken,
+    RefreshTokenError,
     ServiceUnavailableError,
     TooManyRequests,
 )
@@ -1107,7 +1107,7 @@ class SnowflakeRestful:
                     logger.debug(f"{error}. Retrying...")
                     # retryable server exceptions
                     if is_okta_authentication:
-                        raise RefreshToken(
+                        raise RefreshTokenError(
                             msg="OKTA authentication requires token refresh."
                         )
                     raise RetryRequest(error)

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -217,14 +217,11 @@ def test_auth_okta_step4_negative(caplog):
     # the second time when step4 gets retried, we return 200
     def mock_session_request(*args, **kwargs):
         nonlocal raise_token_refresh_error
-        ret = Mock()
         if raise_token_refresh_error:
-            ret.status_code = 429
             raise_token_refresh_error = False
+            return Mock(status_code=429)
         else:
-            ret.status_code = 200
-            ret.text = "success"
-        return ret
+            return Mock(status_code=200, text="success")
 
     with patch.object(
         snowflake.connector.vendored.requests.sessions.Session,

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import pytest
+
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
 from snowflake.connector.network import SnowflakeRestful

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, Mock, PropertyMock
+import logging
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import snowflake.connector.vendored.requests.sessions
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
 from snowflake.connector.network import SnowflakeRestful
@@ -70,8 +72,11 @@ def test_auth_okta():
     def fake_fetch(method, full_url, headers, **kwargs):
         return ref_response_html
 
+    def get_one_time_token():
+        return one_time_token
+
     rest.fetch = fake_fetch
-    response_html = auth._step4(rest._connection, one_time_token, sso_url)
+    response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
     assert response_html == response_html
 
     # step 5
@@ -171,6 +176,68 @@ def test_auth_okta_step3_negative():
     assert rest._connection.errorhandler.called  # auth failure error
 
 
+def test_auth_okta_step4_negative(caplog):
+    """Authentication by OKTA step4 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    # step 3: authentication by IdP failed due to throttling
+    raise_token_refresh_error = True
+    second_token_generated = False
+
+    def get_one_time_token():
+        nonlocal raise_token_refresh_error
+        nonlocal second_token_generated
+        if raise_token_refresh_error:
+            assert not second_token_generated
+        else:
+            second_token_generated = True
+        return "1token1"
+
+    # the first time, when step4 gets executed, we return 429
+    # the second time when step4 gets retried, we return 200
+    def mock_session_request(*args, **kwargs):
+        nonlocal raise_token_refresh_error
+        ret = Mock()
+        if raise_token_refresh_error:
+            ret.status_code = 429
+            raise_token_refresh_error = False
+        else:
+            ret.status_code = 200
+            ret.text = "success"
+        return ret
+
+    with patch.object(
+        snowflake.connector.vendored.requests.sessions.Session,
+        "request",
+        new=mock_session_request,
+    ):
+        caplog.set_level(logging.DEBUG, "snowflake.connector")
+        response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+        # make sure the RefreshToken error is caught and tried
+        assert "step4: refresh token for re-authentication" in caplog.text
+        # test that token generation method is called
+        assert second_token_generated
+        assert response_html == "success"
+        assert not rest._connection.errorhandler.called
+
+
 def test_auth_okta_step5_negative():
     """Authentication by OKTA step5 negative test case."""
     authenticator = "https://testsso.snowflake.net/"
@@ -217,8 +284,11 @@ def test_auth_okta_step5_negative():
     def fake_fetch(method, full_url, headers, **kwargs):
         return ref_response_html
 
+    def get_one_time_token():
+        return one_time_token
+
     rest.fetch = fake_fetch
-    response_html = auth._step4(rest._connection, one_time_token, sso_url)
+    response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
     assert response_html == ref_response_html
 
     # step 5
@@ -245,6 +315,7 @@ def _init_rest(ref_sso_url, ref_token_url, success=True, message=None):
         }
 
     connection = MagicMock()
+    connection.login_timeout = 120
     connection._login_timeout = 120
     connection._network_timeout = None
     connection.errorhandler = Mock(return_value=None)

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
-import snowflake.connector.vendored.requests.sessions
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
 from snowflake.connector.network import SnowflakeRestful
 
 try:  # pragma: no cover
+    import snowflake.connector.vendored.requests.sessions
     from snowflake.connector.auth import AuthByOkta
 except ImportError:
     from snowflake.connector.auth_okta import AuthByOkta
@@ -176,6 +176,7 @@ def test_auth_okta_step3_negative():
     assert rest._connection.errorhandler.called  # auth failure error
 
 
+@pytest.mark.skipolddriver
 def test_auth_okta_step4_negative(caplog):
     """Authentication by OKTA step4 negative test case."""
     authenticator = "https://testsso.snowflake.net/"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-862388

refresh token if okta authentication gets throttled because okta token is one time token, it gets invalid once it's used, so we need a new one 


2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
