### PR TITLE
Add the original error message when there is a ConfigSourceError

### DIFF
--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -283,7 +283,7 @@ class ConfigManager:
                 read_config_piece = tomlkit.parse(filep.read_text())
             except Exception as e:
                 raise ConfigSourceError(
-                    "An error happened while loading " f"'{str(filep)}': {e}"
+                    "An error happened while loading " f"'{str(filep)}': \n\n{e}"
                 ) from e
             if section is None:
                 read_config_file = read_config_piece

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -283,7 +283,7 @@ class ConfigManager:
                 read_config_piece = tomlkit.parse(filep.read_text())
             except Exception as e:
                 raise ConfigSourceError(
-                    "An unknown error happened while loading " f"'{str(filep)}'"
+                    "An error happened while loading " f"'{str(filep)}': {e}"
                 ) from e
             if section is None:
                 read_config_file = read_config_piece


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1696 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Since some tools (e.g. snowcli) don't show the full stack trace, this adds the original error message that generated the Exception to the ConfigSourceError, which means that instead of this:
   ```
   ConfigSourceError: An unknown error happened while loading '/Users/zblackwood/.snowflake/config.toml'
   ```
   I get this:
   ```
   ConfigSourceError: An error happened while loading '/Users/zblackwood/.snowflake/config.toml': 
   
   Control characters (codes less than 0x1f and 0x7f) are not allowed in strings, use \u000a instead at line 3 col 18
   ```