### PR TITLE
SNOW-878611 renaming and aliasing CONFIG_PARSER to CONFIG_MANAGER

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.1.1(TBD)
+
+  - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.
+
 - v3.1.0(July 31,2023)
 
   - Added a feature that lets you add connection definitions to the `connections.toml` configuration file. A connection definition refers to a collection of connection parameters, for example, if you wanted to define a connection named `prod``:

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -163,7 +163,7 @@ class ConfigOption:
         """Get value from the cached config file if possible.
 
         Since this is the last resource for retrieving the value it raises
-        an MissingConfigOptionError if it's unable to find this option.
+        a MissingConfigOptionError if it's unable to find this option.
         """
         if (
             self._root_manager.conf_file_cache is None
@@ -192,7 +192,7 @@ class ConfigOption:
 
 
 class ConfigManager:
-    """Reads a TOML configuration file with managed multi-source precedence.
+    """Read a TOML configuration file with managed multi-source precedence.
 
     Note that multi-source precedence is actually implemented by ConfigOption.
     This is done to make sure that special handling can be done for special options.

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -370,7 +370,7 @@ class ConfigManager:
         return self._sub_parsers[name]
 
 
-CONFIG_PARSER = ConfigManager(
+CONFIG_MANAGER = ConfigManager(
     name="CONFIG_PARSER",
     file_path=CONFIG_FILE,
     _slices=[
@@ -383,13 +383,18 @@ CONFIG_PARSER = ConfigManager(
         ),
     ],
 )
-CONFIG_PARSER.add_option(
+CONFIG_MANAGER.add_option(
     name="connections",
     parse_str=tomlkit.parse,
 )
 
+# Alias for the old name of CONFIG_MANAGER in the first release, please use the actual name
+#  This might get deprecated in the future.
+CONFIG_PARSER = CONFIG_MANAGER
+
 __all__ = [
     "ConfigOption",
     "ConfigManager",
+    "CONFIG_MANAGER",
     "CONFIG_PARSER",
 ]

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -87,9 +87,9 @@ class ConfigOption:
             parse_str: String parser function for this instance.
             choices: List of possible values for this instance.
             env_name: Environmental variable name value should be read from.
-              Providing a string will use that env variable, False disables reading
-              value from environmental variables and the default None generates an
-              environmental variable name for it using the _nest_path and name.
+              Providing a string will use that environment variable, False disables
+              reading value from environmental variables and the default None generates
+              an environmental variable name for it using the _nest_path and name.
             _root_manager: Reference to the root manager. Should be supplied by
               the parent ConfigManager.
             _nest_path: The names of the ConfigManagers that this option is

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -41,7 +41,7 @@ from .auth import (
 from .auth.idtoken import AuthByIdToken
 from .bind_upload_agent import BindUploadError
 from .compat import IS_LINUX, IS_WINDOWS, quote, urlencode
-from .config_manager import CONFIG_PARSER
+from .config_manager import CONFIG_MANAGER
 from .connection_diagnostic import ConnectionDiagnostic
 from .constants import (
     ENV_VAR_PARTNER,
@@ -334,13 +334,13 @@ class SnowflakeConnection:
         self.query_context_cache_size = 5
         if connections_file_path is not None:
             # Change config file path and force update cache
-            for i, s in enumerate(CONFIG_PARSER._slices):
+            for i, s in enumerate(CONFIG_MANAGER._slices):
                 if s.section == "connections":
-                    CONFIG_PARSER._slices[i] = s._replace(path=connections_file_path)
-                    CONFIG_PARSER.read_config()
+                    CONFIG_MANAGER._slices[i] = s._replace(path=connections_file_path)
+                    CONFIG_MANAGER.read_config()
                     break
         if connection_name is not None:
-            connections = CONFIG_PARSER["connections"]
+            connections = CONFIG_MANAGER["connections"]
             if connection_name not in connections:
                 raise Error(
                     f"Invalid connection_name '{connection_name}',"

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -620,7 +620,7 @@ class MissingConfigOptionError(ConfigSourceError):
 
 
 class ConfigManagerError(Error):
-    """Configuration parser related errors.
+    """Configuration manager related errors.
 
     This means that ConfigManager is misused by a developer.
     """

--- a/src/snowflake/connector/errors.py
+++ b/src/snowflake/connector/errors.py
@@ -622,5 +622,5 @@ class MissingConfigOptionError(ConfigSourceError):
 class ConfigManagerError(Error):
     """Configuration parser related errors.
 
-    These mean that ConfigManager is misused by a developer.
+    This means that ConfigManager is misused by a developer.
     """

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -394,7 +394,7 @@ def test_error_child_conflict():
     cp.add_subparser(ConfigManager(name="b"))
     with pytest.raises(
         ConfigManagerError,
-        match="'b' subparser, or option conflicts with a child element of 'test_parser'",
+        match="'b' sub-manager, or option conflicts with a child element of 'test_parser'",
     ):
         cp.add_option(name="b")
 
@@ -491,7 +491,7 @@ def test_error_missing_fp_retrieve():
     tp.add_option(name="option")
     with pytest.raises(
         ConfigManagerError,
-        match="Root parser 'test_parser' is missing file_path",
+        match="Root manager 'test_parser' is missing file_path",
     ):
         tp["option"]
 

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -611,3 +611,45 @@ def test_configoption_missing_nest_path():
             _nest_path=None,
             _root_manager=ConfigManager(name="test_manager"),
         )
+
+
+def test_deprecationwarning_sub_parsers():
+    with warnings.catch_warnings(record=True) as w:
+        assert ConfigManager(name="test_cm")._sub_managers == {}
+        assert len(w) == 0
+        assert ConfigManager(name="test_cm")._sub_parsers == {}
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "_sub_parsers has been deprecated, use _sub_managers instead"
+    )
+
+
+def test_deprecationwarning_add_subparser():
+    with warnings.catch_warnings(record=True) as w:
+        ConfigManager(name="test_cm").add_submanager(ConfigManager(name="test_cm2"))
+        assert len(w) == 0
+        ConfigManager(name="test_cm").add_subparser(ConfigManager(name="test_cm3"))
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "add_subparser has been deprecated, use add_submanager instead"
+    )
+
+
+def test_deprecationwarning_config_parser():
+    from snowflake.connector import config_manager
+
+    with warnings.catch_warnings(record=True) as w:
+        config_manager.CONFIG_MANAGER
+        assert len(w) == 0
+        config_manager.CONFIG_PARSER
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "CONFIG_PARSER has been deprecated, use CONFIG_MANAGER instead"
+    )
+    assert config_manager.CONFIG_MANAGER is config_manager.CONFIG_PARSER


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-878611

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I modify doc-strings and rename all parser occurrences to manager while being backwards compatible.