### PR TITLE
SNOW-891470 adding implementation for default_connection_name

### DIFF
--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+from functools import wraps
+
 apilevel = "2.0"
 threadsafety = 2
 paramstyle = "pyformat"
@@ -47,6 +49,7 @@ from .version import VERSION
 logging.getLogger(__name__).addHandler(NullHandler())
 
 
+@wraps(SnowflakeConnection.__init__)
 def Connect(**kwargs) -> SnowflakeConnection:
     return SnowflakeConnection(**kwargs)
 

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -166,8 +166,8 @@ class ConfigOption:
         env_var = os.environ.get(env_name)
         if env_var is None:
             return False, None
-        loaded_var: str | _T | None = env_var
-        if env_var is not None and self.parse_str is not None:
+        loaded_var: str | _T = env_var
+        if self.parse_str is not None:
             loaded_var = self.parse_str(env_var)
         if isinstance(loaded_var, (Table, tomlkit.TOMLDocument)):
             # If we got a TOML table we probably want it in dictionary form

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -126,7 +126,7 @@ class ConfigOption:
                 value = self._get_config()
                 source = "configuration file"
             except MissingConfigOptionError:
-                if self.default:
+                if self.default is not None:
                     source = "default_value"
                     value = self.default
                 else:
@@ -167,7 +167,7 @@ class ConfigOption:
         if env_var is None:
             return False, None
         loaded_var: str | _T | None = env_var
-        if env_var and self.parse_str is not None:
+        if env_var is not None and self.parse_str is not None:
             loaded_var = self.parse_str(env_var)
         if isinstance(loaded_var, (Table, tomlkit.TOMLDocument)):
             # If we got a TOML table we probably want it in dictionary form
@@ -449,6 +449,7 @@ CONFIG_MANAGER = ConfigManager(
 CONFIG_MANAGER.add_option(
     name="connections",
     parse_str=tomlkit.parse,
+    default=dict(),
 )
 CONFIG_MANAGER.add_option(
     name="default_connection_name",

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -308,7 +308,7 @@ class SnowflakeConnection:
         snowflake.connector.constants.CONNECTIONS_FILE.
 
         When connection_name is supplied we will first load that connection
-        and then overwrite any other values supplied.
+        and then override any other values supplied.
 
         When no arguments are given (other than connection_file_path) the
         default connection will be loaded first. Note that no overwriting is
@@ -339,7 +339,7 @@ class SnowflakeConnection:
             setattr(self, f"_{name}", value)
 
         self.heartbeat_thread = None
-        empty_kwargs = not bool(kwargs)
+        is_kwargs_empty = not kwargs
 
         if "application" not in kwargs:
             if ENV_VAR_PARTNER in os.environ.keys():
@@ -365,7 +365,7 @@ class SnowflakeConnection:
                     f" known ones are {list(connections.keys())}"
                 )
             kwargs = {**connections[connection_name], **kwargs}
-        elif empty_kwargs:
+        elif is_kwargs_empty:
             # connection_name is None and kwargs was empty when called
             def_connection_name = CONFIG_MANAGER["default_connection_name"]
             connections = CONFIG_MANAGER["connections"]

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from textwrap import dedent
 from unittest.mock import patch
 
 import pytest
@@ -31,10 +32,11 @@ except ImportError:
 
 try:  # pragma: no cover
     from snowflake.connector.auth import AuthByUsrPwdMfa
+    from snowflake.connector.config_manager import CONFIG_MANAGER
     from snowflake.connector.constants import ENV_VAR_PARTNER, QueryStatus
 except ImportError:
     ENV_VAR_PARTNER = "SF_PARTNER"
-    QueryStatus = None
+    QueryStatus = CONFIG_MANAGER = None
 
     class AuthByUsrPwdMfa(AuthByDefault):
         def __init__(self, password: str, mfa_token: str) -> None:
@@ -216,13 +218,101 @@ def test_negative_custom_auth(auth_class):
         )
 
 
-def test_missing_default_connection(monkeypatch):
-    connection_name = random_string(5)
+def test_missing_default_connection(monkeypatch, tmp_path):
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
     with monkeypatch.context() as m:
-        m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", connection_name)
-        m.setenv("SNOWFLAKE_CONNECTIONS", "")
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match="Default connection with name 'default' cannot be found, known ones are \\[\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conf_file(monkeypatch, tmp_path):
+    connection_name = random_string(5)
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        dedent(
+            f"""\
+            default_connection_name = "{connection_name}"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
         with pytest.raises(
             Error,
             match=f"Default connection with name '{connection_name}' cannot be found, known ones are \\[\\]",
         ):
-            snowflake.connector.connect()
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conn_file(monkeypatch, tmp_path):
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    connections_file.write_text(
+        dedent(
+            """\
+            [con_a]
+            user = "test user"
+            account = "test account"
+            password = "test password"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match="Default connection with name 'default' cannot be found, known ones are \\['con_a'\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conf_conn_file(monkeypatch, tmp_path):
+    connection_name = random_string(5)
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        dedent(
+            f"""\
+            default_connection_name = "{connection_name}"
+            """
+        )
+    )
+    connections_file.write_text(
+        dedent(
+            """\
+            [con_a]
+            user = "test user"
+            account = "test account"
+            password = "test password"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match=f"Default connection with name '{connection_name}' cannot be found, known ones are \\['con_a'\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -220,9 +220,9 @@ def test_missing_default_connection(monkeypatch):
     connection_name = random_string(5)
     with monkeypatch.context() as m:
         m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", connection_name)
-        m.setenv("SNOWFLAKE_CONNECTIONS", "[connections]")
+        m.setenv("SNOWFLAKE_CONNECTIONS", "")
         with pytest.raises(
             Error,
-            match=f"Default connection with name '{connection_name}' cannot be found, known ones are .*",
+            match=f"Default connection with name '{connection_name}' cannot be found, known ones are \\[\\]",
         ):
             snowflake.connector.connect()

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -24,7 +24,6 @@ try:
         AuthByOkta,
         AuthByWebBrowser,
     )
-    from snowflake.connector.config_manager import CONFIG_MANAGER
 except ImportError:
     from unittest.mock import MagicMock
 
@@ -218,12 +217,10 @@ def test_negative_custom_auth(auth_class):
 
 
 def test_missing_default_connection(monkeypatch):
-    connections = CONFIG_MANAGER["connections"]
-    connection_name = None
-    while connection_name is None or connection_name in connections:
-        connection_name = random_string(5)
+    connection_name = random_string(5)
     with monkeypatch.context() as m:
         m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", connection_name)
+        m.setenv("SNOWFLAKE_CONNECTIONS", "[connections]")
         with pytest.raises(
             Error,
             match=f"Default connection with name '{connection_name}' cannot be found, known ones are .*",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-891470

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Now that we have flushed out how the configuration file option `default_connection_name` should work I add actual support for it.