### PR TITLE
Implement thread safety during instantiation of TelemetryService

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,7 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.2.1(TBD)
 
-  - Added thread safety when instantiating multiple connections
+  - Added thread safety in telemetry when instantiating multiple connections concurrently.
 
 - v3.2.0(September 06,2023)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.2.1(TBD)
+
+  - Added thread safety when instantiating multiple connections
+
 - v3.2.0(September 06,2023)
 
   - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -159,10 +159,9 @@ class TelemetryService:
     @classmethod
     def get_instance(cls) -> TelemetryService:
         """Static access method."""
-        cls.__lock_init.acquire()
-        if cls.__instance is None:
-            cls()
-        cls.__lock_init.release()
+        with cls.__lock_init:
+            if cls.__instance is None:
+                cls()
         return cls.__instance
 
     def __init__(self) -> None:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-895151: Non Thread Safe Singleton Telemetry Service in Python](https://github.com/snowflakedb/snowflake-connector-python/issues/1700)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adding a lock guarding the instantiation of `TelemetryService` prevents multiple threads from entering `__init__` and violating the singleton constraint.
