### PR TITLE
SNOW-956671: We should change the user-agent of the diagnostic report…

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -17,6 +17,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added the `socket_timeout` argument to `snowflake.connector.connect` specifying socket read and connect timeout.
   - Fixed `login_timeout` and `network_timeout` behaviour. Retries of login and network requests are now properly halted after these timeouts expire.
   - Fixed bug for issue https://github.com/urllib3/urllib3/issues/1878 in vendored `urllib`.
+  - Add User-Agent header for diagnostic report for tracking.
 
 - v3.3.1(October 16,2023)
 

--- a/src/snowflake/connector/connection_diagnostic.py
+++ b/src/snowflake/connector/connection_diagnostic.py
@@ -214,6 +214,12 @@ class ConnectionDiagnostic:
                 context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
                 sock = context.wrap_socket(conn, server_hostname=host)
                 certificate = ssl.DER_cert_to_PEM_cert(sock.getpeercert(True))
+                http_request = f"""GET / {host}:{port} HTTP/1.1\r\n
+                                   Host: {host}\r\n
+                                   User-Agent: snowflake-connector-python-diagnostic
+                                   \r\n\r\n"""
+                sock.send(str.encode(http_request))
+                sock.recv(4096).decode("utf-8")
                 conn.close()
                 return certificate
             else:

--- a/src/snowflake/connector/connection_diagnostic.py
+++ b/src/snowflake/connector/connection_diagnostic.py
@@ -218,8 +218,13 @@ class ConnectionDiagnostic:
                                    Host: {host}\r\n
                                    User-Agent: snowflake-connector-python-diagnostic
                                    \r\n\r\n"""
-                sock.send(str.encode(http_request))
-                sock.recv(4096).decode("utf-8")
+                try:
+                    sock.send(str.encode(http_request))
+                except Exception as e:
+                    self.__append_message(
+                        host_type,
+                        f"{host}:{port}: URL Check: Failed: Unknown Exception: {e}",
+                    )
                 conn.close()
                 return certificate
             else:

--- a/test/unit/test_connection_diagnostic.py
+++ b/test/unit/test_connection_diagnostic.py
@@ -37,6 +37,20 @@ def test_https_host_report(caplog):
     )
 
 
+def test_test_socket_get_cert(caplog):
+    connection_diag = ConnectionDiagnostic(
+        account="test", host="test.snowflakecomputing.com"
+    )
+    test_socket_get_cert = connection_diag._ConnectionDiagnostic__test_socket_get_cert
+    result = test_socket_get_cert(
+        host="client-telemetry.snowflakecomputing.com",
+        port=443,
+        host_type="OUT_OF_BAND_TELEMETRY",
+    )
+
+    assert "BEGIN CERTIFICATE" in result
+
+
 def test_decode_dict():
     test_dict = {b"CN": b"client-telemetry.snowflakecomputing.com"}
     result = _decode_dict(test_dict)


### PR DESCRIPTION
… so we can track it's usage

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-956671

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   I added a user-agent header to our ssl cert checks so we can track the usage of the python connector diagnostic.