### PR TITLE
SNOW-872568: Fix retry oscp URL for private link

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.2.1(TBD)
+
+  - Fixed a bug where url port and path were ignore in private link oscp retry.
+
 - v3.2.0(September 06,2023)
 
   - Made the ``parser`` -> ``manager`` renaming more consistent in ``snowflake.connector.config_manager`` module.

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -439,7 +439,15 @@ class OCSPServer:
         if self.OCSP_RETRY_URL is None:
             target_url = f"{ocsp_url}/{b64data}"
         else:
-            target_url = self.OCSP_RETRY_URL.format(parsed_url.hostname, b64data)
+            # values of parsed_url.netloc and parsed_url.path based on oscp_url are as follows:
+            # URL                                    NETLOC                         PATH
+            # "http://oneocsp.microsoft.com"         "oneocsp.microsoft.com"        ""
+            # "http://oneocsp.microsoft.com:8080"    "oneocsp.microsoft.com:8080"   ""
+            # "http://oneocsp.microsoft.com/"        "oneocsp.microsoft.com"        "/"
+            # "http://oneocsp.microsoft.com/ocsp"    "oneocsp.microsoft.com"        "/ocsp"
+            # The check below is to treat first two urls same
+            path = parsed_url.path if parsed_url.path != "/" else ""
+            target_url = self.OCSP_RETRY_URL.format(parsed_url.netloc + path, b64data)
 
         logger.debug("OCSP Retry URL is - %s", target_url)
         return target_url

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -395,6 +395,33 @@ def test_building_retry_url():
         == "http://ocsp.us-east-1.snowflakecomputing.com/retry/{0}/{1}"
     )
 
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com/", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com/ocsp", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/ocsp/1234"
+    )
+
+    # ensure we also handle port
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080/", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080/ocsp", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/ocsp/1234"
+    )
+
     # privatelink retry url with port
     OCSP_SERVER.OCSP_RETRY_URL = None
     OCSP_SERVER.CACHE_SERVER_URL = (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-872568

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Porting fix for getting the correct retry link for oscp private link url
