### PR TITLE
SNOW-739316 Enforce content-length checking in vendored urllib3

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug in retry logic for okta authentication to refresh token.
   - Support `RSAPublicKey` when constructing `AuthByKeyPair` in addition to raw bytes.
   - Fixed a bug when connecting through SOCKS5 proxy, the attribute `proxy_header` is missing on `SOCKSProxyManager`.
+  - Cherry-picked https://github.com/urllib3/urllib3/commit/fd2759aa16b12b33298900c77d29b3813c6582de onto vendored urllib3 (v1.26.15) to enable enforce_content_length by default.
+
 
 - v3.1.0(July 31,2023)
 

--- a/src/snowflake/connector/vendored/urllib3/response.py
+++ b/src/snowflake/connector/vendored/urllib3/response.py
@@ -213,7 +213,7 @@ class HTTPResponse(io.IOBase):
         connection=None,
         msg=None,
         retries=None,
-        enforce_content_length=False,
+        enforce_content_length=True,
         request_method=None,
         request_url=None,
         auto_close=True,


### PR DESCRIPTION
### **Notes**
This is equivalent to cherry-picking [`fd2759aa16b12b33298900c77d29b3813c6582de`](https://github.com/urllib3/urllib3/commit/fd2759aa16b12b33298900c77d29b3813c6582de) onto the current vendored version `1.26.15`. We are merging the cherry pick to unblock release.

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1425

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [X] I am MAYBE modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

urllib3 does not do content-length checking.
result_batch.py does a get request in line 298, which can therefore in case of connection issues return an incomplete response. This is passed directly to an ArrowIterator. The already existing retry mechanism does not catch this as no Exception is generated.

   Please write a short description of how your code change solves the related issue.
4. Setting enforce_content_length checks the length of the response and raises an IncompleteRead error, which should already trigger the existing retry mechanism.
This is the same behaviour as in urllib 3 V2.0. 

In other words: #1689 is the better fix to this problem. I'm sending this PR to document the issue and maybe to provide a quickfix version for the interested parties.

Also some info: I should add that this is not confirmed to fix the issue yet. It's just my best guess. I also thought about actually not only overriding the default, but also enforcing enforce_content_length to true in the function itself. But I think requests is the only user in this case and it's also vendored and it never sets it explicitly, so I just overrode the default.
