### PR TITLE
SNOW-862388: fix okta retry bug

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.1.1(TBD)
+
+  - Fixed a bug in retry logic for okta authentication to refresh token.
+
 - v3.1.0(July 31,2023)
 
   - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, for example, if you wanted to define a connection named `prod``:

--- a/src/snowflake/connector/auth/okta.py
+++ b/src/snowflake/connector/auth/okta.py
@@ -277,13 +277,14 @@ class AuthByOkta(AuthByPlugin):
         logger.debug("step 4: query IDP URL snowflake app to get SAML " "response")
         timeout_time = time.time() + conn.login_timeout if conn.login_timeout else None
         response_html = {}
+        origin_sso_url = sso_url
         while timeout_time is None or time.time() < timeout_time:
             try:
                 url_parameters = {
                     "RelayState": "/some/deep/link",
                     "onetimetoken": generate_one_time_token(),
                 }
-                sso_url = sso_url + "?" + urlencode(url_parameters)
+                sso_url = origin_sso_url + "?" + urlencode(url_parameters)
                 headers = {
                     HTTP_HEADER_ACCEPT: "*/*",
                 }

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -216,6 +216,8 @@ def test_auth_okta_step4_negative(caplog):
     # the first time, when step4 gets executed, we return 429
     # the second time when step4 gets retried, we return 200
     def mock_session_request(*args, **kwargs):
+        url = kwargs.get("url")
+        assert url.count("onetimetoken") == 1
         nonlocal raise_token_refresh_error
         if raise_token_refresh_error:
             raise_token_refresh_error = False

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -219,16 +219,11 @@ def test_auth_okta_step4_negative(caplog):
     def mock_session_request(*args, **kwargs):
         nonlocal second_token_generated
         url = kwargs.get("url")
-        if not second_token_generated:
-            assert (
-                url
-                == "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=1token1"
-            )
-        else:
-            assert (
-                url
-                == "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=2token2"
-            )
+        assert url == (
+            "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=1token1"
+            if not second_token_generated
+            else "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=2token2"
+        )
         nonlocal raise_token_refresh_error
         if raise_token_refresh_error:
             raise_token_refresh_error = False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-862388

there's a bug in the implementation that the new generated token got appended to the url already with old token
so making the new token not working at all

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
