### PR TITLE
SNOW-890625 Do not write cache when we have no OCSP response

### DIFF
--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -308,6 +308,22 @@ def test_ocsp_with_invalid_cache_file():
         assert ocsp.validate(url, connection), f"Failed to validate: {url}"
 
 
+@mock.patch(
+    "snowflake.connector.ocsp_snowflake.SnowflakeOCSP._fetch_ocsp_response",
+    side_effect=BrokenPipeError("fake error"),
+)
+def test_ocsp_cache_when_server_is_down(mock_fetch_ocsp_response, tmpdir):
+    ocsp = SFOCSP()
+
+    """Attempts to use outdated OCSP response cache file."""
+    cache_file_name, target_hosts = _store_cache_in_file(tmpdir)
+
+    # reading cache file
+    OCSPCache.read_ocsp_response_cache_file(ocsp, cache_file_name)
+    cache_data = snowflake.connector.ocsp_snowflake.OCSP_RESPONSE_VALIDATION_CACHE
+    assert not cache_data, "no cache should present because of broken pipe"
+
+
 def test_concurrent_ocsp_requests(tmpdir):
     """Run OCSP revocation checks in parallel. The memory and file caches are deleted randomly."""
     cache_file_name = path.join(str(tmpdir), "cache_file.txt")


### PR DESCRIPTION
Description

When there is connection error, we will get None as OCSP response, which should not be written to cache.

Testing

unit test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-890625

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
