### PR TITLE
Remove unused requirement for importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     pyjwt<3.0.0
     pytz
     requests<3.0.0
-    importlib-metadata; python_version < '3.8'
     packaging
     charset_normalizer>=2,<4
     idna>=2.5,<4


### PR DESCRIPTION
## What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

None. It just removes a requirement that can't possibly be used since it'd only be used for Python < 3.8, but the library itself requires Python >= 3.8.

## Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

## Please describe how your code solves the related issue.

It removes the unnecessary requirement line.