### PR TITLE
SNOW-890306 Use sys module copy to avoid race condition

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug in retry logic for okta authentication to refresh token.
   - Support `RSAPublicKey` when constructing `AuthByKeyPair` in addition to raw bytes.
   - Fixed a bug when connecting through SOCKS5 proxy, the attribute `proxy_header` is missing on `SOCKSProxyManager`.
+  - Fixed a bug when SnowflakeConnection fails due to a race condition when multiple threads are importing packages and reading the content of `sys.modules` simultaneously.
 
 - v3.1.0(July 31,2023)
 

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1723,9 +1723,10 @@ class SnowflakeConnection:
         if self._log_imported_packages_in_telemetry:
             # filter out duplicates caused by submodules
             # and internal modules with names starting with an underscore
+            sys_modules_copy = sys.modules.copy()
             imported_modules = {
                 k.split(".", maxsplit=1)[0]
-                for k in sys.modules.keys()
+                for k in sys_modules_copy.keys()
                 if not k.startswith("_")
             }
             ts = get_time_millis()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-890306](https://snowflakecomputing.atlassian.net/browse/SNOW-890306)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In [SNOW-890306](https://snowflakecomputing.atlassian.net/browse/SNOW-890306), users reported seeing `RuntimeError: dictionary changed size during iteration` being raised from `_log_telemetry_imported_packages` due to multiple threads (1) importing packages (modifying `sys.modules`) and (2) running L1726-L1730 in `_log_telemetry_imported_packages` simultaneously. This could be prevented by using a shallow copy instead.
   
   No tests were added for now given this is a simple change and the race condition happens non-deterministically. Please let me know if you prefer having tests for this.


[SNOW-890306]: https://snowflakecomputing.atlassian.net/browse/SNOW-890306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-890306]: https://snowflakecomputing.atlassian.net/browse/SNOW-890306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ