### PR TITLE
SNOW-902097 adding default_connection_name and default value to ConfigOption

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.1.2(TBD)
 
   - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.
+  - Added support for default values for ConfigOptions
 
 - v3.1.1(August 28,2023)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.
   - Added support for default values for ConfigOptions
+  - Added default_connection_name to config.toml file
 
 - v3.1.1(August 28,2023)
 

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -450,6 +450,10 @@ CONFIG_MANAGER.add_option(
     name="connections",
     parse_str=tomlkit.parse,
 )
+CONFIG_MANAGER.add_option(
+    name="default_connection_name",
+    default="default",
+)
 
 
 def __getattr__(name):

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -62,6 +62,9 @@ class ConfigOption:
           supplied, we'll construct this. False disables reading from
           environmental variables, None uses the auto generated variable name
           and explicitly provided string overwrites the default one.
+        default: The value we should resolve to when the option is not defined
+          in any of the sources. When it's None we treat that as there's no
+          default value.
         _root_manager: Reference to the root manager. Used to efficiently
           refer to cached config file. Is supplied by the parent
           ConfigManager.
@@ -78,6 +81,7 @@ class ConfigOption:
         parse_str: Callable[[str], _T] | None = None,
         choices: Iterable[Any] | None = None,
         env_name: str | None | Literal[False] = None,
+        default: Any | None = None,
         _root_manager: ConfigManager | None = None,
         _nest_path: list[str] | None,
     ) -> None:
@@ -91,6 +95,8 @@ class ConfigOption:
               Providing a string will use that environment variable, False disables
               reading value from environmental variables and the default None generates
               an environmental variable name for it using the _nest_path and name.
+            default: Default value for the option. Used in case the value is
+              is not defined in any of the sources.
             _root_manager: Reference to the root manager. Should be supplied by
               the parent ConfigManager.
             _nest_path: The names of the ConfigManagers that this option is
@@ -106,6 +112,7 @@ class ConfigOption:
         self._nest_path = _nest_path + [name]
         self._root_manager: ConfigManager = _root_manager
         self.env_name = env_name
+        self.default = default
 
     def value(self) -> Any:
         """Retrieve a value of option.
@@ -115,8 +122,15 @@ class ConfigOption:
         source = "environment variable"
         loaded_env, value = self._get_env()
         if not loaded_env:
-            source = "configuration file"
-            value = self._get_config()
+            try:
+                value = self._get_config()
+                source = "configuration file"
+            except MissingConfigOptionError:
+                if self.default:
+                    source = "default_value"
+                    value = self.default
+                else:
+                    raise
         if self.choices and value not in self.choices:
             raise ConfigSourceError(
                 f"The value of {self.option_name} read from "

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -8,6 +8,7 @@ import os.path
 import re
 import shutil
 import stat
+import string
 import warnings
 from pathlib import Path
 from test.randomize import random_string
@@ -653,3 +654,26 @@ def test_deprecationwarning_config_parser():
         == "CONFIG_PARSER has been deprecated, use CONFIG_MANAGER instead"
     )
     assert config_manager.CONFIG_MANAGER is config_manager.CONFIG_PARSER
+
+
+def test_configoption_default_value(tmp_path, monkeypatch):
+    env_name = random_string(
+        5,
+        "SF_TEST_OPTION_",
+        choices=string.ascii_uppercase,
+    )
+    conf_val = random_string(5)
+    cm = ConfigManager(
+        name="test_manager",
+        file_path=tmp_path / "config.toml",
+    )
+    cm.add_option(
+        name="test_option",
+        env_name=env_name,
+        default=conf_val,
+    )
+    assert cm["test_option"] == conf_val
+    env_value = random_string(5)
+    with monkeypatch.context() as c:
+        c.setenv(env_name, env_value)
+        assert cm["test_option"] == env_value

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -23,6 +23,7 @@ from snowflake.connector.compat import IS_WINDOWS
 
 try:
     from snowflake.connector.config_manager import (
+        CONFIG_MANAGER,
         ConfigManager,
         ConfigOption,
         ConfigSlice,
@@ -680,34 +681,31 @@ def test_configoption_default_value(tmp_path, monkeypatch):
 
 
 def test_defaultconnectionname(tmp_path, monkeypatch):
-    with monkeypatch.context() as m:
-        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
-        assert CONFIG_MANAGER["default_connection_name"] == "default"
-    env_val = random_string(5, "DEF_CONN_")
-    with monkeypatch.context() as m:
-        m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", env_val)
-        assert CONFIG_MANAGER["default_connection_name"] == env_val
-    assert CONFIG_MANAGER.file_path is not None
-    con_name = random_string(5, "conn_")
     c_file = tmp_path / "config.toml"
-    c_file.write_text(
-        dedent(
-            f"""\
-            default_connection_name = "{con_name}"
-
-            [connections.{con_name}]
-            user="testuser"
-            account="testaccount"
-            password="testpassword"
-            """
-        )
-    )
     old_path = CONFIG_MANAGER.file_path
+    CONFIG_MANAGER.file_path = c_file
+    CONFIG_MANAGER.conf_file_cache = None
     try:
+        with monkeypatch.context() as m:
+            m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+            assert CONFIG_MANAGER["default_connection_name"] == "default"
+        env_val = random_string(5, "DEF_CONN_")
+        with monkeypatch.context() as m:
+            m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", env_val)
+            assert CONFIG_MANAGER["default_connection_name"] == env_val
+        assert CONFIG_MANAGER.file_path is not None
+        con_name = random_string(5, "conn_")
+        c_file.write_text(
+            dedent(
+                f"""\
+                default_connection_name = "{con_name}"
+                """
+            )
+        )
         # re-cache config file from disk
         CONFIG_MANAGER.file_path = c_file
         CONFIG_MANAGER.conf_file_cache = None
         assert CONFIG_MANAGER["default_connection_name"] == con_name
     finally:
         CONFIG_MANAGER.file_path = old_path
-        CONFIG_MANAGER.read_config()
+        CONFIG_MANAGER.conf_file_cache = None


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-902097 and SNOW-902098

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR I add the capability to add default values to ConfigOption class and am adding the first ConfigOption that is going to use it `default_connection_name` that defaults to `default`.