### PR TITLE
SNOW-943025: improve flaky OOB test

### DIFF
--- a/test/unit/test_telemetry_oob.py
+++ b/test/unit/test_telemetry_oob.py
@@ -69,7 +69,12 @@ def test_telemetry_oob_simple_flush(telemetry_setup, caplog):
         "Failed to generate a JSON dump from the passed in telemetry OOB events"
         not in caplog.text
     )
-    assert telemetry.size() == 0
+    # since pytests can run test in parallel and TelemetryService is a singleton, other tests
+    # might encounter error logged into the queue of the OOB Telemetry simultaneously
+    # leading to assert telemetry.size() == 0 failure
+    # here we check that the OCSP exception event in the test is flushed
+    for event in list(telemetry.queue.queue):
+        assert "OCSPException" not in event.name
 
 
 @pytest.mark.flaky(reruns=3)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-943025, Fixes flaky OOB test

since pytests can run test in parallel and TelemetryService is a singleton, other tests might encounter error logged into the queue of the OOB Telemetry simultaneously leading to assert telemetry.size() == 0 failure, here we check that the OCSP exception event in the test is flushed

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
