### PR TITLE
Robust containerized externalbrowser

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,19 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.2.1(TBD)
+
+  - Improved `externalbrowser` auth in containerized environments
+    - Instruct browser to not fetch `/favicon` on success page
+    - Simple retry strategy on empty socket.recv
+    - Add `SF_AUTH_SOCKET_REUSEPORT` flag (usage: `SF_AUTH_SOCKET_REUSEPORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
+      - Useful when the randomized port used in the localhost callback url is being followed before the container engine completes port forwarding to host
+      - Statically map a port between your host and container and allow that port to be reused in rapid succession with:
+         `SF_AUTH_SOCKET_PORT=3037 SF_AUTH_SOCKET_REUSEPORT=true poetry run python somescript.py`
+    - Add `SF_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
+      - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
+      - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
+
 - v3.2.0(September 06,2023)
 
   - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -17,7 +17,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
       - Useful when the randomized port used in the localhost callback url is being followed before the container engine completes port forwarding to host
       - Statically map a port between your host and container and allow that port to be reused in rapid succession with:
          `SF_AUTH_SOCKET_PORT=3037 SNOWFLAKE_AUTH_SOCKET_REUSE_PORT=true poetry run python somescript.py`
-    - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
+    - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,11 +13,11 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Improved `externalbrowser` auth in containerized environments
     - Instruct browser to not fetch `/favicon` on success page
     - Simple retry strategy on empty socket.recv
-    - Add `SF_AUTH_SOCKET_REUSEPORT` flag (usage: `SF_AUTH_SOCKET_REUSEPORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
+    - Add `SNOWFLAKE_AUTH_SOCKET_REUSE_PORT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_REUSE_PORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
       - Useful when the randomized port used in the localhost callback url is being followed before the container engine completes port forwarding to host
       - Statically map a port between your host and container and allow that port to be reused in rapid succession with:
-         `SF_AUTH_SOCKET_PORT=3037 SF_AUTH_SOCKET_REUSEPORT=true poetry run python somescript.py`
-    - Add `SF_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
+         `SF_AUTH_SOCKET_PORT=3037 SNOWFLAKE_AUTH_SOCKET_REUSE_PORT=true poetry run python somescript.py`
+    - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
 

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -114,6 +114,10 @@ class AuthByWebBrowser(AuthByPlugin):
         logger.debug("authenticating by Web Browser")
 
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        if os.getenv("SF_AUTH_SOCKET_REUSEPORT", 'False').lower() == 'true':
+            socket_connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
         try:
             try:
                 socket_connection.bind(

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -209,7 +209,8 @@ class AuthByWebBrowser(AuthByPlugin):
                 socket_client = None
                 max_attempts = 15
                 msg_dont_wait = (
-                    os.getenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == "true"
+                    os.getenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "false").lower()
+                    == "true"
                 )
 
                 # when running in a containerized environment, socket_client.recv ocassionally returns an empty byte array

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -203,17 +203,37 @@ class AuthByWebBrowser(AuthByPlugin):
                 attempts = 0
                 raw_data = bytearray()
                 socket_client = None
+                max_attempts = 15
+                msg_dont_wait = os.getenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == 'true'
 
                 # when running in a containerized environment, socket_client.recv ocassionally returns an empty byte array
-                #   an immediate successive call to socket_client.recv gets the actual data 
-                while len(raw_data) == 0 and attempts < 5:
+                #   an immediate successive call to socket_client.recv gets the actual data
+                while len(raw_data) == 0 and attempts < max_attempts:
                     attempts += 1
                     read_sockets, _write_sockets, _exception_sockets = select.select([socket_connection], [], [])
 
                     if read_sockets[0] is not None:
                         # Receive the data in small chunks and retransmit it
                         socket_client, _ = socket_connection.accept()
-                        raw_data = socket_client.recv(BUF_SIZE)
+
+                        try:
+                            if msg_dont_wait:
+                                # WSL containerized environment sometimes causes socket_client.recv to hang indefinetly
+                                #   To avoid this, passing the socket.MSG_DONTWAIT flag which raises BlockingIOError if
+                                #   operation would block
+                                logger.debug('Calling socket_client.recv with MSG_DONTWAIT flag due to SF_AUTH_SOCKET_MESSAGE_DONTWAIT env var')
+                                raw_data = socket_client.recv(BUF_SIZE, socket.MSG_DONTWAIT)
+                            else:
+                                raw_data = socket_client.recv(BUF_SIZE)
+
+                        except BlockingIOError:
+                            logger.debug(f'BlockingIOError raised from socket.recv while attempting to retrieve callback token request')
+                            if attempts < max_attempts:
+                                sleep_time = 0.25
+                                logger.debug(f'Waiting {sleep_time} seconds before trying again')
+                                time.sleep(sleep_time)
+                            else:
+                                logger.debug('Exceeded retry count')
 
                 data = raw_data.decode("utf-8").split("\r\n")
 

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -115,7 +115,7 @@ class AuthByWebBrowser(AuthByPlugin):
 
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        if os.getenv("SF_AUTH_SOCKET_REUSEPORT", "False").lower() == "true":
+        if os.getenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "False").lower() == "true":
             socket_connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
         try:
@@ -209,7 +209,7 @@ class AuthByWebBrowser(AuthByPlugin):
                 socket_client = None
                 max_attempts = 15
                 msg_dont_wait = (
-                    os.getenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == "true"
+                    os.getenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == "true"
                 )
 
                 # when running in a containerized environment, socket_client.recv ocassionally returns an empty byte array

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-import socket
 import select
+import socket
 import time
 import webbrowser
 from types import ModuleType
@@ -115,7 +115,7 @@ class AuthByWebBrowser(AuthByPlugin):
 
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        if os.getenv("SF_AUTH_SOCKET_REUSEPORT", 'False').lower() == 'true':
+        if os.getenv("SF_AUTH_SOCKET_REUSEPORT", "False").lower() == "true":
             socket_connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
         try:
@@ -208,13 +208,17 @@ class AuthByWebBrowser(AuthByPlugin):
                 raw_data = bytearray()
                 socket_client = None
                 max_attempts = 15
-                msg_dont_wait = os.getenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == 'true'
+                msg_dont_wait = (
+                    os.getenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() == "true"
+                )
 
                 # when running in a containerized environment, socket_client.recv ocassionally returns an empty byte array
                 #   an immediate successive call to socket_client.recv gets the actual data
                 while len(raw_data) == 0 and attempts < max_attempts:
                     attempts += 1
-                    read_sockets, _write_sockets, _exception_sockets = select.select([socket_connection], [], [])
+                    read_sockets, _write_sockets, _exception_sockets = select.select(
+                        [socket_connection], [], []
+                    )
 
                     if read_sockets[0] is not None:
                         # Receive the data in small chunks and retransmit it
@@ -225,19 +229,27 @@ class AuthByWebBrowser(AuthByPlugin):
                                 # WSL containerized environment sometimes causes socket_client.recv to hang indefinetly
                                 #   To avoid this, passing the socket.MSG_DONTWAIT flag which raises BlockingIOError if
                                 #   operation would block
-                                logger.debug('Calling socket_client.recv with MSG_DONTWAIT flag due to SF_AUTH_SOCKET_MESSAGE_DONTWAIT env var')
-                                raw_data = socket_client.recv(BUF_SIZE, socket.MSG_DONTWAIT)
+                                logger.debug(
+                                    "Calling socket_client.recv with MSG_DONTWAIT flag due to SF_AUTH_SOCKET_MESSAGE_DONTWAIT env var"
+                                )
+                                raw_data = socket_client.recv(
+                                    BUF_SIZE, socket.MSG_DONTWAIT
+                                )
                             else:
                                 raw_data = socket_client.recv(BUF_SIZE)
 
                         except BlockingIOError:
-                            logger.debug('BlockingIOError raised from socket.recv while attempting to retrieve callback token request')
+                            logger.debug(
+                                "BlockingIOError raised from socket.recv while attempting to retrieve callback token request"
+                            )
                             if attempts < max_attempts:
                                 sleep_time = 0.25
-                                logger.debug(f'Waiting {sleep_time} seconds before trying again')
+                                logger.debug(
+                                    f"Waiting {sleep_time} seconds before trying again"
+                                )
                                 time.sleep(sleep_time)
                             else:
-                                logger.debug('Exceeded retry count')
+                                logger.debug("Exceeded retry count")
 
                 data = raw_data.decode("utf-8").split("\r\n")
 

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -230,7 +230,7 @@ class AuthByWebBrowser(AuthByPlugin):
                                 #   To avoid this, passing the socket.MSG_DONTWAIT flag which raises BlockingIOError if
                                 #   operation would block
                                 logger.debug(
-                                    "Calling socket_client.recv with MSG_DONTWAIT flag due to SF_AUTH_SOCKET_MESSAGE_DONTWAIT env var"
+                                    "Calling socket_client.recv with MSG_DONTWAIT flag due to SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT env var"
                                 )
                                 raw_data = socket_client.recv(
                                     BUF_SIZE, socket.MSG_DONTWAIT

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -231,7 +231,7 @@ class AuthByWebBrowser(AuthByPlugin):
                                 raw_data = socket_client.recv(BUF_SIZE)
 
                         except BlockingIOError:
-                            logger.debug(f'BlockingIOError raised from socket.recv while attempting to retrieve callback token request')
+                            logger.debug('BlockingIOError raised from socket.recv while attempting to retrieve callback token request')
                             if attempts < max_attempts:
                                 sleep_time = 0.25
                                 logger.debug(f'Waiting {sleep_time} seconds before trying again')

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -275,6 +275,7 @@ class AuthByWebBrowser(AuthByPlugin):
         else:
             msg = """
 <!DOCTYPE html><html><head><meta charset="UTF-8"/>
+<link rel="icon" href="data:,">
 <title>SAML Response for Snowflake</title></head>
 <body>
 Your identity was confirmed and propagated to Snowflake {}.

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -241,7 +241,7 @@ def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypatch):
     ref_token = "MOCK_TOKEN"
     rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
-    monkeypatch.setenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "true")
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
 
     # mock socket
     mock_socket_pkg = _init_socket(
@@ -291,7 +291,7 @@ def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
     ref_token = "MOCK_TOKEN"
     rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
-    monkeypatch.setenv("SF_AUTH_SOCKET_MSG_DONTWAIT", "true")
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
 
     # mock socket
     mock_socket_pkg = _init_socket(
@@ -342,7 +342,7 @@ def test_auth_webbrowser_socket_reuseport_with_env_flag(monkeypatch):
     mock_webbrowser = MagicMock()
     mock_webbrowser.open_new.return_value = True
 
-    monkeypatch.setenv("SF_AUTH_SOCKET_REUSEPORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
 
     # Mock select.select to return socket client
     with mock.patch(
@@ -386,7 +386,7 @@ def test_auth_webbrowser_socket_reuseport_option_not_set_with_false_flag(monkeyp
     mock_webbrowser = MagicMock()
     mock_webbrowser.open_new.return_value = True
 
-    monkeypatch.setenv("SF_AUTH_SOCKET_REUSEPORT", "false")
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "false")
 
     # Mock select.select to return socket client
     with mock.patch(

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -42,9 +42,9 @@ def mock_webserver(target_instance, application, port):
 
 
 def test_auth_webbrowser_get():
+
     """Authentication by WebBrowser positive test case."""
     ref_token = "MOCK_TOKEN"
-
     rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
     # mock webbrowser
@@ -67,26 +67,28 @@ def test_auth_webbrowser_get():
     mock_socket_instance.accept.return_value = (mock_socket_client, None)
     mock_socket = Mock(return_value=mock_socket_instance)
 
-    auth = AuthByWebBrowser(
-        application=APPLICATION,
-        webbrowser_pkg=mock_webbrowser,
-        socket_pkg=mock_socket,
-    )
-    auth.prepare(
-        conn=rest._connection,
-        authenticator=AUTHENTICATOR,
-        service_name=SERVICE_NAME,
-        account=ACCOUNT,
-        user=USER,
-        password=PASSWORD,
-    )
-    assert not rest._connection.errorhandler.called  # no error
-    assert auth.assertion_content == ref_token
-    body = {"data": {}}
-    auth.update_body(body)
-    assert body["data"]["TOKEN"] == ref_token
-    assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
-    assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+    # Mock select.select to return socket client
+    with mock.patch('select.select', return_value=([mock_socket_instance], [], [])):
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
 
 
 def test_auth_webbrowser_post():
@@ -118,26 +120,28 @@ def test_auth_webbrowser_post():
     mock_socket_instance.accept.return_value = (mock_socket_client, None)
     mock_socket = Mock(return_value=mock_socket_instance)
 
-    auth = AuthByWebBrowser(
-        application=APPLICATION,
-        webbrowser_pkg=mock_webbrowser,
-        socket_pkg=mock_socket,
-    )
-    auth.prepare(
-        conn=rest._connection,
-        authenticator=AUTHENTICATOR,
-        service_name=SERVICE_NAME,
-        account=ACCOUNT,
-        user=USER,
-        password=PASSWORD,
-    )
-    assert not rest._connection.errorhandler.called  # no error
-    assert auth.assertion_content == ref_token
-    body = {"data": {}}
-    auth.update_body(body)
-    assert body["data"]["TOKEN"] == ref_token
-    assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
-    assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+    # Mock select.select to return socket client
+    with mock.patch('select.select', return_value=([mock_socket_instance], [], [])):
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
 
 
 @pytest.mark.parametrize(
@@ -225,29 +229,31 @@ def test_auth_webbrowser_fail_webserver(capsys):
     mock_socket_instance.accept.return_value = (mock_socket_client, None)
     mock_socket = Mock(return_value=mock_socket_instance)
 
-    # case 1: invalid HTTP request
-    auth = AuthByWebBrowser(
-        application=APPLICATION,
-        webbrowser_pkg=mock_webbrowser,
-        socket_pkg=mock_socket,
-    )
-    auth.prepare(
-        conn=rest._connection,
-        authenticator=AUTHENTICATOR,
-        service_name=SERVICE_NAME,
-        account=ACCOUNT,
-        user=USER,
-        password=PASSWORD,
-    )
-    captured = capsys.readouterr()
-    assert captured.out == (
-        "Initiating login request with your identity provider. A browser window "
-        "should have opened for you to complete the login. If you can't see it, "
-        "check existing browser windows, or your OS settings. Press CTRL+C to "
-        f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\n"
-    )
-    assert rest._connection.errorhandler.called  # an error
-    assert auth.assertion_content is None
+    # Mock select.select to return socket client
+    with mock.patch('select.select', return_value=([mock_socket_instance], [], [])):
+        # case 1: invalid HTTP request
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "Initiating login request with your identity provider. A browser window "
+            "should have opened for you to complete the login. If you can't see it, "
+            "check existing browser windows, or your OS settings. Press CTRL+C to "
+            f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\n"
+        )
+        assert rest._connection.errorhandler.called  # an error
+        assert auth.assertion_content is None
 
 
 def _init_rest(ref_sso_url, ref_proof_key, success=True, message=None):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1251 

2. Fill out the following pre-review checklist:

Yes:
   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
   - [X] I am modifying authorization mechanisms
   
No:
   - [  ] I am adding a new telemetry message
   - [  ] I am adding new credentials
   - [  ] I am modifying OCSP code
   - [  ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    - Improved `externalbrowser` auth in containerized environments
      - Instruct browser to not fetch `/favicon` on success page (can cause failure to parse subsequent tokens)
      - Simple retry strategy on empty socket.recv (occurs frequently when containerized)
      - Add `SF_AUTH_SOCKET_REUSEPORT` flag (usage: `SF_AUTH_SOCKET_REUSEPORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
        - Use in combination with `SF_AUTH_SOCKET_PORT`
        - Consider using if running in a containerized environment and the localhost callback url is being followed before the container fully opens the port
      - Add `SF_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
        - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
        - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
