### PR TITLE
SNOW-950840 Add support for the vector data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ core.*
 
 # Compiled Cython
 src/snowflake/connector/arrow_iterator.cpp
+src/snowflake/connector/nanoarrow_cpp/ArrowIterator/nanoarrow_arrow_iterator.cpp

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 
+- v3.6.0(TBD)
+
+  - Added support for Vector types
+
 - v3.5.0(November 13,2023)
 
   - Version 3.5.0 is the snowflake-connector-python purely built upon apache arrow-nanoarrow project.

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,9 @@ if _ABLE_TO_COMPILE_EXTENSIONS and not SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSION
                     ),
                     os.path.join(NANOARROW_ARROW_ITERATOR_SRC_DIR, "DateConverter.cpp"),
                     os.path.join(
+                        NANOARROW_ARROW_ITERATOR_SRC_DIR, "FixedSizeListConverter.cpp"
+                    ),
+                    os.path.join(
                         NANOARROW_ARROW_ITERATOR_SRC_DIR, "FloatConverter.cpp"
                     ),
                     os.path.join(NANOARROW_ARROW_ITERATOR_SRC_DIR, "IntConverter.cpp"),

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -95,6 +95,14 @@ FIELD_TYPES: tuple[FieldType, ...] = (
     FieldType(
         name="GEOMETRY", dbapi_type=[DBAPI_TYPE_STRING], pa_type=lambda: pa.string()
     ),
+    FieldType(
+        # TODO(SNOW-969160): While pa.binary() results in the correct pandas column
+        # type being generated, it should be switched to pa.list_(...) once parsing
+        # for the new result metadata fields is added.
+        name="VECTOR",
+        dbapi_type=[DBAPI_TYPE_BINARY],
+        pa_type=lambda: pa.binary(),
+    ),
 )
 
 FIELD_NAME_TO_ID: DefaultDict[Any, int] = defaultdict(int)

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -320,6 +320,9 @@ class SnowflakeConverter:
 
     _ARRAY_to_python = _VARIANT_to_python
 
+    def _VECTOR_to_python(self, _: dict[str, Any]) -> Any | None:
+        return None  # skip conv
+
     def _BOOLEAN_to_python(
         self, ctx: dict[str, str | None] | dict[str, str]
     ) -> Callable:

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import binascii
 import decimal
+import json
 import time
 from datetime import date, datetime
 from datetime import time as dt_t
@@ -320,8 +321,8 @@ class SnowflakeConverter:
 
     _ARRAY_to_python = _VARIANT_to_python
 
-    def _VECTOR_to_python(self, _: dict[str, Any]) -> Any | None:
-        return None  # skip conv
+    def _VECTOR_to_python(self, ctx: dict[str, Any]) -> Callable:
+        return lambda v: json.loads(v)
 
     def _BOOLEAN_to_python(
         self, ctx: dict[str, str | None] | dict[str, str]

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -11,6 +11,7 @@
 #include "BinaryConverter.hpp"
 #include "BooleanConverter.hpp"
 #include "DateConverter.hpp"
+#include "FixedSizeListConverter.hpp"
 #include "TimeStampConverter.hpp"
 #include "TimeConverter.hpp"
 #include <memory>
@@ -435,6 +436,12 @@ void CArrowChunkIterator::initColumnConverters()
           }
         }
 
+        break;
+      }
+
+      case SnowflakeType::Type::VECTOR:
+      {
+        m_currentBatchConverters.push_back(std::make_shared<sf::FixedSizeListConverter>(array));
         break;
       }
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.cpp
@@ -44,11 +44,11 @@ PyObject* FixedSizeListConverter::toPyObject(int64_t rowIndex) const
   // the lengths of the fixed size lists in the array.
 
   ArrowArrayView* elements = m_array->children[0];
-  const auto length = elements->length / m_array->length;
-  PyObject* list = PyList_New(length);
+  const auto fixedSizeArrayLength = elements->length / m_array->length;
+  PyObject* list = PyList_New(fixedSizeArrayLength);
 
-  const int64_t startIndexWithoutOffset = rowIndex * length;
-  for (int64_t i = 0; i < length; ++i)
+  const int64_t startIndexWithoutOffset = rowIndex * fixedSizeArrayLength;
+  for (int64_t i = 0; i < fixedSizeArrayLength; ++i)
   {
     const auto bufferIndexWithoutOffset = startIndexWithoutOffset + i;
     // Currently, the backend only sends back INT32 and FLOAT32, but the
@@ -63,8 +63,7 @@ PyObject* FixedSizeListConverter::toPyObject(int64_t rowIndex) const
         const auto value =
             ArrowArrayViewGetIntUnsafe(elements, bufferIndexWithoutOffset);
         PyList_SetItem(list, i, PyLong_FromLongLong(value));
-      }
-      break;
+      } break;
       case NANOARROW_TYPE_HALF_FLOAT:
       case NANOARROW_TYPE_FLOAT:
       case NANOARROW_TYPE_DOUBLE:
@@ -72,8 +71,7 @@ PyObject* FixedSizeListConverter::toPyObject(int64_t rowIndex) const
         const auto value =
             ArrowArrayViewGetDoubleUnsafe(elements, bufferIndexWithoutOffset);
         PyList_SetItem(list, i, PyFloat_FromDouble(value));
-      }
-      break;
+      } break;
       default:
         std::string errorInfo = Logger::formatString(
             "[Snowflake Exception] invalid arrow element type for fixed size "

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "FixedSizeListConverter.hpp"
+
+namespace sf
+{
+Logger* FixedSizeListConverter::logger =
+    new Logger("snowflake.connector.FixedSizeListConverter");
+
+FixedSizeListConverter::FixedSizeListConverter(ArrowArrayView* array)
+: m_array(array)
+{
+}
+
+void FixedSizeListConverter::generateError(const std::string& msg) const
+{
+  logger->error(__FILE__, __func__, __LINE__, msg.c_str());
+  PyErr_SetString(PyExc_Exception, msg.c_str());
+}
+
+PyObject* FixedSizeListConverter::toPyObject(int64_t rowIndex) const
+{
+  if (ArrowArrayViewIsNull(m_array, rowIndex))
+  {
+    Py_RETURN_NONE;
+  }
+
+  if (m_array->n_children != 1)
+  {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] invalid arrow element schema for fixed size "
+        "list: got (%d) "
+        "children",
+        m_array->n_children);
+    this->generateError(errorInfo);
+    return nullptr;
+  }
+
+  // m_array->length represents the number of fixed size lists in the array
+  // m_array->children[0] has a buffer view that contains the actual data of
+  // each list, back-to-back m_array->children[0]->length represents the sum of
+  // the lengths of the fixed size lists in the array.
+
+  ArrowArrayView* elements = m_array->children[0];
+  const auto length = elements->length / m_array->length;
+  PyObject* list = PyList_New(length);
+
+  const int64_t startIndexWithoutOffset = rowIndex * length;
+  for (int64_t i = 0; i < length; ++i)
+  {
+    const auto bufferIndexWithoutOffset = startIndexWithoutOffset + i;
+    // Currently, the backend only sends back INT32 and FLOAT32, but the
+    // remaining types are enumerated for future use.
+    switch (elements->storage_type)
+    {
+      case NANOARROW_TYPE_INT8:
+      case NANOARROW_TYPE_INT16:
+      case NANOARROW_TYPE_INT32:
+      case NANOARROW_TYPE_INT64:
+      {
+        const auto value =
+            ArrowArrayViewGetIntUnsafe(elements, bufferIndexWithoutOffset);
+        PyList_SetItem(list, i, PyLong_FromLongLong(value));
+      }
+      break;
+      case NANOARROW_TYPE_HALF_FLOAT:
+      case NANOARROW_TYPE_FLOAT:
+      case NANOARROW_TYPE_DOUBLE:
+      {
+        const auto value =
+            ArrowArrayViewGetDoubleUnsafe(elements, bufferIndexWithoutOffset);
+        PyList_SetItem(list, i, PyFloat_FromDouble(value));
+      }
+      break;
+      default:
+        std::string errorInfo = Logger::formatString(
+            "[Snowflake Exception] invalid arrow element type for fixed size "
+            "list: got (%s)",
+            ArrowTypeString(elements->storage_type));
+        this->generateError(errorInfo);
+        return nullptr;
+    }
+  }
+
+  return list;
+}
+
+}  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/FixedSizeListConverter.hpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#ifndef PC_FIXEDSIZELISTCONVERTER_HPP
+#define PC_FIXEDSIZELISTCONVERTER_HPP
+
+#include <memory>
+
+#include "IColumnConverter.hpp"
+#include "logging.hpp"
+#include "nanoarrow.h"
+#include "nanoarrow.hpp"
+
+namespace sf
+{
+
+class FixedSizeListConverter : public IColumnConverter
+{
+public:
+  explicit FixedSizeListConverter(ArrowArrayView* array);
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+private:
+  void generateError(const std::string& msg) const;
+
+  ArrowArrayView* m_array;
+
+  static Logger* logger;
+};
+
+}  // namespace sf
+
+#endif  // PC_FIXEDSIZELISTCONVERTER_HPP

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
@@ -29,6 +29,7 @@ std::unordered_map<std::string, SnowflakeType::Type>
         {"TIMESTAMP_LTZ", SnowflakeType::Type::TIMESTAMP_LTZ},
         {"TIMESTAMP_NTZ", SnowflakeType::Type::TIMESTAMP_NTZ},
         {"TIMESTAMP_TZ", SnowflakeType::Type::TIMESTAMP_TZ},
-        {"VARIANT", SnowflakeType::Type::VARIANT}};
+        {"VARIANT", SnowflakeType::Type::VARIANT},
+        {"VECTOR", SnowflakeType::Type::VECTOR}};
 
 }  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
@@ -32,7 +32,8 @@ public:
     TIMESTAMP_LTZ = 12,
     TIMESTAMP_NTZ = 13,
     TIMESTAMP_TZ = 14,
-    VARIANT = 15
+    VARIANT = 15,
+    VECTOR = 16
   };
 
   static SnowflakeType::Type snowflakeTypeFromString(std::string str)

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -583,6 +583,54 @@ def test_timestampltz(conn_cnx, scale, timezone):
         finish(conn, table)
 
 
+@pytest.mark.skipif(
+    not installed_pandas or no_arrow_iterator_ext,
+    reason="arrow_iterator extension is not built, or pandas is missing.",
+)
+def test_vector(conn_cnx, is_public_test):
+    if is_public_test:
+        pytest.xfail(
+            reason="This feature hasn't been rolled out for public Snowflake deployments yet."
+        )
+    tests = [
+        (
+            "vector(int,3)",
+            [
+                "NULL",
+                "[1,2,3]::vector(int,3)",
+            ],
+            ["NULL", numpy.array([1, 2, 3])],
+        ),
+        (
+            "vector(float,3)",
+            [
+                "NULL",
+                "[1.3,2.4,3.5]::vector(float,3)",
+            ],
+            ["NULL", numpy.array([1.3, 2.4, 3.5], dtype=numpy.float32)],
+        ),
+    ]
+    for vector_type, cases, typed_cases in tests:
+        table = "test_arrow_vector"
+        column = f"(a {vector_type})"
+        values = [f"{i}, {c}" for i, c in enumerate(cases)]
+        with conn_cnx() as conn:
+            init_with_insert_select(conn, table, column, values)
+            # Test general fetches
+            sql_text = f"select a from {table} order by s"
+            validate_pandas(
+                conn, sql_text, typed_cases, 1, method="one", data_type=vector_type
+            )
+
+            # Test empty result sets
+            cur = conn.cursor()
+            cur.execute(f"select a from {table} limit 0")
+            df = cur.fetch_pandas_all()
+            assert len(df) == 0
+
+            finish(conn, table)
+
+
 def validate_pandas(
     cnx_table,
     sql,
@@ -649,7 +697,7 @@ def validate_pandas(
         for i in range(row_count):
             for j in range(col_count):
                 c_new = df_new.iat[i, j]
-                if cases[i] == "NULL":
+                if type(cases[i]) == str and cases[i] == "NULL":
                     assert c_new is None or pandas.isnull(c_new), (
                         "{} row, {} column: original value is NULL, "
                         "new value is {}, values are not equal".format(i, j, c_new)
@@ -686,6 +734,12 @@ def validate_pandas(
                             "values are not equal".format(i, j, cases[i], c_new)
                         )
                         break
+                    elif data_type.startswith("vector"):
+                        assert numpy.array_equal(cases[i], c_new), (
+                            "{} row, {} column: original value is {}, new value is {}, "
+                            "values are not equal".format(i, j, cases[i], c_new)
+                        )
+                        continue
                     else:
                         c_case = cases[i]
                     if epsilon is None:
@@ -859,6 +913,16 @@ def init(json_cnx, table, column, values, timezone=None):
     column_with_seq = column[0] + "s number, " + column[1:]
     cursor_json.execute(f"create or replace table {table} {column_with_seq}")
     cursor_json.execute(f"insert into {table} values {values}")
+
+
+def init_with_insert_select(json_cnx, table, column, rows, timezone=None):
+    cursor_json = json_cnx.cursor()
+    if timezone is not None:
+        cursor_json.execute(f"ALTER SESSION SET TIMEZONE = '{timezone}'")
+    column_with_seq = column[0] + "s number, " + column[1:]
+    cursor_json.execute(f"create or replace table {table} {column_with_seq}")
+    for row in rows:
+        cursor_json.execute(f"insert into {table} select {row}")
 
 
 def finish(json_cnx, table):

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -375,6 +375,17 @@ def test_select_semi_structure(conn_cnx):
     iterate_over_test_chunk("struct", conn_cnx, sql_text, row_count, col_count)
 
 
+def test_select_vector(conn_cnx):
+    sql_text = """select [1,2,3]::vector(int,3),
+        [1.1,2.2]::vector(float,2),
+        NULL::vector(int,2),
+        NULL::vector(float,3);
+    """
+    row_count = 1
+    col_count = 4
+    iterate_over_test_chunk("vector", conn_cnx, sql_text, row_count, col_count)
+
+
 def test_select_time(conn_cnx):
     for scale in range(10):
         select_time_with_scale(conn_cnx, scale)
@@ -641,6 +652,8 @@ def iterate_over_test_chunk(
                             and eps is not None
                         ):
                             assert abs(json_res[j] - arrow_res[j]) <= eps
+                        elif test_name == "vector":
+                            assert json_res[j] == pytest.approx(arrow_res[j])
                         else:
                             assert json_res[j] == arrow_res[j]
             else:

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -360,7 +360,14 @@ def test_select_double_precision(conn_cnx):
     finish(conn_cnx, table)
 
 
-def test_select_semi_structure(conn_cnx):
+@pytest.mark.skipif(
+    no_arrow_iterator_ext, reason="arrow_iterator extension is not built."
+)
+def test_select_semi_structure(conn_cnx, is_public_test):
+    if is_public_test:
+        pytest.xfail(
+            reason="This feature hasn't been rolled out for public Snowflake deployments yet."
+        )
     sql_text = """select array_construct(10, 20, 30),
         array_construct(null, 'hello', 3::double, 4, 5),
         array_construct(),

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -360,14 +360,7 @@ def test_select_double_precision(conn_cnx):
     finish(conn_cnx, table)
 
 
-@pytest.mark.skipif(
-    no_arrow_iterator_ext, reason="arrow_iterator extension is not built."
-)
-def test_select_semi_structure(conn_cnx, is_public_test):
-    if is_public_test:
-        pytest.xfail(
-            reason="This feature hasn't been rolled out for public Snowflake deployments yet."
-        )
+def test_select_semi_structure(conn_cnx):
     sql_text = """select array_construct(10, 20, 30),
         array_construct(null, 'hello', 3::double, 4, 5),
         array_construct(),
@@ -382,7 +375,12 @@ def test_select_semi_structure(conn_cnx, is_public_test):
     iterate_over_test_chunk("struct", conn_cnx, sql_text, row_count, col_count)
 
 
-def test_select_vector(conn_cnx):
+def test_select_vector(conn_cnx, is_public_test):
+    if is_public_test:
+        pytest.xfail(
+            reason="This feature hasn't been rolled out for public Snowflake deployments yet."
+        )
+
     sql_text = """select [1,2,3]::vector(int,3),
         [1.1,2.2]::vector(float,2),
         NULL::vector(int,2),


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-950840

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add support for vectors (soon in Private Preview) to the connector. This primarily consists of Arrow deserialization logic.

I will follow these changes up with parsing logic for the new result metadata fields so that the vector field type definition in `constants.py` can use the correct pyarrow type. Right now, we return `pa.binary()` for `FieldType.pa_type` since we don't have access to the vector's type and dimension (which are needed by `pa.list_`). This bypass is functionally equivalent since we only use `FieldType.pa_type` to generate pandas type mappings (`object` for vectors), but I will update it once the aforementioned result metadata changes are complete.