### PR TITLE
SNOW-899912 patching out urllib3.contrib.pyopenssl deprecation warnings

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Fixed a bug where url port and path were ignore in private link oscp retry.
   - Added thread safety in telemetry when instantiating multiple connections concurrently.
+  - Removed the deprecation warning from the vendored urllib3 about urllib3.contrib.pyopenssl deprecation.
 
 - v3.2.0(September 06,2023)
 

--- a/src/snowflake/connector/vendored/urllib3/__init__.py
+++ b/src/snowflake/connector/vendored/urllib3/__init__.py
@@ -19,23 +19,6 @@ from .util.retry import Retry
 from .util.timeout import Timeout
 from .util.url import get_host
 
-# === NOTE TO REPACKAGERS AND VENDORS ===
-# Please delete this block, this logic is only
-# for urllib3 being distributed via PyPI.
-# See: https://github.com/urllib3/urllib3/issues/2680
-try:
-    import urllib3_secure_extra  # type: ignore # noqa: F401
-except ImportError:
-    pass
-else:
-    warnings.warn(
-        "'urllib3[secure]' extra is deprecated and will be removed "
-        "in a future release of urllib3 2.x. Read more in this issue: "
-        "https://github.com/urllib3/urllib3/issues/2680",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-
 __author__ = "Andrey Petrov (andrey.petrov@shazow.net)"
 __license__ = "MIT"
 __version__ = __version__

--- a/src/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py
+++ b/src/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py
@@ -73,19 +73,10 @@ except ImportError:  # Platform-specific: Python 3
 import logging
 import ssl
 import sys
-import warnings
 
 from .. import util
 from ..packages import six
 from ..util.ssl_ import PROTOCOL_TLS_CLIENT
-
-warnings.warn(
-    "'urllib3.contrib.pyopenssl' module is deprecated and will be removed "
-    "in a future release of urllib3 2.x. Read more in this issue: "
-    "https://github.com/urllib3/urllib3/issues/2680",
-    category=DeprecationWarning,
-    stacklevel=2,
-)
 
 __all__ = ["inject_into_urllib3", "extract_from_urllib3"]
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1713

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Patching out https://github.com/snowflakedb/vendored-urllib3/commit/f95b9640604e7dd70d50d81f68fd14a36c082841