### PR TITLE
SNOW-957010: loosen restrictions on expected call count in timeout test to account…

### DIFF
--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -351,4 +351,5 @@ def test_handle_timeout(mockSessionRequest, next_action):
 
     # authenticator should be the only retry mechanism for login requests
     # 9 seconds should be enough for authenticator to attempt twice
-    assert mockSessionRequest.call_count == 2
+    # however, loosen restrictions to avoid thread scheduling causing failure
+    assert 1 < mockSessionRequest.call_count < 4


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-957010](https://snowflakecomputing.atlassian.net/browse/SNOW-957010)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[SNOW-957010]: https://snowflakecomputing.atlassian.net/browse/SNOW-957010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ