### PR TITLE
SNOW-897148: fix oob telemetry tags generation

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug in retry logic for okta authentication to refresh token.
   - Support `RSAPublicKey` when constructing `AuthByKeyPair` in addition to raw bytes.
   - Fixed a bug when connecting through SOCKS5 proxy, the attribute `proxy_header` is missing on `SOCKSProxyManager`.
+  - Fixed a bug in tag generation of OOB telemetry event.
 
 - v3.1.0(July 31,2023)
 

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -124,13 +124,13 @@ class TelemetryEvent(TelemetryEventBase):
 
         telemetry = TelemetryService.get_instance()
         # Add telemetry service generated tags
-        tags[TelemetryField.KEY_OOB_DRIVER] = CLIENT_NAME
-        tags[TelemetryField.KEY_OOB_VERSION] = str(SNOWFLAKE_CONNECTOR_VERSION)
+        tags[TelemetryField.KEY_OOB_DRIVER.value] = CLIENT_NAME
+        tags[TelemetryField.KEY_OOB_VERSION.value] = str(SNOWFLAKE_CONNECTOR_VERSION)
         tags[
-            TelemetryField.KEY_OOB_TELEMETRY_SERVER_DEPLOYMENT
+            TelemetryField.KEY_OOB_TELEMETRY_SERVER_DEPLOYMENT.value
         ] = telemetry.deployment.name
         tags[
-            TelemetryField.KEY_OOB_CONNECTION_STRING
+            TelemetryField.KEY_OOB_CONNECTION_STRING.value
         ] = telemetry.get_connection_string()
         if telemetry.context and len(telemetry.context) > 0:
             for k, v in telemetry.context.items():

--- a/test/unit/test_telemetry_oob.py
+++ b/test/unit/test_telemetry_oob.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 import snowflake.connector.errorcode
@@ -49,7 +51,7 @@ def telemetry_setup(request):
     telemetry.flush()
 
 
-def test_telemetry_oob_simple_flush(telemetry_setup):
+def test_telemetry_oob_simple_flush(telemetry_setup, caplog):
     """Tests capturing and sending a simple OCSP Exception message."""
     telemetry = TelemetryService.get_instance()
 
@@ -57,7 +59,12 @@ def test_telemetry_oob_simple_flush(telemetry_setup):
         event_type, telemetry_data, exception=exception, stack_trace=stack_trace
     )
     assert telemetry.size() == 1
+    caplog.set_level(logging.DEBUG, "snowflake.connector.telemetry_oob")
     telemetry.flush()
+    assert (
+        "Failed to generate a JSON dump from the passed in telemetry OOB events"
+        not in caplog.text
+    )
     assert telemetry.size() == 0
 
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-897148: telemetry log event tags dictionary keys only accept int/str, not accepting the class `TelemetryField`

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
