### PR TITLE
Add support for use_logical_type in write_pandas.

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -301,7 +301,7 @@ def write_pandas(
     ):
         warnings.warn(
             "Dataframe contains a datetime with timezone column, but "
-            f"'use_logical_type = {use_logical_type}'. This can result in dateimes "
+            f"'{use_logical_type=}'. This can result in dateimes "
             "being incorrectly written to Snowflake. Consider setting "
             "'use_logical_type = True'",
             UserWarning,

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -20,6 +20,7 @@ from typing import (
     Sequence,
     TypeVar,
 )
+from pandas.api.types import is_datetime64tz_dtype
 
 from snowflake.connector import ProgrammingError
 from snowflake.connector.options import pandas
@@ -118,12 +119,15 @@ def _create_temp_stage(
 
 
 def _do_create_temp_file_format(
-    cursor: SnowflakeCursor, file_format_location: str, compression: str
+    cursor: SnowflakeCursor,
+    file_format_location: str,
+    compression: str,
+    sql_use_logical_type: str,
 ) -> None:
     file_format_sql = (
         f"CREATE TEMP FILE FORMAT {file_format_location} "
         f"/* Python:snowflake.connector.pandas_tools.write_pandas() */ "
-        f"TYPE=PARQUET COMPRESSION={compression}"
+        f"TYPE=PARQUET COMPRESSION={compression}{sql_use_logical_type}"
     )
     logger.debug(f"creating file format with '{file_format_sql}'")
     cursor.execute(file_format_sql, _is_internal=True)
@@ -135,6 +139,7 @@ def _create_temp_file_format(
     schema: str | None,
     quote_identifiers: bool,
     compression: str,
+    sql_use_logical_type: str,
 ) -> str:
     file_format_name = random_string()
     file_format_location = build_location_helper(
@@ -144,7 +149,9 @@ def _create_temp_file_format(
         quote_identifiers=quote_identifiers,
     )
     try:
-        _do_create_temp_file_format(cursor, file_format_location, compression)
+        _do_create_temp_file_format(
+            cursor, file_format_location, compression, sql_use_logical_type
+        )
     except ProgrammingError as e:
         # User may not have the privilege to create file format on the target schema, so fall back to use current schema
         # as the old behavior.
@@ -152,7 +159,9 @@ def _create_temp_file_format(
             f"creating stage {file_format_location} failed. Exception {str(e)}. Fall back to use current schema"
         )
         file_format_location = file_format_name
-        _do_create_temp_file_format(cursor, file_format_location, compression)
+        _do_create_temp_file_format(
+            cursor, file_format_location, compression, sql_use_logical_type
+        )
 
     return file_format_location
 
@@ -172,6 +181,7 @@ def write_pandas(
     create_temp_table: bool = False,
     overwrite: bool = False,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
+    use_logical_type: bool | None = None,
     **kwargs: Any,
 ) -> tuple[
     bool,
@@ -232,6 +242,11 @@ def write_pandas(
             Pandas DataFrame.
         table_type: The table type of to-be-created table. The supported table types include ``temp``/``temporary``
             and ``transient``. Empty means permanent table as per SQL convention.
+        use_logical_type: Boolean that specifies whether to use Parquet logical types. With this file format option,
+            Snowflake can interpret Parquet logical types during data loading. To enable Parquet logical types,
+            set use_logical_type as True. Set to None to use Snowflakes default. For more information, see:
+            https://docs.snowflake.com/en/sql-reference/sql/create-file-format
+
 
     Returns:
         Returns the COPY INTO command's results to verify ingestion in the form of a tuple of whether all chunks were
@@ -279,6 +294,27 @@ def write_pandas(
             UserWarning,
             stacklevel=2,
         )
+
+    # use_logical_type should be True when dataframe contains datetimes with timezone.
+    # https://github.com/snowflakedb/snowflake-connector-python/issues/1687
+    if use_logical_type is not True and any(
+        [is_datetime64tz_dtype(df[c]) for c in df.columns]
+    ):
+        warnings.warn(
+            "Dataframe contains a datetime with timezone column, but "
+            f"'use_logical_type = {use_logical_type}'. This can result in dateimes "
+            "being incorrectly written to Snowflake. Consider setting "
+            "'use_logical_type = True'",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    if use_logical_type is None:
+        sql_use_logical_type = ""
+    elif use_logical_type:
+        sql_use_logical_type = " USE_LOGICAL_TYPE = TRUE"
+    else:
+        sql_use_logical_type = " USE_LOGICAL_TYPE = FALSE"
 
     cursor = conn.cursor()
     stage_location = _create_temp_stage(
@@ -329,7 +365,12 @@ def write_pandas(
 
     if auto_create_table or overwrite:
         file_format_location = _create_temp_file_format(
-            cursor, database, schema, quote_identifiers, compression_map[compression]
+            cursor,
+            database,
+            schema,
+            quote_identifiers,
+            compression_map[compression],
+            sql_use_logical_type,
         )
         infer_schema_sql = f"SELECT COLUMN_NAME, TYPE FROM table(infer_schema(location=>'@{stage_location}', file_format=>'{file_format_location}'))"
         logger.debug(f"inferring schema with '{infer_schema_sql}'")
@@ -381,7 +422,7 @@ def write_pandas(
             f"COPY INTO {target_table_location} /* Python:snowflake.connector.pandas_tools.write_pandas() */ "
             f"({columns}) "
             f"FROM (SELECT {parquet_columns} FROM @{stage_location}) "
-            f"FILE_FORMAT=(TYPE=PARQUET COMPRESSION={compression_map[compression]}{' BINARY_AS_TEXT=FALSE' if auto_create_table or overwrite else ''}) "
+            f"FILE_FORMAT=(TYPE=PARQUET COMPRESSION={compression_map[compression]}{' BINARY_AS_TEXT=FALSE' if auto_create_table or overwrite else ''}{sql_use_logical_type}) "
             f"PURGE=TRUE ON_ERROR={on_error}"
         )
         logger.debug(f"copying into with '{copy_into_sql}'")

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Generator
 from unittest import mock
 

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Generator
 from unittest import mock
 
@@ -413,6 +413,54 @@ def test_write_pandas_create_temp_table_deprecation_warning(
                 .fetchall()
             )
             assert table_info[0]["kind"] == "TEMPORARY"
+        finally:
+            cnx.execute_string(drop_sql)
+
+
+@pytest.mark.parametrize("use_logical_type", [None, True, False])
+def test_write_pandas_use_logical_type(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection, None, None]],
+    use_logical_type: bool | None,
+):
+    table_name = random_string(5, "USE_LOCAL_TYPE_").upper()
+    col_name = "DT"
+    create_sql = f"CREATE OR REPLACE TABLE {table_name} ({col_name} TIMESTAMP_TZ)"
+    select_sql = f"SELECT * FROM {table_name}"
+    drop_sql = f"DROP TABLE IF EXISTS {table_name}"
+    timestamp = datetime(
+        year=2020,
+        month=1,
+        day=2,
+        hour=3,
+        minute=4,
+        second=5,
+        microsecond=6,
+        tzinfo=timezone(timedelta(hours=2)),
+    )
+    df_write = pandas.DataFrame({col_name: [timestamp]})
+
+    with conn_cnx() as cnx:  # type: SnowflakeConnection
+        cnx.cursor().execute(create_sql).fetchall()
+
+        write_pandas_kwargs = dict(
+            conn=cnx,
+            df=df_write,
+            use_logical_type=use_logical_type,
+            auto_create_table=False,
+            table_name=table_name,
+        )
+
+        try:
+            # When use_logical_type = True, datetimes with timestamps should be
+            # correctly written to Snowflake.
+            if use_logical_type:
+                write_pandas(**write_pandas_kwargs)
+                df_read = cnx.cursor().execute(select_sql).fetch_pandas_all()
+                assert all(df_write == df_read)
+            # For other use_logical_type values, a UserWarning should be displayed.
+            else:
+                with pytest.warns(UserWarning, match="Dataframe contains a datetime.*"):
+                    write_pandas(**write_pandas_kwargs)
         finally:
             cnx.execute_string(drop_sql)
 


### PR DESCRIPTION
use_logical_type is a new file format option of Snowflake. It is a Boolean that specifies whether Snowflake interprets Parquet logical types during data loading. The default behaviour of write_pandas is unchanged. When users write a dataframe that contains datetimes with timezones and do not pass use_logical_type = True as an argument, a warning is raised (see #1687). Providing this option also fixes issue #1687

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1687

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Snowflake recently released a fix for issue https://github.com/snowflakedb/snowflake-connector-python/issues/1688, which was server side related. The fix involves a new file format parameter "use_logical_type" for parquet files. When writing data that contains timezones, the parameter should be set to True. Write_pandas uses parquet files on the background, so support should be added for the newly added parameter "use_logical_type", such that write_pandas can correctly write dataframes with timezones. The pull request presented here not only adds this option to the write_pandas method, but also raises a user warning if the users writes a pandas dataframe that contains timezones, yet does not set use_logical_type to True. Reason for raising a warning and not an error is to maintain old behaviour, and to prevent users from suddenly running into issues when updating their pandas version.

I have read the CLA Document and I hereby sign the CLA