### PR TITLE
SNOW-912527 Milestone 1 + Milestone 3: Convert SnowflakeRestful to use aiohttp, convert SnowflakeStorageClient to use aiohttp

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -860,7 +860,9 @@ class SnowflakeConnection:
             self.proxy_host, self.proxy_port, self.proxy_user, self.proxy_password
         )
 
-        self._rest = SnowflakeRestful(
+        # Yichuan: TEMPORARY
+        from .network_async import SnowflakeRestfulAsync
+        self._rest = SnowflakeRestfulAsync(
             host=self.host,
             port=self.port,
             protocol=self._protocol,

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -886,6 +886,7 @@ class SnowflakeCursor:
                 sf_file_transfer_agent.execute()
                 data = sf_file_transfer_agent.result()
                 self._total_rowcount = len(data["rowset"]) if "rowset" in data else -1
+                sf_file_transfer_agent.close()
 
             if _exec_async:
                 self.connection._async_sfqids[self._sfqid] = None

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -883,10 +883,12 @@ class SnowflakeCursor:
                     multipart_threshold=data.get("threshold"),
                     use_s3_regional_url=self._connection.enable_stage_s3_privatelink_for_us_east_1,
                 )
-                sf_file_transfer_agent.execute()
-                data = sf_file_transfer_agent.result()
-                self._total_rowcount = len(data["rowset"]) if "rowset" in data else -1
-                sf_file_transfer_agent.close()
+                try:
+                    sf_file_transfer_agent.execute()
+                    data = sf_file_transfer_agent.result()
+                    self._total_rowcount = len(data["rowset"]) if "rowset" in data else -1
+                finally:
+                    sf_file_transfer_agent.close()
 
             if _exec_async:
                 self.connection._async_sfqids[self._sfqid] = None

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -861,10 +861,15 @@ class SnowflakeCursor:
             )
             logger.debug("PUT OR GET: %s", self.is_file_transfer)
             if self.is_file_transfer:
-                from .file_transfer_agent import SnowflakeFileTransferAgent
+                if self._connection._use_async:
+                    from .file_transfer_agent_async import SnowflakeFileTransferAgentAsync
+                    agent_class = SnowflakeFileTransferAgentAsync
+                else:
+                    from .file_transfer_agent import SnowflakeFileTransferAgent
+                    agent_class = SnowflakeFileTransferAgent
 
                 # Decide whether to use the old, or new code path
-                sf_file_transfer_agent = SnowflakeFileTransferAgent(
+                sf_file_transfer_agent = agent_class(
                     self,
                     query,
                     ret,

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -673,7 +673,10 @@ class SnowflakeFileTransferAgent:
                 use_s3_regional_url=self._use_s3_regional_url,
             )
         elif self._stage_location_type == S3_FS:
-            return SnowflakeS3RestClient(
+            # Yichuan: TEMPORARY
+            from .s3_storage_client_async import SnowflakeS3RestClientAsync
+
+            return SnowflakeS3RestClientAsync(
                 meta,
                 self._credentials,
                 self._stage_info,
@@ -681,6 +684,14 @@ class SnowflakeFileTransferAgent:
                 use_accelerate_endpoint=self._use_accelerate_endpoint,
                 use_s3_regional_url=self._use_s3_regional_url,
             )
+            # return SnowflakeS3RestClient(
+            #     meta,
+            #     self._credentials,
+            #     self._stage_info,
+            #     _chunk_size_calculator(meta.src_file_size),
+            #     use_accelerate_endpoint=self._use_accelerate_endpoint,
+            #     use_s3_regional_url=self._use_s3_regional_url,
+            # )
         elif self._stage_location_type == GCS_FS:
             return SnowflakeGCSRestClient(
                 meta,
@@ -1184,3 +1195,6 @@ class SnowflakeFileTransferAgent:
                 else:
                     m.dst_file_name = m.name
                     m.dst_compression_type = None
+
+    def close(self) -> None:
+        pass

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -673,10 +673,7 @@ class SnowflakeFileTransferAgent:
                 use_s3_regional_url=self._use_s3_regional_url,
             )
         elif self._stage_location_type == S3_FS:
-            # Yichuan: TEMPORARY
-            from .s3_storage_client_async import SnowflakeS3RestClientAsync
-
-            return SnowflakeS3RestClientAsync(
+            return SnowflakeS3RestClient(
                 meta,
                 self._credentials,
                 self._stage_info,
@@ -684,14 +681,6 @@ class SnowflakeFileTransferAgent:
                 use_accelerate_endpoint=self._use_accelerate_endpoint,
                 use_s3_regional_url=self._use_s3_regional_url,
             )
-            # return SnowflakeS3RestClient(
-            #     meta,
-            #     self._credentials,
-            #     self._stage_info,
-            #     _chunk_size_calculator(meta.src_file_size),
-            #     use_accelerate_endpoint=self._use_accelerate_endpoint,
-            #     use_s3_regional_url=self._use_s3_regional_url,
-            # )
         elif self._stage_location_type == GCS_FS:
             return SnowflakeGCSRestClient(
                 meta,

--- a/src/snowflake/connector/file_transfer_agent_async.py
+++ b/src/snowflake/connector/file_transfer_agent_async.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from .file_transfer_agent import *
+from .file_transfer_agent import _chunk_size_calculator
 from .network_async import EventLoopThreadRunner
 
 # YICHUAN: SnowflakeFileTransferAgentAsync is identical to SnowflakeFileTransferAgent, except for two differences; it
@@ -20,6 +21,28 @@ class SnowflakeFileTransferAgentAsync(SnowflakeFileTransferAgent):
         self._loop_runner.start()
 
         super().__init__(*args, **kwargs)
+
+    def _create_file_transfer_client(
+        self, meta: SnowflakeFileMeta
+    ) -> SnowflakeStorageClient:
+        if self._stage_location_type == LOCAL_FS:
+            raise Exception("Local not supported for SnowflakeFileTransferAgentAsync")
+        elif self._stage_location_type == AZURE_FS:
+            raise Exception("Azure not supported for SnowflakeFileTransferAgentAsync")
+        elif self._stage_location_type == S3_FS:
+            from .s3_storage_client_async import SnowflakeS3RestClientAsync
+
+            return SnowflakeS3RestClientAsync(
+                meta,
+                self._credentials,
+                self._stage_info,
+                _chunk_size_calculator(meta.src_file_size),
+                use_accelerate_endpoint=self._use_accelerate_endpoint,
+                use_s3_regional_url=self._use_s3_regional_url,
+            )
+        elif self._stage_location_type == GCS_FS:
+            raise Exception("GCS not supported for SnowflakeFileTransferAgentAsync")
+        raise Exception(f"{self._stage_location_type} is an unknown stage type")
 
     def close(self) -> None:
         self._loop_runner.stop()

--- a/src/snowflake/connector/file_transfer_agent_async.py
+++ b/src/snowflake/connector/file_transfer_agent_async.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from .file_transfer_agent import *
+from .network_async import EventLoopThreadRunner
+
+# YICHUAN: SnowflakeFileTransferAgentAsync is identical to SnowflakeFileTransferAgent, except for two differences; it
+# owns an EventLoopThreadRunner and uses instances of SnowflakeStorageClientAsync
+
+
+class SnowflakeFileTransferAgentAsync(SnowflakeFileTransferAgent):
+    def __init__(self, *args, **kwargs) -> None:
+        # YICHUAN: This EventLoopThreadRunner may never be used if there is one available in the SnowflakeRestfulAsync
+        # instance owned by SnowflakeConnector, but a thread running an event loop that does nothing is lightweight
+        # and saves us headaches if no SnowflakeConnector instance is associated to a transfer
+        self._loop_runner = EventLoopThreadRunner()
+        self._loop_runner.start()
+
+        super().__init__(*args, **kwargs)
+
+    def close(self) -> None:
+        self._loop_runner.stop()

--- a/src/snowflake/connector/network_async.py
+++ b/src/snowflake/connector/network_async.py
@@ -1,0 +1,465 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+
+from .network import *
+
+# YICHUAN: If we don't want to duplicate these raise  functions we can also modify them to directly take the error
+# status and reason instead of a response object (that way we can use the same for both sync and async)
+
+
+# For this commit I'm just adding separate functions for async so that I don't need to change too much code
+def raise_okta_unauthorized_error_async(
+    connection: SnowflakeConnection | None, response: aiohttp.ClientResponse
+) -> None:
+    Error.errorhandler_wrapper(
+        connection,
+        None,
+        DatabaseError,
+        {
+            "msg": f"Failed to get authentication by OKTA: {response.status}: {response.reason}",
+            "errno": ER_FAILED_TO_CONNECT_TO_DB,
+            "sqlstate": SQLSTATE_CONNECTION_REJECTED,
+        },
+    )
+
+
+def raise_failed_request_error_async(
+    connection: SnowflakeConnection | None,
+    url: str,
+    method: str,
+    response: aiohttp.ClientResponse,
+) -> None:
+    # YICHUAN: NO TELEMETRY FOR NOW
+
+    # TelemetryService.get_instance().log_http_request_error(
+    #     f"HttpError{response.status}",
+    #     url,
+    #     method,
+    #     SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+    #     ER_FAILED_TO_REQUEST,
+    #     response=response,
+    # )
+    Error.errorhandler_wrapper(
+        connection,
+        None,
+        InterfaceError,
+        {
+            "msg": f"{response.status} {response.reason}: {method} {url}",
+            "errno": ER_FAILED_TO_REQUEST,
+            "sqlstate": SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+        },
+    )
+
+
+# Yichuan: CURRENTLY UNUSED, see SnowflakeRestfulAsync._request_exec_async
+class SnowflakeAuthAsync(aiohttp.BasicAuth):
+    def __new__(cls, token: str) -> aiohttp.BasicAuth:
+        # for class compatibility with BasicAuth, these parameters are never used
+        return super().__new__(cls, "", "", "")
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def encode(self) -> str:
+        """aiohttp will use this to set the Authorization header"""
+        return HEADER_SNOWFLAKE_TOKEN.format(token=self.token)
+
+
+class SnowflakeRestfulAsync(SnowflakeRestful):
+    def __init__(self, **kwargs) -> None:
+        self._loop = asyncio.get_event_loop()
+
+        super().__init__(**kwargs)
+
+    def __del__(self) -> None:
+        self._loop.close()
+
+    def fetch(self, *args, **kwargs) -> dict[Any, Any]:
+        return self._loop.run_until_complete(self.fetch_async(*args, **kwargs))
+
+    async def fetch_async(
+        self,
+        method: str,
+        full_url: str,
+        headers: dict[str, Any],
+        data: dict[str, Any] | None = None,
+        timeout: int | None = None,
+        **kwargs,
+    ) -> dict[Any, Any]:
+        """Carry out API request with session management."""
+
+        class RetryCtx(TimeoutBackoffCtx):
+            def __init__(
+                self,
+                _include_retry_params: bool = False,
+                _include_retry_reason: bool = False,
+                **kwargs,
+            ) -> None:
+                super().__init__(**kwargs)
+                self.retry_reason = 0
+                self._include_retry_params = _include_retry_params
+                self._include_retry_reason = _include_retry_reason
+
+            def add_retry_params(self, full_url: str) -> str:
+                if self._include_retry_params and self.current_retry_count > 0:
+                    retry_params = {
+                        "clientStartTime": self._start_time_millis,
+                        "retryCount": self.current_retry_count,
+                    }
+                    if self._include_retry_reason:
+                        retry_params.update({"retryReason": self.retry_reason})
+                    suffix = urlencode(retry_params)
+                    sep = "&" if urlparse(full_url).query else "?"
+                    return full_url + sep + suffix
+                else:
+                    return full_url
+
+        include_retry_reason = self._connection._enable_retry_reason_in_query_response
+        include_retry_params = kwargs.pop("_include_retry_params", False)
+
+        async with self._use_requests_session_async(full_url) as session:
+            retry_ctx = RetryCtx(
+                _include_retry_params=include_retry_params,
+                _include_retry_reason=include_retry_reason,
+                timeout=timeout
+                if timeout is not None
+                else self._connection.network_timeout,
+                backoff_generator=self._connection._backoff_generator,
+            )
+
+            retry_ctx.set_start_time()
+            while True:
+                ret = await self._request_exec_wrapper_async(
+                    session, method, full_url, headers, data, retry_ctx, **kwargs
+                )
+                if ret is not None:
+                    return ret
+
+    async def _request_exec_wrapper_async(
+        self,
+        session,
+        method,
+        full_url,
+        headers,
+        data,
+        retry_ctx,
+        no_retry: bool = False,
+        token=NO_TOKEN,
+        **kwargs,
+    ):
+        conn = self._connection
+        logger.debug(
+            "remaining request timeout: %s ms, retry cnt: %s",
+            retry_ctx.remaining_time_millis if retry_ctx.timeout is not None else "N/A",
+            retry_ctx.current_retry_count + 1,
+        )
+
+        full_url = retry_ctx.add_retry_params(full_url)
+        full_url = SnowflakeRestful.add_request_guid(full_url)
+        try:
+            return_object = await self._request_exec_async(
+                session=session,
+                method=method,
+                full_url=full_url,
+                headers=headers,
+                data=data,
+                token=token,
+                **kwargs,
+            )
+            if return_object is not None:
+                return return_object
+            self._handle_unknown_error(method, full_url, headers, data, conn)
+            TelemetryService.get_instance().log_http_request_error(
+                "HttpRequestUnknownError",
+                full_url,
+                method,
+                SQLSTATE_IO_ERROR,
+                ER_FAILED_TO_REQUEST,
+                retry_timeout=retry_ctx.timeout,
+                retry_count=retry_ctx.current_retry_count,
+            )
+            return {}
+        except RetryRequest as e:
+            if (
+                retry_ctx.current_retry_count
+                == TelemetryService.get_instance().num_of_retry_to_trigger_telemetry
+            ):
+                TelemetryService.get_instance().log_http_request_error(
+                    "HttpRequestRetry%dTimes" % retry_ctx.current_retry_count,
+                    full_url,
+                    method,
+                    SQLSTATE_IO_ERROR,
+                    ER_FAILED_TO_REQUEST,
+                    retry_timeout=retry_ctx.timeout,
+                    retry_count=retry_ctx.current_retry_count,
+                    exception=str(e),
+                    stack_trace=traceback.format_exc(),
+                )
+            cause = e.args[0]
+            if no_retry:
+                self.log_and_handle_http_error_with_cause(
+                    e,
+                    full_url,
+                    method,
+                    retry_ctx.timeout,
+                    retry_ctx.current_retry_count,
+                    conn,
+                    timed_out=False,
+                )
+                return {}  # required for tests
+            if not retry_ctx.should_retry:
+                self.log_and_handle_http_error_with_cause(
+                    e,
+                    full_url,
+                    method,
+                    retry_ctx.timeout,
+                    retry_ctx.current_retry_count,
+                    conn,
+                )
+                return {}  # required for tests
+
+            logger.debug(
+                "retrying: errorclass=%s, "
+                "error=%s, "
+                "counter=%s, "
+                "sleeping=%s(s)",
+                type(cause),
+                cause,
+                retry_ctx.current_retry_count + 1,
+                retry_ctx.current_sleep_time,
+            )
+            # YICHUAN: Async might change how we want to  calculate timeouts; instead of {current time} - {start time}
+            # we should consider tracking the time spent sleeping, because a coroutine might spend excessive time
+            # waiting for control to be given back to it by the event loop
+            await asyncio.sleep(float(retry_ctx.current_sleep_time))
+            retry_ctx.increment()
+
+            reason = getattr(cause, "errno", 0)
+            retry_ctx.retry_reason = reason
+
+            # YICHUAN: aiohttp doesn't provide a convenient method like session.get_adapter to close an adapter if we
+            # receive "Connection aborted" or "ECONNRESET"; aiohttp tends to release the connection itself on success
+            # receiving EOF, or close the connection itself if something went wrong
+
+            # (If you want to see for yourself, look at aiohttp.ClientResponse._response_eof)
+
+            # This means that we can't access the connection used to close it without calling internal methods, which
+            # is dangerous if it was acquired concurrently before the control flow reaches here
+
+            # Not checking for "Connection aborted" or "ECONNRESET" shouldn't cause any problems as aiohttp rebuilds
+            # broken connections the next time it's used anyway, but we can subclass ClientSession to override _request
+            # if we really want to add the check, at the cost of a lot more code
+
+            return None  # retry
+        except Exception as e:
+            if not no_retry:
+                raise e
+            logger.debug("Ignored error", exc_info=True)
+            return {}
+
+    async def _request_exec_async(
+        self,
+        session,
+        method,
+        full_url,
+        headers,
+        data,
+        token,
+        catch_okta_unauthorized_error: bool = False,
+        is_raw_text: bool = False,
+        is_raw_binary: bool = False,
+        binary_data_handler=None,
+        socket_timeout: int | None = None,
+        is_okta_authentication: bool = False,
+    ):
+        if is_raw_binary or binary_data_handler is not None:
+            raise Exception(
+                "YICHUAN: Placeholder check, this should never happen in async code path"
+            )
+
+        if socket_timeout is None:
+            if self._connection.socket_timeout is not None:
+                logger.debug("socket_timeout specified in connection")
+                socket_timeout = self._connection.socket_timeout
+            else:
+                socket_timeout = DEFAULT_SOCKET_CONNECT_TIMEOUT
+        logger.debug("socket timeout: %s", socket_timeout)
+
+        try:
+            if not catch_okta_unauthorized_error and data and len(data) > 0:
+                headers["Content-Encoding"] = "gzip"
+                input_data = gzip.compress(data.encode("utf-8"))
+            else:
+                input_data = data
+
+            # YICHUAN: Adding auth headers here isn't ideal (though I've checked that they won't be overriden)
+
+            # If we want to pass an auth mechanism to request instead we can pass in auth=SnowflakeAuthAsync, but we
+            # have to do some hacky stuff with the class to make it play nice with aiohttp.BasicAuth
+            if HEADER_AUTHORIZATION_KEY in headers:
+                del headers[HEADER_AUTHORIZATION_KEY]
+            if token != NO_TOKEN:
+                headers[HEADER_AUTHORIZATION_KEY] = HEADER_SNOWFLAKE_TOKEN.format(
+                    token=token
+                )
+
+            # Yichuan: No need to track these as aiohttp doesn't have is_raw_binary
+
+            # download_start_time = get_time_millis()
+
+            resp = await session.request(
+                method=method,
+                url=full_url,
+                headers=headers,
+                data=input_data,
+                ssl=None,  # Yichuan: Default SSL check, replace later
+                auth=None,  # Yichuan: auth=None so auth headers aren't overriden
+            )
+
+            # download_end_time = get_time_millis()
+
+            try:
+                if resp.status == OK:
+                    logger.debug("SUCCESS")
+                    if is_raw_text:
+                        ret = await resp.text()
+                    else:
+                        ret = await resp.json()
+                    return ret
+
+                if is_login_request(full_url) and resp.status == FORBIDDEN:
+                    raise ForbiddenError
+
+                elif is_retryable_http_code(resp.status):
+                    err = get_http_retryable_error(resp.status_code)
+                    # retryable server exceptions
+                    if is_okta_authentication:
+                        raise RefreshTokenError(
+                            msg="OKTA authentication requires token refresh."
+                        )
+                    if is_login_request(full_url):
+                        logger.debug(
+                            "Received retryable response code while logging in. Will be handled by "
+                            f"authenticator. Ignore the following. Error stack: {err}",
+                            exc_info=True,
+                        )
+                        raise OperationalError(
+                            msg="Login request is retryable. Will be handled by authenticator",
+                            errno=ER_RETRYABLE_CODE,
+                        )
+                    else:
+                        logger.debug(f"{err}. Retrying...")
+                        raise RetryRequest(err)
+
+                elif resp.status == UNAUTHORIZED and catch_okta_unauthorized_error:
+                    # OKTA Unauthorized errors
+                    raise_okta_unauthorized_error_async(self._connection, resp)
+                    return None  # required for tests
+                else:
+                    raise_failed_request_error_async(
+                        self._connection, full_url, method, resp
+                    )
+                    return None  # required for tests
+            finally:
+                # YICHUAN: aiohttp releases the connection at the end of the request; we don't need to
+                # (I'll remove this redundant block when cleaning up the code later, this is here for clarity)
+                pass
+        except aiohttp.ClientSSLError as se:
+            logger.debug("Hit non-retryable SSL error, %s", str(se))
+            TelemetryService.get_instance().log_http_request_error(
+                "CertificateException%s" % str(se),
+                full_url,
+                method,
+                SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+                ER_FAILED_TO_REQUEST,
+                exception=se,
+                stack_trace=traceback.format_exc(),
+            )
+
+        # YICHUAN: The requests caught here are tentative, I have likely missed some and will add more in with as I
+        # test more types of requests
+        except (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientPayloadError,
+            aiohttp.ClientResponseError,
+            aiohttp.ServerTimeoutError,
+            IncompleteRead,
+            OpenSSL.SSL.SysCallError,
+            KeyError,  # SNOW-39175: asn1crypto.keys.PublicKeyInfo
+            ValueError,
+            RuntimeError,
+            AttributeError,  # json decoding error
+        ) as err:
+            if is_login_request(full_url):
+                logger.debug(
+                    "Hit a timeout error while logging in. Will be handled by "
+                    f"authenticator. Ignore the following. Error stack: {err}",
+                    exc_info=True,
+                )
+                raise OperationalError(
+                    msg="ConnectionTimeout occurred during login. Will be handled by authenticator",
+                    errno=ER_CONNECTION_TIMEOUT,
+                )
+            else:
+                logger.debug(
+                    "Hit retryable client error. Retrying... Ignore the following "
+                    f"error stack: {err}",
+                    exc_info=True,
+                )
+                raise RetryRequest(err)
+        except Exception as err:
+            TelemetryService.get_instance().log_http_request_error(
+                "HttpException%s" % str(err),
+                full_url,
+                method,
+                SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+                ER_FAILED_TO_REQUEST,
+                exception=err,
+                stack_trace=traceback.format_exc(),
+            )
+            raise err
+
+    # Yichuan: Override method, not _async because it's not an async method
+    def make_requests_session(self) -> aiohttp.ClientSession:
+        # Yichuan: auth=None so auth headers aren't overriden inside ClientSession requests
+        return aiohttp.ClientSession(auth=None, loop=self._loop)
+
+    # Yichuan: Literally copy & pasted but unfortunately needed because this method needs to be async
+
+    # Q for later: Why do we need to pool sessions when sessions already pool connections for different hosts?
+    @contextlib.asynccontextmanager
+    async def _use_requests_session_async(self, url: str | None = None):
+        """Session caching context manager."""
+
+        # short-lived session, not added to the _sessions_map
+        if self._connection.disable_request_pooling:
+            session = self.make_requests_session()
+            try:
+                yield session
+            finally:
+                await session.close()
+        else:
+            try:
+                hostname = urlparse(url).hostname
+            except Exception:
+                hostname = None
+
+            # Yichuan: SessionPool works as-is for aiohttp ClientSession, but type hinting in it is not entirely clear,
+            # so I will find a way to clean up the code later
+            session_pool: SessionPool = self._sessions_map[hostname]
+            session = session_pool.get_session()
+            logger.debug(f"Session status for SessionPool '{hostname}', {session_pool}")
+            try:
+                yield session
+            finally:
+                session_pool.return_session(session)
+                logger.debug(
+                    f"Session status for SessionPool '{hostname}', {session_pool}"
+                )

--- a/src/snowflake/connector/network_async.py
+++ b/src/snowflake/connector/network_async.py
@@ -319,8 +319,11 @@ class SnowflakeRestfulAsync(SnowflakeRestful):
                 url=full_url,
                 headers=headers,
                 data=input_data,
+                proxy=None,
+                # Yichuan: Should be fine specifying this unconditionally as proxy_headers will be ignored if no proxy
+                # is specified in env variables (REQUIRES TESTING)
+                proxy_headers={"Host": parse_url(full_url).hostname},
                 ssl=None,  # Yichuan: Default SSL check, replace later
-                auth=None,  # Yichuan: auth=None so auth headers aren't overriden
             )
 
             # download_end_time = get_time_millis()
@@ -428,8 +431,11 @@ class SnowflakeRestfulAsync(SnowflakeRestful):
 
     # Yichuan: Override method, not _async because it's not an async method
     def make_requests_session(self) -> aiohttp.ClientSession:
-        # Yichuan: auth=None so auth headers aren't overriden inside ClientSession requests
-        return aiohttp.ClientSession(auth=None, loop=self._loop)
+        return aiohttp.ClientSession(
+            auth=None,  # Yichuan: auth=None so auth headers aren't overriden inside ClientSession requests
+            trust_env=True,  # Yichuan: So aiohttp will read the proxy variables set in proxy.set_proxies
+            loop=self._loop,
+        )
 
     # Yichuan: Literally copy & pasted but unfortunately needed because this method needs to be async
 

--- a/src/snowflake/connector/s3_storage_client_async.py
+++ b/src/snowflake/connector/s3_storage_client_async.py
@@ -1,0 +1,364 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import asyncio
+
+import aiohttp
+
+from .s3_storage_client import *
+from .storage_client_async import *
+
+
+# YICHUAN: Prioritize methods inherited SnowflakeStorageClientAsync because it will only override what it needs to
+# For the most part, this class overrides private methods with "_async" suffix that will be called by public methods
+# in SnowflakeStorageClientAsync
+class SnowflakeS3RestClientAsync(SnowflakeStorageClientAsync, SnowflakeS3RestClient):
+    def transfer_accelerate_config(
+        self, use_accelerate_endpoint: bool | None = None
+    ) -> bool:
+        # if self.endpoint has been set, e.g. by metadata, no more config is needed.
+        if self.endpoint is not None:
+            return self.endpoint.find("s3-accelerate.amazonaws.com") >= 0
+        if self.use_s3_regional_url:
+            self.endpoint = (
+                f"https://{self.s3location.bucket_name}."
+                f"s3.{self.region_name}.amazonaws.com"
+            )
+            return False
+        else:
+            if use_accelerate_endpoint is None:
+                use_accelerate_endpoint = self._loop_runner.run_coro(
+                    self._get_bucket_accelerate_config_async(
+                        self.s3location.bucket_name
+                    )
+                )
+
+            if use_accelerate_endpoint:
+                self.endpoint = (
+                    f"https://{self.s3location.bucket_name}.s3-accelerate.amazonaws.com"
+                )
+            else:
+                self.endpoint = (
+                    f"https://{self.s3location.bucket_name}.s3.amazonaws.com"
+                )
+            return use_accelerate_endpoint
+
+    async def _has_expired_token_async(self, response: aiohttp.ClientResponse) -> bool:
+        """Extract error code and error message from the S3's error response.
+
+        Expected format:
+        https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses
+
+        Args:
+            response: Rest error response in XML format
+
+        Returns: True if the error response is caused by token expiration
+
+        """
+        if response.status != 400:
+            return False
+        message = await response.text()
+        if not message or message.isspace():
+            return False
+        err = ET.fromstring(message)
+        return err.find("Code").text == EXPIRED_TOKEN
+
+    async def _send_request_with_authentication_and_retry_async(
+        self,
+        url: str,
+        verb: str,
+        retry_id: int | str,
+        query_parts: dict[str, str] | None = None,
+        x_amz_headers: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        payload: bytes | bytearray | IOBase | None = None,
+        unsigned_payload: bool = False,
+        ignore_content_encoding: bool = False,
+    ) -> aiohttp.ClientResponse:
+        if x_amz_headers is None:
+            x_amz_headers = {}
+        if headers is None:
+            headers = {}
+        if payload is None:
+            payload = b""
+        if query_parts is None:
+            query_parts = {}
+        parsed_url = urlparse(url)
+        x_amz_headers["x-amz-security-token"] = self.credentials.creds.get(
+            "AWS_TOKEN", ""
+        )
+        x_amz_headers["host"] = parsed_url.hostname
+        if unsigned_payload:
+            x_amz_headers["x-amz-content-sha256"] = UNSIGNED_PAYLOAD
+        else:
+            x_amz_headers["x-amz-content-sha256"] = (
+                SnowflakeS3RestClient._hash_bytes_hex(payload).lower().decode()
+            )
+
+        def generate_authenticated_url_and_args_v4() -> tuple[bytes, dict[str, bytes]]:
+            t = datetime.utcnow()
+            amzdate = t.strftime("%Y%m%dT%H%M%SZ")
+            short_amzdate = amzdate[:8]
+            x_amz_headers["x-amz-date"] = amzdate
+
+            (
+                canonical_request,
+                signed_headers,
+            ) = self._construct_canonical_request_and_signed_headers(
+                verb=verb,
+                canonical_uri_parameter=parsed_url.path
+                + (f";{parsed_url.params}" if parsed_url.params else ""),
+                query_parts=query_parts,
+                canonical_headers=x_amz_headers,
+                payload_hash=x_amz_headers["x-amz-content-sha256"],
+            )
+            string_to_sign, scope = self._construct_string_to_sign(
+                self.region_name,
+                "s3",
+                amzdate,
+                short_amzdate,
+                self._hash_bytes_hex(canonical_request.encode("utf-8")).lower(),
+            )
+            kDate = self._sign_bytes(
+                ("AWS4" + self.credentials.creds["AWS_SECRET_KEY"]).encode("utf-8"),
+                short_amzdate,
+            )
+            kRegion = self._sign_bytes(kDate, self.region_name)
+            kService = self._sign_bytes(kRegion, "s3")
+            signing_key = self._sign_bytes(kService, "aws4_request")
+
+            signature = self._sign_bytes_hex(signing_key, string_to_sign).lower()
+            authorization_header = (
+                "AWS4-HMAC-SHA256 "
+                + f"Credential={self.credentials.creds['AWS_KEY_ID']}/{scope}, "
+                + f"SignedHeaders={signed_headers}, "
+                + f"Signature={signature.decode('utf-8')}"
+            )
+            headers.update(x_amz_headers)
+            headers["Authorization"] = authorization_header
+            rest_args = {"headers": headers}
+
+            if payload:
+                rest_args["data"] = payload
+
+            # FORMERLY:
+            # add customized hook: to remove content-encoding from response.
+
+            # YICHUAN: aiohttp doesn't provide hooks the same way requests does, but we removed the Content-Encoding
+            # header was to prevent server data from being decompressed, and we can achieve the same effect here
+            if ignore_content_encoding:
+                # rest_args["hooks"] = {"response": remove_content_encoding}
+                rest_args["auto_decompress"] = False
+
+            # YICHUAN: Don't encode url, aiohttp does not play nice with byte strings
+            return url, rest_args
+
+        return await self._send_request_with_retry_async(
+            verb, generate_authenticated_url_and_args_v4, retry_id
+        )
+
+    async def get_file_header_async(self, filename: str) -> FileHeader | None:
+        """Gets the metadata of file in specified location.
+
+        Args:
+            filename: Name of remote file.
+
+        Returns:
+            None if HEAD returns 404, otherwise a FileHeader instance populated
+            with metadata
+        """
+        path = quote(self.s3location.path + filename.lstrip("/"))
+        url = self.endpoint + f"/{path}"
+
+        retry_id = "HEAD"
+        self.retry_count[retry_id] = 0
+        response = await self._send_request_with_authentication_and_retry_async(
+            url=url, verb="HEAD", retry_id=retry_id
+        )
+        if response.status == 200:
+            self.meta.result_status = ResultStatus.UPLOADED
+            metadata = response.headers
+            encryption_metadata = (
+                EncryptionMetadata(
+                    key=metadata.get(META_PREFIX + AMZ_KEY),
+                    iv=metadata.get(META_PREFIX + AMZ_IV),
+                    matdesc=metadata.get(META_PREFIX + AMZ_MATDESC),
+                )
+                if metadata.get(META_PREFIX + AMZ_KEY)
+                else None
+            )
+            return FileHeader(
+                digest=metadata.get(META_PREFIX + SFC_DIGEST),
+                content_length=int(metadata.get("Content-Length")),
+                encryption_metadata=encryption_metadata,
+            )
+        elif response.status == 404:
+            logger.debug(
+                f"not found. bucket: {self.s3location.bucket_name}, path: {path}"
+            )
+            self.meta.result_status = ResultStatus.NOT_FOUND_FILE
+            return None
+        else:
+            response.raise_for_status()
+
+    async def _initiate_multipart_upload_async(self) -> None:
+        query_parts = (("uploads", ""),)
+        path = quote(self.s3location.path + self.meta.dst_file_name.lstrip("/"))
+        query_string = self._construct_query_string(query_parts)
+        url = self.endpoint + f"/{path}?{query_string}"
+        s3_metadata = self._prepare_file_metadata()
+        # initiate multipart upload
+        retry_id = "Initiate"
+        self.retry_count[retry_id] = 0
+        response = await self._send_request_with_authentication_and_retry_async(
+            url=url,
+            verb="POST",
+            retry_id=retry_id,
+            x_amz_headers=s3_metadata,
+            headers={HTTP_HEADER_CONTENT_TYPE: HTTP_HEADER_VALUE_OCTET_STREAM},
+            query_parts=dict(query_parts),
+        )
+        if response.status == 200:
+            self.upload_id = ET.fromstring(await response.text())[2].text
+            self.etags = [None] * self.num_of_chunks
+        else:
+            response.raise_for_status()
+
+    async def _upload_chunk_async(self, chunk_id: int, chunk: bytes) -> None:
+        path = quote(self.s3location.path + self.meta.dst_file_name.lstrip("/"))
+        url = self.endpoint + f"/{path}"
+
+        if self.num_of_chunks == 1:  # single request
+            s3_metadata = self._prepare_file_metadata()
+            response = await self._send_request_with_authentication_and_retry_async(
+                url=url,
+                verb="PUT",
+                retry_id=chunk_id,
+                payload=chunk,
+                x_amz_headers=s3_metadata,
+                headers={HTTP_HEADER_CONTENT_TYPE: HTTP_HEADER_VALUE_OCTET_STREAM},
+                unsigned_payload=True,
+            )
+            response.raise_for_status()
+        else:
+            # multipart PUT
+            query_parts = (
+                ("partNumber", str(chunk_id + 1)),
+                ("uploadId", self.upload_id),
+            )
+            query_string = self._construct_query_string(query_parts)
+            chunk_url = f"{url}?{query_string}"
+            response = await self._send_request_with_authentication_and_retry_async(
+                url=chunk_url,
+                verb="PUT",
+                retry_id=chunk_id,
+                payload=chunk,
+                unsigned_payload=True,
+                query_parts=dict(query_parts),
+            )
+            if response.status == 200:
+                self.etags[chunk_id] = response.headers["ETag"]
+            response.raise_for_status()
+
+    async def _complete_multipart_upload_async(self) -> None:
+        query_parts = (("uploadId", self.upload_id),)
+        path = quote(self.s3location.path + self.meta.dst_file_name.lstrip("/"))
+        query_string = self._construct_query_string(query_parts)
+        url = self.endpoint + f"/{path}?{query_string}"
+        logger.debug("Initiating multipart upload complete")
+        # Complete multipart upload
+        root = ET.Element("CompleteMultipartUpload")
+        for idx, etag_str in enumerate(self.etags):
+            part = ET.Element("Part")
+            etag = ET.Element("ETag")
+            etag.text = etag_str
+            part.append(etag)
+            part_number = ET.Element("PartNumber")
+            part_number.text = str(idx + 1)
+            part.append(part_number)
+            root.append(part)
+        retry_id = "Complete"
+        self.retry_count[retry_id] = 0
+        response = await self._send_request_with_authentication_and_retry_async(
+            url=url,
+            verb="POST",
+            retry_id=retry_id,
+            payload=ET.tostring(root),
+            query_parts=dict(query_parts),
+        )
+        response.raise_for_status()
+
+    async def _abort_multipart_upload_async(self) -> None:
+        if self.upload_id is None:
+            return
+        query_parts = (("uploadId", self.upload_id),)
+        path = quote(self.s3location.path + self.meta.dst_file_name.lstrip("/"))
+        query_string = self._construct_query_string(query_parts)
+        url = self.endpoint + f"/{path}?{query_string}"
+
+        retry_id = "Abort"
+        self.retry_count[retry_id] = 0
+        response = await self._send_request_with_authentication_and_retry_async(
+            url=url,
+            verb="DELETE",
+            retry_id=retry_id,
+            query_parts=dict(query_parts),
+        )
+        response.raise_for_status()
+
+    # YICHUAN: aiohttp version of S3RestClient.download_chunk, invoked by SnowflakeStorageClientAsync.download_chunk
+    async def _download_chunk_async(self, chunk_id: int) -> None:
+        logger.debug(f"Downloading chunk {chunk_id}")
+        path = quote(self.s3location.path + self.meta.src_file_name.lstrip("/"))
+        url = self.endpoint + f"/{path}"
+        if self.num_of_chunks == 1:
+            response = await self._send_request_with_authentication_and_retry_async(
+                url=url,
+                verb="GET",
+                retry_id=chunk_id,
+                ignore_content_encoding=True,
+            )
+            if response.status == 200:
+                self.write_downloaded_chunk(0, await response.read())
+                self.meta.result_status = ResultStatus.DOWNLOADED
+            response.raise_for_status()
+        else:
+            chunk_size = self.chunk_size
+            if chunk_id < self.num_of_chunks - 1:
+                _range = f"{chunk_id * chunk_size}-{(chunk_id+1)*chunk_size-1}"
+            else:
+                _range = f"{chunk_id * chunk_size}-"
+
+            response = await self._send_request_with_authentication_and_retry_async(
+                url=url,
+                verb="GET",
+                retry_id=chunk_id,
+                headers={"Range": f"bytes={_range}"},
+            )
+            if response.status in (200, 206):
+                self.write_downloaded_chunk(chunk_id, await response.read())
+            response.raise_for_status()
+
+    async def _get_bucket_accelerate_config_async(self, bucket_name: str) -> bool:
+        query_parts = (("accelerate", ""),)
+        query_string = self._construct_query_string(query_parts)
+        url = f"https://{bucket_name}.s3.amazonaws.com/?{query_string}"
+        retry_id = "accelerate"
+        self.retry_count[retry_id] = 0
+        response = await self._send_request_with_authentication_and_retry_async(
+            url=url, verb="GET", retry_id=retry_id, query_parts=dict(query_parts)
+        )
+        if response.status == 200:
+            config = ET.fromstring(await response.text())
+            namespace = config.tag[: config.tag.index("}") + 1]
+            statusTag = f"{namespace}Status"
+            found = config.find(statusTag)
+            use_accelerate_endpoint = (
+                False if found is None else (found.text == "Enabled")
+            )
+            logger.debug(f"use_accelerate_endpoint: {use_accelerate_endpoint}")
+            return use_accelerate_endpoint
+        return False

--- a/src/snowflake/connector/storage_client_async.py
+++ b/src/snowflake/connector/storage_client_async.py
@@ -1,0 +1,302 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+
+import aiohttp
+
+from .network_async import EventLoopThreadRunner
+from .storage_client import *
+
+# YICHUAN: Not much to explain in this file, we add async versions of existing private methods and override public
+# methods to call async private methods instead
+# We explicitly add new private methods with suffix "_async" for clarity instead of overriding
+
+
+class SnowflakeStorageClientAsync(SnowflakeStorageClient):
+    TRANSIENT_ERRORS_ASYNC = (
+        ssl.SSLSyscallError,
+        asyncio.TimeoutError,
+        aiohttp.ClientConnectionError,
+    )
+
+    @property
+    def _loop_runner(self) -> EventLoopThreadRunner:
+        if self.meta.sfagent and self.meta.sfagent._cursor.connection:
+            return self.meta.sfagent._cursor.connection._rest._loop_runner
+        else:
+            return self._loop_runner
+
+    @abstractmethod
+    async def get_file_header_async(self, filename: str) -> FileHeader | None:
+        pass
+
+    def preprocess(self) -> None:
+        meta = self.meta
+        logger.debug(f"Preprocessing {meta.src_file_name}")
+
+        # check if file exists on remote
+        file_header = self._loop_runner.run_coro(
+            self.get_file_header_async(meta.dst_file_name)
+        )
+        if not meta.overwrite:
+            self.get_digest()  # self.get_file_header needs digest for multiparts upload when aws is used.
+            if meta.result_status == ResultStatus.UPLOADED:
+                # Skipped
+                logger.debug(
+                    f'file already exists location="{self.stage_info["location"]}", '
+                    f'file_name="{meta.dst_file_name}"'
+                )
+                meta.dst_file_size = 0
+                meta.result_status = ResultStatus.SKIPPED
+                self.preprocessed = True
+                return
+        # Uploading
+        if meta.require_compress:
+            self.compress()
+        self.get_digest()
+
+        if (
+            meta.skip_upload_on_content_match
+            and file_header
+            and meta.sha256_digest == file_header.digest
+        ):
+            logger.debug(f"same file contents for {meta.name}, skipping upload")
+            meta.result_status = ResultStatus.SKIPPED
+
+        self.preprocessed = True
+
+    def prepare_upload(self) -> None:
+        meta = self.meta
+
+        if not self.preprocessed:
+            self.preprocess()
+        elif meta.encryption_material:
+            # need to clean up previous encrypted file
+            os.remove(self.data_file)
+
+        logger.debug(f"Preparing to upload {meta.src_file_name}")
+
+        if meta.encryption_material:
+            self.encrypt()
+        else:
+            self.data_file = meta.real_src_file_name
+        logger.debug("finished preprocessing")
+        meta.multipart_threshold = 0
+        if meta.upload_size < meta.multipart_threshold or not self.chunked_transfer:
+            self.num_of_chunks = 1
+        else:
+            self.num_of_chunks = ceil(meta.upload_size / self.chunk_size)
+        logger.debug(f"number of chunks {self.num_of_chunks}")
+        # clean up
+        self.retry_count = {}
+
+        for chunk_id in range(self.num_of_chunks):
+            self.retry_count[chunk_id] = 0
+        if self.chunked_transfer and self.num_of_chunks > 1:
+            self._loop_runner.run_coro(self._initiate_multipart_upload_async())
+
+    @abstractmethod
+    async def _has_expired_token_async(self, response: aiohttp.ClientResponse) -> bool:
+        pass
+
+    async def _send_request_with_retry_async(
+        self,
+        verb: str,
+        get_request_args: Callable[[], tuple[bytes, dict[str, Any]]],
+        retry_id: int,
+    ) -> aiohttp.ClientResponse:
+        url = ""  # YICHUAN: Not sure why this is a bytes string in original version, but aiohttp doesn't like bytes
+        conn = None
+        if self.meta.sfagent and self.meta.sfagent._cursor.connection:
+            conn = self.meta.sfagent._cursor.connection
+
+        while self.retry_count[retry_id] < self.max_retry:
+            cur_timestamp = self.credentials.timestamp
+            url, rest_kwargs = get_request_args()
+            try:
+                if conn:
+                    logger.debug("storage client request with session from connection")
+                    session_manager = conn._rest._use_requests_session_async(url)
+                else:
+                    logger.debug("storage client request with new created session")
+                    session_manager = aiohttp.ClientSession(
+                        auth=None,  # Yichuan: auth=None so auth headers aren't overriden inside ClientSession requests
+                        trust_env=True,  # Yichuan: So aiohttp will read the proxy variables set in proxy.set_proxies
+                        loop=self._loop,
+                    )
+
+                # YICHUAN: Self explanatory, of course get_request_args needs to be modified for aiohttp as well
+                async with session_manager as session:
+                    response = await session.request(verb, url, **rest_kwargs)
+
+                if await self._has_expired_presigned_url_async(response):
+                    self._update_presigned_url()
+                else:
+                    self.last_err_is_presigned_url = False
+                    if response.status in self.TRANSIENT_HTTP_ERR:
+                        time.sleep(
+                            min(
+                                # TODO should SLEEP_UNIT come from the parent
+                                #  SnowflakeConnection and be customizable by users?
+                                (2 ** self.retry_count[retry_id]) * self.SLEEP_UNIT,
+                                self.SLEEP_MAX,
+                            )
+                        )
+                        self.retry_count[retry_id] += 1
+                    elif await self._has_expired_token_async(response):
+                        self.credentials.update(cur_timestamp)
+                    else:
+                        return response
+            except self.TRANSIENT_ERRORS_ASYNC as e:
+                self.last_err_is_presigned_url = False
+                time.sleep(
+                    min(
+                        (2 ** self.retry_count[retry_id]) * self.SLEEP_UNIT,
+                        self.SLEEP_MAX,
+                    )
+                )
+                logger.warning(f"{verb} with url {url} failed for transient error: {e}")
+                self.retry_count[retry_id] += 1
+        else:
+            raise RequestExceedMaxRetryError(
+                f"{verb} with url {url} failed for exceeding maximum retries."
+            )
+
+    def prepare_download(self) -> None:
+        # TODO: add nicer error message for when target directory is not writeable
+        #  but this should be done before we get here
+        base_dir = os.path.dirname(self.full_dst_file_name)
+        if not os.path.exists(base_dir):
+            os.makedirs(base_dir)
+
+        # HEAD
+        file_header = self._loop_runner.run_coro(
+            self.get_file_header_async(self.meta.real_src_file_name)
+        )
+
+        if file_header and file_header.encryption_metadata:
+            self.encryption_metadata = file_header.encryption_metadata
+
+        self.num_of_chunks = 1
+        if file_header and file_header.content_length:
+            self.meta.src_file_size = file_header.content_length
+            if (
+                self.chunked_transfer
+                and self.meta.src_file_size > self.meta.multipart_threshold
+            ):
+                self.num_of_chunks = ceil(file_header.content_length / self.chunk_size)
+
+        # Preallocate encrypted file.
+        with self.intermediate_dst_path.open("wb+") as fd:
+            fd.truncate(self.meta.src_file_size)
+
+    def finish_upload(self) -> None:
+        meta = self.meta
+        if self.successful_transfers == self.num_of_chunks:
+            if self.num_of_chunks > 1:
+                self._loop_runner.run_coro(self._complete_multipart_upload_async())
+            meta.result_status = ResultStatus.UPLOADED
+            meta.dst_file_size = meta.upload_size
+            logger.debug(f"{meta.src_file_name} upload is completed.")
+        else:
+            # TODO: add more error details to result/meta
+            meta.dst_file_size = 0
+            logger.debug(f"{meta.src_file_name} upload is aborted.")
+            if self.num_of_chunks > 1:
+                self._loop_runner.run_coro(self._abort_multipart_upload_async())
+            meta.result_status = ResultStatus.ERROR
+
+    def finish_download(self) -> None:
+        meta = self.meta
+        if self.num_of_chunks != 0 and self.successful_transfers == self.num_of_chunks:
+            meta.result_status = ResultStatus.DOWNLOADED
+            if meta.encryption_material:
+                logger.debug(f"encrypted data file={self.full_dst_file_name}")
+                # For storage utils that do not have the privilege of
+                # getting the metadata early, both object and metadata
+                # are downloaded at once. In which case, the file meta will
+                # be updated with all the metadata that we need and
+                # then we can call get_file_header to get just that and also
+                # preserve the idea of getting metadata in the first place.
+                # One example of this is the utils that use presigned url
+                # for upload/download and not the storage client library.
+                if meta.presigned_url is not None:
+                    file_header = self._loop_runner.run_coro(
+                        self.get_file_header_async(meta.src_file_name)
+                    )
+                    self.encryption_metadata = file_header.encryption_metadata
+
+                tmp_dst_file_name = SnowflakeEncryptionUtil.decrypt_file(
+                    self.encryption_metadata,
+                    meta.encryption_material,
+                    str(self.intermediate_dst_path),
+                    tmp_dir=self.tmp_dir,
+                )
+                shutil.move(tmp_dst_file_name, self.full_dst_file_name)
+                self.intermediate_dst_path.unlink()
+            else:
+                logger.debug(f"not encrypted data file={self.full_dst_file_name}")
+                shutil.move(str(self.intermediate_dst_path), self.full_dst_file_name)
+            stat_info = os.stat(self.full_dst_file_name)
+            meta.dst_file_size = stat_info.st_size
+        else:
+            # TODO: add more error details to result/meta
+            if os.path.isfile(self.full_dst_file_name):
+                os.unlink(self.full_dst_file_name)
+            logger.exception(f"Failed to download a file: {self.full_dst_file_name}")
+            meta.dst_file_size = -1
+            meta.result_status = ResultStatus.ERROR
+
+    def upload_chunk(self, chunk_id: int) -> None:
+        new_stream = not bool(self.meta.src_stream or self.meta.intermediate_stream)
+        fd = (
+            self.meta.src_stream
+            or self.meta.intermediate_stream
+            or open(self.data_file, "rb")
+        )
+        try:
+            if self.num_of_chunks == 1:
+                _data = fd.read()
+            else:
+                fd.seek(chunk_id * self.chunk_size)
+                _data = fd.read(self.chunk_size)
+        finally:
+            if new_stream:
+                fd.close()
+        logger.debug(f"Uploading chunk {chunk_id} of file {self.data_file}")
+        self._loop_runner.run_coro(self._upload_chunk_async(chunk_id, _data))
+        logger.debug(f"Successfully uploaded chunk {chunk_id} of file {self.data_file}")
+
+    @abstractmethod
+    async def _upload_chunk_async(self, chunk_id: int, chunk: bytes) -> None:
+        pass
+
+    def download_chunk(self, chunk_id: int) -> None:
+        self._loop_runner.run_coro(self._download_chunk_async(chunk_id))
+
+    @abstractmethod
+    async def _download_chunk_async(self, chunk_id: int) -> None:
+        pass
+
+    # Override in GCS
+    async def _has_expired_presigned_url_async(
+        self, response: requests.Response
+    ) -> bool:
+        return False
+
+    # Override in S3
+    async def _initiate_multipart_upload_async(self) -> None:
+        return
+
+    # Override in S3
+    async def _complete_multipart_upload_async(self) -> None:
+        return
+
+    # Override in S3
+    async def _abort_multipart_upload_async(self) -> None:
+        return

--- a/test/unit_async/__init__.py
+++ b/test/unit_async/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#

--- a/test/unit_async/conftest.py
+++ b/test/unit_async/conftest.py
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from snowflake.connector.telemetry_oob import TelemetryService
+
+
+@pytest.fixture(autouse=True, scope="session")
+def disable_oob_telemetry():
+    oob_telemetry_service = TelemetryService.get_instance()
+    original_state = oob_telemetry_service.enabled
+    oob_telemetry_service.disable()
+    yield None
+    if original_state:
+        oob_telemetry_service.enable()

--- a/test/unit_async/mock_utils.py
+++ b/test/unit_async/mock_utils.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import time
+from unittest.mock import MagicMock
+
+import aiohttp
+
+try:
+    from snowflake.connector.auth.by_plugin import DEFAULT_AUTH_CLASS_TIMEOUT
+except ImportError:
+    DEFAULT_AUTH_CLASS_TIMEOUT = 120
+
+
+def zero_backoff():
+    while True:
+        yield 0
+
+
+try:
+    from snowflake.connector.connection import DEFAULT_BACKOFF_POLICY
+except ImportError:
+    DEFAULT_BACKOFF_POLICY = zero_backoff
+
+
+def mock_connection(
+    login_timeout=DEFAULT_AUTH_CLASS_TIMEOUT,
+    network_timeout=None,
+    socket_timeout=None,
+    backoff_policy=DEFAULT_BACKOFF_POLICY,
+):
+    return MagicMock(
+        _login_timeout=login_timeout,
+        login_timeout=login_timeout,
+        _network_timeout=network_timeout,
+        network_timeout=network_timeout,
+        _socket_timeout=socket_timeout,
+        socket_timeout=socket_timeout,
+        _backoff_policy=backoff_policy,
+        backoff_policy=backoff_policy,
+    )
+
+
+def mock_request_with_action(next_action, sleep=None):
+    async def mock_request(*args, **kwargs):
+        if sleep is not None:
+            time.sleep(sleep)
+        if next_action == "RETRY":
+            return MagicMock(
+                status=503,
+                close=lambda: None,
+            )
+        elif next_action == "ERROR":
+            raise aiohttp.ServerTimeoutError()
+
+    return mock_request

--- a/test/unit_async/test_auth.py
+++ b/test/unit_async/test_auth.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import inspect
+import time
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+import snowflake.connector.errors
+from snowflake.connector.constants import OCSPMode
+from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
+from snowflake.connector.network import SnowflakeRestful
+
+from .mock_utils import mock_connection
+
+try:  # pragma: no cover
+    from snowflake.connector.auth import Auth, AuthByDefault, AuthByPlugin
+except ImportError:
+    from snowflake.connector.auth import Auth
+    from snowflake.connector.auth_by_plugin import AuthByPlugin
+    from snowflake.connector.auth_default import AuthByDefault
+
+
+def _init_rest(application, post_requset):
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+    connection._ocsp_mode = Mock(return_value=OCSPMode.FAIL_OPEN)
+    type(connection).application = PropertyMock(return_value=application)
+    type(connection)._internal_application_name = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_version = PropertyMock(
+        return_value=CLIENT_VERSION
+    )
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+    rest._post_request = post_requset
+    return rest
+
+
+def _create_mock_auth_mfs_rest_response(next_action: str):
+    def _mock_auth_mfa_rest_response(url, headers, body, **kwargs):
+        """Tests successful case."""
+        global mock_cnt
+        _ = url
+        _ = headers
+        _ = body
+        _ = kwargs.get("dummy")
+        if mock_cnt == 0:
+            ret = {
+                "success": True,
+                "message": None,
+                "data": {
+                    "nextAction": next_action,
+                    "inFlightCtx": "inFlightCtx",
+                },
+            }
+        elif mock_cnt == 1:
+            ret = {
+                "success": True,
+                "message": None,
+                "data": {
+                    "token": "TOKEN",
+                    "masterToken": "MASTER_TOKEN",
+                },
+            }
+
+        mock_cnt += 1
+        return ret
+
+    return _mock_auth_mfa_rest_response
+
+
+def _mock_auth_mfa_rest_response_failure(url, headers, body, **kwargs):
+    """Tests failed case."""
+    global mock_cnt
+    _ = url
+    _ = headers
+    _ = body
+    _ = kwargs.get("dummy")
+
+    if mock_cnt == 0:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": {
+                "nextAction": "EXT_AUTHN_DUO_ALL",
+                "inFlightCtx": "inFlightCtx",
+            },
+        }
+    elif mock_cnt == 1:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": {
+                "nextAction": "BAD",
+                "inFlightCtx": "inFlightCtx",
+            },
+        }
+    elif mock_cnt == 2:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": None,
+        }
+    mock_cnt += 1
+    return ret
+
+
+def _mock_auth_mfa_rest_response_timeout(url, headers, body, **kwargs):
+    """Tests timeout case."""
+    global mock_cnt
+    _ = url
+    _ = headers
+    _ = body
+    _ = kwargs.get("dummy")
+    if mock_cnt == 0:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": {
+                "nextAction": "EXT_AUTHN_DUO_ALL",
+                "inFlightCtx": "inFlightCtx",
+            },
+        }
+    elif mock_cnt == 1:
+        time.sleep(10)  # should timeout while here
+        ret = {}
+    elif mock_cnt == 2:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": None,
+        }
+
+    mock_cnt += 1
+    return ret
+
+
+@pytest.mark.parametrize(
+    "next_action", ("EXT_AUTHN_DUO_ALL", "EXT_AUTHN_DUO_PUSH_N_PASSCODE")
+)
+def test_auth_mfa(next_action: str):
+    """Authentication by MFA."""
+    global mock_cnt
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    password = "testpassword"
+
+    # success test case
+    mock_cnt = 0
+    rest = _init_rest(application, _create_mock_auth_mfs_rest_response(next_action))
+    auth = Auth(rest)
+    auth_instance = AuthByDefault(password)
+    auth.authenticate(auth_instance, account, user)
+    assert not rest._connection.errorhandler.called  # not error
+    assert rest.token == "TOKEN"
+    assert rest.master_token == "MASTER_TOKEN"
+
+    # failure test case
+    mock_cnt = 0
+    rest = _init_rest(application, _mock_auth_mfa_rest_response_failure)
+    auth = Auth(rest)
+    auth_instance = AuthByDefault(password)
+    auth.authenticate(auth_instance, account, user)
+    assert rest._connection.errorhandler.called  # error
+
+    # timeout 1 second
+    mock_cnt = 0
+    rest = _init_rest(application, _mock_auth_mfa_rest_response_timeout)
+    auth = Auth(rest)
+    auth_instance = AuthByDefault(password)
+    auth.authenticate(auth_instance, account, user, timeout=1)
+    assert rest._connection.errorhandler.called  # error
+
+    # ret["data"] is none
+    with pytest.raises(snowflake.connector.errors.Error):
+        mock_cnt = 2
+        rest = _init_rest(application, _mock_auth_mfa_rest_response_timeout)
+        auth = Auth(rest)
+        auth_instance = AuthByDefault(password)
+        auth.authenticate(auth_instance, account, user)
+
+
+def _mock_auth_password_change_rest_response(url, headers, body, **kwargs):
+    """Test successful case."""
+    global mock_cnt
+    _ = url
+    _ = headers
+    _ = body
+    _ = kwargs.get("dummy")
+    if mock_cnt == 0:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": {
+                "nextAction": "PWD_CHANGE",
+                "inFlightCtx": "inFlightCtx",
+            },
+        }
+    elif mock_cnt == 1:
+        ret = {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+            },
+        }
+
+    mock_cnt += 1
+    return ret
+
+
+def test_auth_password_change():
+    """Tests password change."""
+    global mock_cnt
+
+    def _password_callback():
+        return "NEW_PASSWORD"
+
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    password = "testpassword"
+
+    # success test case
+    mock_cnt = 0
+    rest = _init_rest(application, _mock_auth_password_change_rest_response)
+    auth = Auth(rest)
+    auth_instance = AuthByDefault(password)
+    auth.authenticate(
+        auth_instance, account, user, password_callback=_password_callback
+    )
+    assert not rest._connection.errorhandler.called  # not error
+
+
+def test_authbyplugin_abc_api():
+    """This test verifies that the abstract function signatures have not changed."""
+    bc = AuthByPlugin
+
+    # Verify properties
+    assert inspect.isdatadescriptor(bc.timeout)
+    assert inspect.isdatadescriptor(bc.type_)
+    assert inspect.isdatadescriptor(bc.assertion_content)
+
+    # Verify method signatures
+    # update_body
+    assert inspect.isfunction(bc.update_body)
+    assert str(inspect.signature(bc.update_body).parameters) == (
+        "OrderedDict([('self', <Parameter \"self\">), "
+        "('body', <Parameter \"body: 'dict[Any, Any]'\">)])"
+    )
+
+    # authenticate
+    assert inspect.isfunction(bc.prepare)
+    assert str(inspect.signature(bc.prepare).parameters) == (
+        "OrderedDict([('self', <Parameter \"self\">), "
+        "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
+        "('authenticator', <Parameter \"authenticator: 'str'\">), "
+        "('service_name', <Parameter \"service_name: 'str | None'\">), "
+        "('account', <Parameter \"account: 'str'\">), "
+        "('user', <Parameter \"user: 'str'\">), "
+        "('password', <Parameter \"password: 'str | None'\">), "
+        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+    )
+
+    # handle_failure
+    assert inspect.isfunction(bc._handle_failure)
+    assert str(inspect.signature(bc._handle_failure).parameters) == (
+        "OrderedDict([('self', <Parameter \"self\">), "
+        "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
+        "('ret', <Parameter \"ret: 'dict[Any, Any]'\">), "
+        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+    )
+
+    # handle_timeout
+    assert inspect.isfunction(bc.handle_timeout)
+    assert str(inspect.signature(bc.handle_timeout).parameters) == (
+        "OrderedDict([('self', <Parameter \"self\">), "
+        "('authenticator', <Parameter \"authenticator: 'str'\">), "
+        "('service_name', <Parameter \"service_name: 'str | None'\">), "
+        "('account', <Parameter \"account: 'str'\">), "
+        "('user', <Parameter \"user: 'str'\">), "
+        "('password', <Parameter \"password: 'str'\">), "
+        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+    )

--- a/test/unit_async/test_auth_keypair.py
+++ b/test/unit_async/test_auth_keypair.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest.mock import Mock, PropertyMock, patch
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from pytest import raises
+
+from snowflake.connector.auth import Auth
+from snowflake.connector.constants import OCSPMode
+from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
+from snowflake.connector.network import SnowflakeRestful
+
+from .mock_utils import mock_connection
+
+try:  # pragma: no cover
+    from snowflake.connector.auth import AuthByKeyPair
+except ImportError:
+    from snowflake.connector.auth_oauth import AuthByKeyPair
+
+
+def _create_mock_auth_keypair_rest_response():
+    def _mock_auth_key_pair_rest_response(url, headers, body, **kwargs):
+        return {
+            "success": True,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+            },
+        }
+
+    return _mock_auth_key_pair_rest_response
+
+
+def test_auth_keypair():
+    """Simple Key Pair test."""
+    private_key_der, public_key_der_encoded = generate_key_pair(2048)
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    auth_instance = AuthByKeyPair(private_key=private_key_der)
+    auth_instance._retry_ctx.set_start_time()
+    auth_instance.handle_timeout(
+        authenticator="SNOWFLAKE_JWT",
+        service_name=None,
+        account=account,
+        user=user,
+        password=None,
+    )
+
+    # success test case
+    rest = _init_rest(application, _create_mock_auth_keypair_rest_response())
+    auth = Auth(rest)
+    auth.authenticate(auth_instance, account, user)
+    assert not rest._connection.errorhandler.called  # not error
+    assert rest.token == "TOKEN"
+    assert rest.master_token == "MASTER_TOKEN"
+
+
+def test_auth_keypair_abc():
+    """Simple Key Pair test using abstraction layer."""
+    private_key_der, public_key_der_encoded = generate_key_pair(2048)
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+
+    private_key = load_der_private_key(
+        data=private_key_der,
+        password=None,
+        backend=default_backend(),
+    )
+
+    assert isinstance(private_key, RSAPrivateKey)
+
+    auth_instance = AuthByKeyPair(private_key=private_key)
+    auth_instance._retry_ctx.set_start_time()
+    auth_instance.handle_timeout(
+        authenticator="SNOWFLAKE_JWT",
+        service_name=None,
+        account=account,
+        user=user,
+        password=None,
+    )
+
+    # success test case
+    rest = _init_rest(application, _create_mock_auth_keypair_rest_response())
+    auth = Auth(rest)
+    auth.authenticate(auth_instance, account, user)
+    assert not rest._connection.errorhandler.called  # not error
+    assert rest.token == "TOKEN"
+    assert rest.master_token == "MASTER_TOKEN"
+
+
+def test_auth_keypair_bad_type():
+    """Simple Key Pair test using abstraction layer."""
+    account = "testaccount"
+    user = "testuser"
+
+    class Bad:
+        pass
+
+    for bad_private_key in ("abcd", 1234, Bad()):
+        auth_instance = AuthByKeyPair(private_key=bad_private_key)
+        with raises(TypeError) as ex:
+            auth_instance.prepare(account=account, user=user)
+        assert str(type(bad_private_key)) in str(ex)
+
+
+@patch("snowflake.connector.auth.keypair.AuthByKeyPair.prepare")
+def test_renew_token(mockPrepare):
+    private_key_der, _ = generate_key_pair(2048)
+    auth_instance = AuthByKeyPair(private_key=private_key_der)
+
+    # force renew condition to be met
+    auth_instance._retry_ctx.set_start_time()
+    auth_instance._jwt_timeout = 0
+    account = "testaccount"
+    user = "testuser"
+
+    auth_instance.handle_timeout(
+        authenticator="SNOWFLAKE_JWT",
+        service_name=None,
+        account=account,
+        user=user,
+        password=None,
+    )
+
+    assert mockPrepare.called
+
+
+def _init_rest(application, post_requset):
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+    connection._ocsp_mode = Mock(return_value=OCSPMode.FAIL_OPEN)
+    type(connection).application = PropertyMock(return_value=application)
+    type(connection)._internal_application_name = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_version = PropertyMock(
+        return_value=CLIENT_VERSION
+    )
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+    rest._post_request = post_requset
+    return rest
+
+
+def generate_key_pair(key_length):
+    private_key = rsa.generate_private_key(
+        backend=default_backend(), public_exponent=65537, key_size=key_length
+    )
+
+    private_key_der = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        .decode("utf-8")
+    )
+
+    # strip off header
+    public_key_der_encoded = "".join(public_key_pem.split("\n")[1:-2])
+
+    return private_key_der, public_key_der_encoded

--- a/test/unit_async/test_auth_mfa.py
+++ b/test/unit_async/test_auth_mfa.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from unittest import mock
+
+from snowflake.connector import connect
+
+
+def test_mfa_token_cache():
+    with mock.patch(
+        "snowflake.connector.network_async.SnowflakeRestfulAsync.fetch",
+    ):
+        with mock.patch(
+            "snowflake.connector.auth._auth.Auth._write_temporary_credential",
+        ) as save_mock:
+            with connect(
+                account="account",
+                user="user",
+                password="password",
+                authenticator="username_password_mfa",
+                client_store_temporary_credential=True,
+                client_request_mfa_token=True,
+            ):
+                assert save_mock.called
+    with mock.patch(
+        "snowflake.connector.network_async.SnowflakeRestfulAsync.fetch",
+        return_value={
+            "data": {
+                "token": "abcd",
+                "masterToken": "defg",
+            },
+            "success": True,
+        },
+    ):
+        with mock.patch(
+            "snowflake.connector.cursor.SnowflakeCursor._init_result_and_meta",
+        ):
+            with mock.patch(
+                "snowflake.connector.auth._auth.Auth._read_temporary_credential",
+                return_value=None,
+            ) as load_mock:
+                with connect(
+                    account="account",
+                    user="user",
+                    password="password",
+                    authenticator="username_password_mfa",
+                    client_store_temporary_credential=True,
+                    client_request_mfa_token=True,
+                ):
+                    assert load_mock.called

--- a/test/unit_async/test_auth_oauth.py
+++ b/test/unit_async/test_auth_oauth.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+try:  # pragma: no cover
+    from snowflake.connector.auth import AuthByOAuth
+except ImportError:
+    from snowflake.connector.auth_oauth import AuthByOAuth
+
+
+def test_auth_oauth():
+    """Simple OAuth test."""
+    token = "oAuthToken"
+    auth = AuthByOAuth(token)
+    body = {"data": {}}
+    auth.update_body(body)
+    assert body["data"]["TOKEN"] == token, body
+    assert body["data"]["AUTHENTICATOR"] == "OAUTH", body

--- a/test/unit_async/test_auth_okta.py
+++ b/test/unit_async/test_auth_okta.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+
+from snowflake.connector.constants import OCSPMode
+from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
+from snowflake.connector.network import SnowflakeRestful
+
+from .mock_utils import mock_connection
+
+try:  # pragma: no cover
+    import snowflake.connector.vendored.requests.sessions
+    from snowflake.connector.auth import AuthByOkta
+except ImportError:
+    from snowflake.connector.auth_okta import AuthByOkta
+
+
+def test_auth_okta():
+    """Authentication by OKTA positive test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    password = "testpassword"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    assert not rest._connection.errorhandler.called  # no error
+    assert headers.get("accept") is not None
+    assert headers.get("Content-Type") is not None
+    assert headers.get("User-Agent") is not None
+    assert sso_url == ref_sso_url
+    assert token_url == ref_token_url
+
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    # step 3
+    ref_one_time_token = "1token1"
+
+    def fake_fetch(method, full_url, headers, **kwargs):
+        return {
+            "cookieToken": ref_one_time_token,
+        }
+
+    rest.fetch = fake_fetch
+    one_time_token = auth._step3(rest._connection, headers, token_url, user, password)
+    assert not rest._connection.errorhandler.called  # no error
+    assert one_time_token == ref_one_time_token
+
+    # step 4
+    ref_response_html = """
+<html><body>
+<form action="https://testaccount.snowflakecomputing.com/post_back"></form>
+</body></body></html>
+"""
+
+    def fake_fetch(method, full_url, headers, **kwargs):
+        return ref_response_html
+
+    def get_one_time_token():
+        return one_time_token
+
+    rest.fetch = fake_fetch
+    response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+    assert response_html == response_html
+
+    # step 5
+    rest._protocol = "https"
+    rest._host = f"{account}.snowflakecomputing.com"
+    rest._port = 443
+    auth._step5(rest._connection, ref_response_html)
+    assert not rest._connection.errorhandler.called  # no error
+    assert ref_response_html == auth._saml_response
+
+
+def test_auth_okta_step1_negative():
+    """Authentication by OKTA step1 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    # not success status is returned
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url, success=False, message="error")
+    auth = AuthByOkta(application)
+    # step 1
+    _, _, _ = auth._step1(rest._connection, authenticator, service_name, account, user)
+    assert rest._connection.errorhandler.called  # error should be raised
+
+
+def test_auth_okta_step2_negative():
+    """Authentication by OKTA step2 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    # invalid SSO URL
+    ref_sso_url = "https://testssoinvalid.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert rest._connection.errorhandler.called  # error
+
+    # invalid TOKEN URL
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testssoinvalid.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert rest._connection.errorhandler.called  # error
+
+
+def test_auth_okta_step3_negative():
+    """Authentication by OKTA step3 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    password = "testpassword"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    # step 3: authentication by IdP failed.
+    def fake_fetch(method, full_url, headers, **kwargs):
+        return {
+            "failed": "auth failed",
+        }
+
+    rest.fetch = fake_fetch
+    _ = auth._step3(rest._connection, headers, token_url, user, password)
+    assert rest._connection.errorhandler.called  # auth failure error
+
+
+@pytest.mark.skipolddriver
+def test_auth_okta_step4_negative(caplog):
+    """Authentication by OKTA step4 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    # step 3: authentication by IdP failed due to throttling
+    raise_token_refresh_error = True
+    second_token_generated = False
+
+    def get_one_time_token():
+        nonlocal raise_token_refresh_error
+        nonlocal second_token_generated
+        if raise_token_refresh_error:
+            assert not second_token_generated
+            return "1token1"
+        else:
+            second_token_generated = True
+            return "2token2"
+
+    # the first time, when step4 gets executed, we return 429
+    # the second time when step4 gets retried, we return 200
+    def mock_session_request(*args, **kwargs):
+        nonlocal second_token_generated
+        url = kwargs.get("url")
+        assert url == (
+            "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=1token1"
+            if not second_token_generated
+            else "https://testsso.snowflake.net/sso?RelayState=%2Fsome%2Fdeep%2Flink&onetimetoken=2token2"
+        )
+        nonlocal raise_token_refresh_error
+        if raise_token_refresh_error:
+            raise_token_refresh_error = False
+            return Mock(status_code=429)
+        else:
+            return Mock(status_code=200, text="success")
+
+    with patch.object(
+        snowflake.connector.vendored.requests.sessions.Session,
+        "request",
+        new=mock_session_request,
+    ):
+        caplog.set_level(logging.DEBUG, "snowflake.connector")
+        response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+        # make sure the RefreshToken error is caught and tried
+        assert "step4: refresh token for re-authentication" in caplog.text
+        # test that token generation method is called
+        assert second_token_generated
+        assert response_html == "success"
+        assert not rest._connection.errorhandler.called
+
+
+def test_auth_okta_step5_negative():
+    """Authentication by OKTA step5 negative test case."""
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    password = "testpassword"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    # step 1
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    assert not rest._connection.errorhandler.called  # no error
+    # step 2
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+    # step 3
+    ref_one_time_token = "1token1"
+
+    def fake_fetch(method, full_url, headers, **kwargs):
+        return {
+            "cookieToken": ref_one_time_token,
+        }
+
+    rest.fetch = fake_fetch
+    one_time_token = auth._step3(rest._connection, headers, token_url, user, password)
+    assert not rest._connection.errorhandler.called  # no error
+
+    # step 4
+    # HTML includes invalid account name
+    ref_response_html = """
+<html><body>
+<form action="https://invalidtestaccount.snowflakecomputing.com/post_back
+"></form>
+</body></body></html>
+"""
+
+    def fake_fetch(method, full_url, headers, **kwargs):
+        return ref_response_html
+
+    def get_one_time_token():
+        return one_time_token
+
+    rest.fetch = fake_fetch
+    response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+    assert response_html == ref_response_html
+
+    # step 5
+    rest._protocol = "https"
+    rest._host = f"{account}.snowflakecomputing.com"
+    rest._port = 443
+    auth._step5(rest._connection, ref_response_html)
+    assert rest._connection.errorhandler.called  # error
+
+
+def _init_rest(ref_sso_url, ref_token_url, success=True, message=None):
+    def post_request(url, headers, body, **kwargs):
+        _ = url
+        _ = headers
+        _ = body
+        _ = kwargs.get("dummy")
+        return {
+            "success": success,
+            "message": message,
+            "data": {
+                "ssoUrl": ref_sso_url,
+                "tokenUrl": ref_token_url,
+            },
+        }
+
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+    connection._ocsp_mode = Mock(return_value=OCSPMode.FAIL_OPEN)
+    type(connection).application = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_name = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_version = PropertyMock(
+        return_value=CLIENT_VERSION
+    )
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+    connection._rest = rest
+    rest._post_request = post_request
+    return rest

--- a/test/unit_async/test_auth_webbrowser.py
+++ b/test/unit_async/test_auth_webbrowser.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+import pytest
+
+from snowflake.connector import SnowflakeConnection
+from snowflake.connector.constants import OCSPMode
+from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
+from snowflake.connector.network import (
+    EXTERNAL_BROWSER_AUTHENTICATOR,
+    ReauthenticationRequest,
+    SnowflakeRestful,
+)
+
+from .mock_utils import mock_connection
+
+try:  # pragma: no cover
+    from snowflake.connector.auth import AuthByWebBrowser
+except ImportError:
+    from snowflake.connector.auth_webbrowser import AuthByWebBrowser
+
+AUTHENTICATOR = "https://testsso.snowflake.net/"
+APPLICATION = "testapplication"
+ACCOUNT = "testaccount"
+USER = "testuser"
+PASSWORD = "testpassword"
+SERVICE_NAME = ""
+REF_PROOF_KEY = "MOCK_PROOF_KEY"
+REF_SSO_URL = "https://testsso.snowflake.net/sso"
+INVALID_SSO_URL = "this is an invalid URL"
+
+
+def mock_webserver(target_instance, application, port):
+    _ = application
+    _ = port
+    target_instance._webserver_status = True
+
+
+def test_auth_webbrowser_get():
+    """Authentication by WebBrowser positive test case."""
+    ref_token = "MOCK_TOKEN"
+
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # mock socket
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.getsockname.return_value = [None, 12345]
+
+    mock_socket_client = MagicMock()
+    mock_socket_client.recv.return_value = (
+        "\r\n".join(
+            [
+                f"GET /?token={ref_token}&confirm=true HTTP/1.1",
+                "User-Agent: snowflake-agent",
+            ]
+        )
+    ).encode("utf-8")
+    mock_socket_instance.accept.return_value = (mock_socket_client, None)
+    mock_socket = Mock(return_value=mock_socket_instance)
+
+    auth = AuthByWebBrowser(
+        application=APPLICATION,
+        webbrowser_pkg=mock_webbrowser,
+        socket_pkg=mock_socket,
+    )
+    auth.prepare(
+        conn=rest._connection,
+        authenticator=AUTHENTICATOR,
+        service_name=SERVICE_NAME,
+        account=ACCOUNT,
+        user=USER,
+        password=PASSWORD,
+    )
+    assert not rest._connection.errorhandler.called  # no error
+    assert auth.assertion_content == ref_token
+    body = {"data": {}}
+    auth.update_body(body)
+    assert body["data"]["TOKEN"] == ref_token
+    assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+    assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+
+
+def test_auth_webbrowser_post():
+    """Authentication by WebBrowser positive test case with POST."""
+    ref_token = "MOCK_TOKEN"
+
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # mock socket
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.getsockname.return_value = [None, 12345]
+
+    mock_socket_client = MagicMock()
+    mock_socket_client.recv.return_value = (
+        "\r\n".join(
+            [
+                "POST / HTTP/1.1",
+                "User-Agent: snowflake-agent",
+                "Host: localhost:12345",
+                "",
+                f"token={ref_token}&confirm=true",
+            ]
+        )
+    ).encode("utf-8")
+    mock_socket_instance.accept.return_value = (mock_socket_client, None)
+    mock_socket = Mock(return_value=mock_socket_instance)
+
+    auth = AuthByWebBrowser(
+        application=APPLICATION,
+        webbrowser_pkg=mock_webbrowser,
+        socket_pkg=mock_socket,
+    )
+    auth.prepare(
+        conn=rest._connection,
+        authenticator=AUTHENTICATOR,
+        service_name=SERVICE_NAME,
+        account=ACCOUNT,
+        user=USER,
+        password=PASSWORD,
+    )
+    assert not rest._connection.errorhandler.called  # no error
+    assert auth.assertion_content == ref_token
+    body = {"data": {}}
+    auth.update_body(body)
+    assert body["data"]["TOKEN"] == ref_token
+    assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+    assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+
+
+@pytest.mark.parametrize(
+    "input_text,expected_error",
+    [
+        ("", True),
+        ("http://example.com/notokenurl", True),
+        ("http://example.com/sso?token=", True),
+        ("http://example.com/sso?token=MOCK_TOKEN", False),
+    ],
+)
+def test_auth_webbrowser_fail_webbrowser(
+    monkeypatch, capsys, input_text, expected_error
+):
+    """Authentication by WebBrowser with failed to start web browser case."""
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+    ref_token = "MOCK_TOKEN"
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = False
+
+    # mock socket
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.getsockname.return_value = [None, 12345]
+
+    mock_socket_client = MagicMock()
+    mock_socket_client.recv.return_value = (
+        "\r\n".join(["GET /?token=MOCK_TOKEN HTTP/1.1", "User-Agent: snowflake-agent"])
+    ).encode("utf-8")
+    mock_socket_instance.accept.return_value = (mock_socket_client, None)
+    mock_socket = Mock(return_value=mock_socket_instance)
+
+    auth = AuthByWebBrowser(
+        application=APPLICATION,
+        webbrowser_pkg=mock_webbrowser,
+        socket_pkg=mock_socket,
+    )
+    with patch("builtins.input", return_value=input_text):
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "Initiating login request with your identity provider. A browser window "
+        "should have opened for you to complete the login. If you can't see it, "
+        "check existing browser windows, or your OS settings. Press CTRL+C to "
+        f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\nWe were unable to open a browser window for "
+        "you, please open the url above manually then paste the URL you "
+        "are redirected to into the terminal.\n"
+    )
+    if expected_error:
+        assert rest._connection.errorhandler.called  # an error
+        assert auth.assertion_content is None
+    else:
+        assert not rest._connection.errorhandler.called  # no error
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+
+
+def test_auth_webbrowser_fail_webserver(capsys):
+    """Authentication by WebBrowser with failed to start web browser case."""
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # mock socket
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.getsockname.return_value = [None, 12345]
+
+    mock_socket_client = MagicMock()
+    mock_socket_client.recv.return_value = (
+        "\r\n".join(["GARBAGE", "User-Agent: snowflake-agent"])
+    ).encode("utf-8")
+    mock_socket_instance.accept.return_value = (mock_socket_client, None)
+    mock_socket = Mock(return_value=mock_socket_instance)
+
+    # case 1: invalid HTTP request
+    auth = AuthByWebBrowser(
+        application=APPLICATION,
+        webbrowser_pkg=mock_webbrowser,
+        socket_pkg=mock_socket,
+    )
+    auth.prepare(
+        conn=rest._connection,
+        authenticator=AUTHENTICATOR,
+        service_name=SERVICE_NAME,
+        account=ACCOUNT,
+        user=USER,
+        password=PASSWORD,
+    )
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "Initiating login request with your identity provider. A browser window "
+        "should have opened for you to complete the login. If you can't see it, "
+        "check existing browser windows, or your OS settings. Press CTRL+C to "
+        f"abort and try again...\nGoing to open: {REF_SSO_URL} to authenticate...\n"
+    )
+    assert rest._connection.errorhandler.called  # an error
+    assert auth.assertion_content is None
+
+
+def _init_rest(ref_sso_url, ref_proof_key, success=True, message=None):
+    def post_request(url, headers, body, **kwargs):
+        _ = url
+        _ = headers
+        _ = body
+        _ = kwargs.get("dummy")
+        return {
+            "success": success,
+            "message": message,
+            "data": {
+                "ssoUrl": ref_sso_url,
+                "proofKey": ref_proof_key,
+            },
+        }
+
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+    connection._ocsp_mode = Mock(return_value=OCSPMode.FAIL_OPEN)
+    type(connection).application = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_name = PropertyMock(return_value=CLIENT_NAME)
+    type(connection)._internal_application_version = PropertyMock(
+        return_value=CLIENT_VERSION
+    )
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+    rest._post_request = post_request
+    connection._rest = rest
+    return rest
+
+
+@pytest.mark.asyncio
+def test_idtoken_reauth():
+    """This test makes sure that AuthByIdToken reverts to AuthByWebBrowser.
+
+    This happens when the initial connection fails. Such as when the saved ID
+    token has expired.
+    """
+    from snowflake.connector.auth.idtoken import AuthByIdToken
+
+    auth_inst = AuthByIdToken(
+        id_token="token",
+        application="application",
+        protocol="protocol",
+        host="host",
+        port="port",
+    )
+
+    # We'll use this Exception to make sure AuthByWebBrowser authentication
+    #  flow is called as expected
+    class StopExecuting(Exception):
+        pass
+
+    with mock.patch(
+        "snowflake.connector.auth.idtoken.AuthByIdToken.prepare",
+        side_effect=ReauthenticationRequest(Exception()),
+    ):
+        with mock.patch(
+            "snowflake.connector.auth.webbrowser.AuthByWebBrowser.prepare",
+            side_effect=StopExecuting(),
+        ):
+            with pytest.raises(StopExecuting):
+                SnowflakeConnection(
+                    user="user",
+                    account="account",
+                    auth_class=auth_inst,
+                )
+
+
+def test_auth_webbrowser_invalid_sso(monkeypatch):
+    """Authentication by WebBrowser with failed to start web browser case."""
+    rest = _init_rest(INVALID_SSO_URL, REF_PROOF_KEY)
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = False
+
+    # mock socket
+    mock_socket_instance = MagicMock()
+    mock_socket_instance.getsockname.return_value = [None, 12345]
+
+    mock_socket_client = MagicMock()
+    mock_socket_client.recv.return_value = (
+        "\r\n".join(["GET /?token=MOCK_TOKEN HTTP/1.1", "User-Agent: snowflake-agent"])
+    ).encode("utf-8")
+    mock_socket_instance.accept.return_value = (mock_socket_client, None)
+    mock_socket = Mock(return_value=mock_socket_instance)
+
+    auth = AuthByWebBrowser(
+        application=APPLICATION,
+        webbrowser_pkg=mock_webbrowser,
+        socket_pkg=mock_socket,
+    )
+    auth.prepare(
+        conn=rest._connection,
+        authenticator=AUTHENTICATOR,
+        service_name=SERVICE_NAME,
+        account=ACCOUNT,
+        user=USER,
+        password=PASSWORD,
+    )
+    assert rest._connection.errorhandler.called  # an error
+    assert auth.assertion_content is None

--- a/test/unit_async/test_backoff_policies.py
+++ b/test/unit_async/test_backoff_policies.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+try:
+    from snowflake.connector.backoff_policies import exponential_backoff, linear_backoff
+except ImportError:
+    pass
+
+
+@pytest.mark.skipolddriver
+def test_linear_backoff():
+    backoff_generator = linear_backoff(factor=2, base=1, cap=100, enable_jitter=False)()
+    assert [next(backoff_generator) for _ in range(5)] == [1, 3, 5, 7, 9]
+
+
+@pytest.mark.skipolddriver
+def test_exponential_backoff():
+    backoff_generator = exponential_backoff(
+        factor=2, base=1, cap=100, enable_jitter=False
+    )()
+    assert [next(backoff_generator) for _ in range(5)] == [1, 2, 4, 8, 16]

--- a/test/unit_async/test_binaryformat.py
+++ b/test/unit_async/test_binaryformat.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from snowflake.connector.sfbinaryformat import (
+    SnowflakeBinaryFormat,
+    binary_to_python,
+    binary_to_snowflake,
+)
+
+
+def test_basic():
+    """Test hex and base64 formatting."""
+    # Hex
+    fmt = SnowflakeBinaryFormat("heX")
+    assert fmt.format(b"") == ""
+    assert fmt.format(b"\x00") == "00"
+    assert fmt.format(b"\xAB\xCD\x12") == "ABCD12"
+    assert fmt.format(b"\x00\xFF\x42\x01") == "00FF4201"
+
+    # Base64
+    fmt = SnowflakeBinaryFormat("BasE64")
+    assert fmt.format(b"") == ""
+    assert fmt.format(b"\x00") == "AA=="
+    assert fmt.format(b"\xAB\xCD\x12") == "q80S"
+    assert fmt.format(b"\x00\xFF\x42\x01") == "AP9CAQ=="
+
+
+def test_binary_to_python():
+    """Test conversion to Python data type."""
+    assert binary_to_python("") == b""
+    assert binary_to_python("00") == b"\x00"
+    assert binary_to_python("ABCD12") == b"\xAB\xCD\x12"
+
+
+def test_binary_to_snowflake():
+    """Test conversion for passing to Snowflake."""
+    assert binary_to_snowflake(b"") == b""
+    assert binary_to_snowflake(b"\x00") == b"00"
+    assert binary_to_snowflake(b"\xAB\xCD\x12") == b"ABCD12"

--- a/test/unit_async/test_bind_upload_agent.py
+++ b/test/unit_async/test_bind_upload_agent.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_bind_upload_agent_uploading_multiple_files():
+    from snowflake.connector.bind_upload_agent import BindUploadAgent
+
+    csr = MagicMock(auto_spec=True)
+    rows = [bytes(10)] * 10
+    agent = BindUploadAgent(csr, rows, stream_buffer_size=10)
+    agent.upload()
+    assert csr.execute.call_count == 11  # 1 for stage creation + 10 files
+
+
+def test_bind_upload_agent_row_size_exceed_buffer_size():
+    from snowflake.connector.bind_upload_agent import BindUploadAgent
+
+    csr = MagicMock(auto_spec=True)
+    rows = [bytes(15)] * 10
+    agent = BindUploadAgent(csr, rows, stream_buffer_size=10)
+    agent.upload()
+    assert csr.execute.call_count == 11  # 1 for stage creation + 10 files

--- a/test/unit_async/test_cache.py
+++ b/test/unit_async/test_cache.py
@@ -1,0 +1,551 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import datetime
+import logging
+import os
+import os.path
+import pickle
+import stat
+import time
+from unittest import mock
+
+import pytest
+
+from snowflake.connector.compat import IS_WINDOWS
+
+try:
+    import snowflake.connector.cache as cache
+except ImportError:
+    cache = None
+
+# Used to insert entries that expire instantaneously
+NO_LIFETIME = datetime.timedelta(seconds=0)
+
+
+class BrokenReadingPickleObject:
+    def __init__(self):
+        self.val = "string"
+
+    def __getstate__(self):
+        return {"val": "string"}
+
+    def __setstate__(self, state):
+        raise ModuleNotFoundError()
+
+
+class BrokenWritingPickleObject:
+    def __init__(self):
+        self.val = "string"
+
+    def __getstate__(self):
+        raise ModuleNotFoundError()
+
+    def __setstate__(self, state):
+        self.val = "string"
+
+
+class TestSFDictCache:
+    def test_simple_usage(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert 1 in c and 2 in c
+        assert c[1] == "a"
+        assert c[2] == "b"
+
+    def test_miss(self):
+        c = cache.SFDictCache.from_dict(
+            {"a": 1},
+        )
+        with pytest.raises(KeyError):
+            c["b"]
+
+    def test_expiration(self):
+        c = cache.SFDictCache.from_dict(
+            {"a": 1},
+            entry_lifetime=0,
+        )
+        with pytest.raises(KeyError):
+            c[1]
+
+    def test_access_empty(self):
+        c = cache.SFDictCache()
+        with pytest.raises(KeyError):
+            c[1]
+
+    # The rest of tests test that SFDictCache acts like a regular dictionary.
+
+    def test_cast_list(self):
+        c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
+        assert list(c) == ["a", "b"]
+
+    def test_access(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        assert c["a"] == 1
+        c._entry_lifetime = NO_LIFETIME
+        c["b"] = 2
+        with pytest.raises(KeyError):
+            c["b"]
+
+    def test_delete(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        del c["a"]
+        assert len(c.keys()) == 0
+
+    def test_contains(self):
+        c = cache.SFDictCache.from_dict({"a": 1})
+        assert "a" in c
+        c._entry_lifetime = NO_LIFETIME
+        c["b"] = 2
+        assert "b" not in c
+        assert "c" not in c
+
+    def test_iter(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        counter = 1
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["a"] = 100
+        for e in iter(c):
+            assert e == counter
+            # Make sure that cache can be modified while iterating
+            del c[e]
+            counter += 1
+        assert len(c._cache) == 0
+
+    def test_clear(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert len(c.keys()) == 2
+        c.clear()
+        assert len(c.keys()) == 0
+
+    def test_get(self):
+        c = cache.SFDictCache.from_dict({1: "a", 2: "b"})
+        assert c.get("a", -999) == -999
+        assert c.get(1) == "a"
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.get("d") is None
+        with c._lock:
+            assert c._getitem_non_locking(1) == "a"
+
+    def test_items(self):
+        c = cache.SFDictCache()
+        assert c.items() == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.items() == [("a", 1), ("b", 2)]
+
+    def test_keys(self):
+        c = cache.SFDictCache()
+        assert list(c.keys()) == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.keys() == ["a", "b"]
+
+    def test_update(self):
+        c = cache.SFDictCache()
+        c.update({"a": 1})
+        other = cache.SFDictCache.from_dict({"b": 2, "c": 3})
+        c["b"] = 4
+        c.update(other)
+        assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.items() == [("a", 1), ("b", 2), ("c", 3)]
+
+    def test_update_newer(self):
+        c = cache.SFDictCache()
+        c.update({"a": 1})
+        with mock.patch(
+            "snowflake.connector.cache.now",
+            lambda: datetime.datetime.now() + datetime.timedelta(seconds=1),
+        ):
+            other = cache.SFDictCache.from_dict({"a": 2, "b": 4, "c": 2})
+        with mock.patch(
+            "snowflake.connector.cache.now",
+            lambda: datetime.datetime.now() + datetime.timedelta(seconds=2),
+        ):
+            c["b"] = 2
+        c.update_newer(other)
+        assert c.items() == [("a", 2), ("b", 2), ("c", 2)]
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["d"] = 4
+        assert c.items() == [("a", 2), ("b", 2), ("c", 2)]
+
+    def test_values(self):
+        c = cache.SFDictCache()
+        assert c.values() == []
+        c["a"] = 1
+        c["b"] = 2
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        assert c.values() == [1, 2]
+
+    def test_telemetry(self):
+        c = cache.SFDictCache.from_dict({"a": 1, "b": 2})
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }
+        c["a"] = 1
+        assert c.telemetry["hit"] == 0
+        assert c["a"] == 1
+        assert c.telemetry["hit"] == 1
+        with pytest.raises(KeyError):
+            c["c"]
+        assert c.telemetry["miss"] == 1
+        # Make sure that this filters out expired entries
+        c._entry_lifetime = NO_LIFETIME
+        c["c"] = 3
+        with pytest.raises(KeyError):
+            c["c"]
+        assert c.telemetry["expiration"] == 1
+        assert c.get("c") is None
+        assert c.telemetry["miss"] == 2
+        # These functions should not affect any numbers other than expirations
+        c["c"] = 3  # expired
+        assert c.values() == [1, 2]
+        assert c.keys() == ["a", "b"]
+        assert c.items() == [("a", 1), ("b", 2)]
+        assert c.telemetry == {
+            "hit": 1,
+            "miss": 2,
+            "expiration": 2,
+            "size": 2,
+        }
+        assert "b" in c
+        c.clear()
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 0,
+        }
+        c.update({"a": 1, "b": 2})
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }
+
+
+if cache is not None:
+
+    class AlwaysSaveSFDictFileCache(cache.SFDictFileCache):
+        def _should_save(self):
+            return True
+
+    class NeverSaveSFDictFileCache(cache.SFDictFileCache):
+        def _should_save(self):
+            return False
+
+
+class TestSFDictFileCache:
+    # Since the __getitem__ is overwritten copied over tests to test it
+    def test_simple_usage(self, tmpdir):
+        c = cache.SFDictFileCache.from_dict(
+            {1: "a", 2: "b"},
+            file_path=os.path.join(tmpdir, "c.txt"),
+        )
+        assert 1 in c and 2 in c
+        assert c[1] == "a"
+        assert c[2] == "b"
+        assert c.telemetry == {
+            "hit": 4,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }
+
+    def test_miss(self, tmpdir):
+        c = cache.SFDictFileCache.from_dict(
+            {"a": 1},
+            file_path=os.path.join(tmpdir, "c.txt"),
+        )
+        with pytest.raises(KeyError):
+            c["b"]
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 1,
+            "expiration": 0,
+            "size": 1,
+        }
+
+    def test_expiration(self, tmpdir):
+        tmp_file = os.path.join(tmpdir, "c.txt")
+        c = NeverSaveSFDictFileCache.from_dict(
+            {"a": 1},
+            entry_lifetime=0,
+            file_path=tmp_file,
+        )
+        with pytest.raises(KeyError):
+            c["a"]
+        assert c.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 1,
+            "size": 0,
+        }
+        c2 = AlwaysSaveSFDictFileCache(file_path=tmp_file)
+        c["a"] = 1
+        c2["a"] = 2
+        assert c2["a"] == 2
+        assert c["a"] == 2
+
+    # The rest of the tests test the file cache portion
+
+    def test_simple_miss(self, tmpdir):
+        """Check whether miss triggers a load."""
+        c = AlwaysSaveSFDictFileCache.from_dict(
+            {"a": 1, "b": 2}, file_path=os.path.join(tmpdir, "c.txt")
+        )
+        c2 = pickle.loads(pickle.dumps(c))
+        c2["c"] = 3
+        with mock.patch(
+            "snowflake.connector.cache.getmtime",
+            lambda path: os.path.getmtime(path) + 1,
+        ):
+            assert c["c"] == 3
+
+    def test_simple_expiration(self, tmpdir):
+        """Check whether expiration triggers a load."""
+        c = AlwaysSaveSFDictFileCache.from_dict(
+            {"a": 1, "b": 2}, file_path=os.path.join(tmpdir, "c.txt")
+        )
+        c2 = pickle.loads(pickle.dumps(c))
+        c2._entry_lifetime = NO_LIFETIME
+        c2["c"] = 3
+        c["c"] = 3
+        with mock.patch(
+            "snowflake.connector.cache.getmtime",
+            lambda path: os.path.getmtime(path) + 1,
+        ):
+            assert c2["c"] == 3
+
+    def test_filelock_hang(self, tmpdir, caplog):
+        """Check whether if file lock is held save doesn't hang."""
+        c = AlwaysSaveSFDictFileCache.from_dict(
+            {"a": 1, "b": 2}, file_path=os.path.join(tmpdir, "c.txt")
+        )
+        c2 = pickle.loads(pickle.dumps(c))
+        with c2._file_lock:
+            with caplog.at_level(logging.DEBUG, logger="snowflake.connector.cache"):
+                # c will dump cache to file every time an item is set as it's AlwaysSaveSFDictFileCache
+                # so the program exeucted at this point, c._cache_modified is false as it has the latest cache
+                # changes, we set force_flush to True
+                with c._lock:
+                    assert not c._save(force_flush=True)
+            assert (
+                "snowflake.connector.cache",
+                logging.DEBUG,
+                f"acquiring {c._file_lock_path} timed out, skipping saving...",
+            ) in caplog.record_tuples
+
+    def test_pickle(self, tmpdir):
+        c = AlwaysSaveSFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
+        c2 = pickle.loads(pickle.dumps(c))
+        assert c is not c2
+        assert c._lock is not c2._lock
+        assert c._file_lock is not c2._file_lock
+
+        c.arribute_shoud_not_be_pickled = "value"
+        c2 = pickle.loads(pickle.dumps(c))
+        assert c.arribute_shoud_not_be_pickled
+        assert c is not c2
+        assert c._lock is not c2._lock
+        assert c._file_lock is not c2._file_lock
+        assert not hasattr(c2, "arribute_shoud_not_be_pickled")
+        for attr in cache.SFDictFileCache._ATTRIBUTES_TO_PICKLE:
+            assert hasattr(c2, attr) and getattr(c2, attr) == getattr(c, attr)
+
+    def test_precise_save_load(self, tmpdir):
+        c1 = NeverSaveSFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
+        c2 = pickle.loads(pickle.dumps(c1))
+        c1["a"] = 1
+        c1["b"] = 1
+        assert c1.save()
+        assert c2.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 0,
+        }
+        assert c2.load()
+        assert c2.telemetry == {
+            "hit": 0,
+            "miss": 0,
+            "expiration": 0,
+            "size": 2,
+        }
+
+    def test_clear_expired_entries(self, tmpdir):
+        c1 = NeverSaveSFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
+        c2 = pickle.loads(pickle.dumps(c1))
+        c1["a"] = 1
+        c1._entry_lifetime = NO_LIFETIME
+        c1["b"] = 1
+        c1["c"] = 1
+        assert c1.save()  # Save calls self._clear_expired_entries()
+        assert c2.load()
+        assert c2.keys() == ["a"]
+
+    def test_path_choosing(self, tmpdir):
+        tmp_file = os.path.join(tmpdir, "cache.txt")
+        non_existent_file = "/nowhere/cache.txt"
+        platforms = ("linux", "darwin", "windows")
+        wrong_paths = {p: non_existent_file for p in platforms}
+        for platform in platforms:
+            with mock.patch(
+                "snowflake.connector.cache.platform.system", return_value=platform
+            ):
+                assert (
+                    cache.SFDictFileCache(
+                        file_path={**wrong_paths, platform: tmp_file},
+                    ).file_path
+                    == tmp_file
+                )
+        # Test fallback too
+        with mock.patch(
+            "snowflake.connector.cache.platform.system",
+            return_value="BSD",
+        ):
+            assert (
+                cache.SFDictFileCache(
+                    file_path={
+                        "linux": tmp_file,
+                        "windows": non_existent_file,
+                    },
+                ).file_path
+                == tmp_file
+            )
+
+    def test_read_only(self, tmpdir):
+        if IS_WINDOWS:
+            pytest.skip("chmod does not work on Windows")
+        os.chmod(tmpdir, stat.S_IRUSR | stat.S_IXUSR)
+        with pytest.raises(
+            PermissionError,
+            match=f"Cache folder is not writeable: '{tmpdir}'",
+        ):
+            cache.SFDictFileCache(file_path=os.path.join(tmpdir, "cache.txt"))
+
+    def test_clear(self, tmpdir):
+        cache_path = os.path.join(tmpdir, "cache.txt")
+        c = AlwaysSaveSFDictFileCache(file_path=cache_path)
+        c.clear()
+        assert not c._cache
+        assert os.path.exists(cache_path)
+        # Make sure not existing cache file doesn't raise Exception during cache
+        os.unlink(cache_path)
+        c["a"] = 1
+        assert os.path.exists(cache_path)
+
+    def test_load_with_expired_entries(self, tmpdir):
+        # Test: https://snowflakecomputing.atlassian.net/browse/SNOW-698526
+
+        # create cache first
+        cache_path = os.path.join(tmpdir, "cache.txt")
+        c1 = cache.SFDictFileCache(file_path=cache_path)
+        c1["a"] = 1
+        c1.save()
+
+        # load cache
+        c2 = cache.SFDictFileCache(
+            file_path=cache_path, entry_lifetime=int(NO_LIFETIME.total_seconds())
+        )
+        c2["b"] = 2
+        c2["c"] = 3
+        # cache will expire immediately due to the NO_LIFETIME setting
+        # when loading again, clearing cache logic will be triggered
+        # load will trigger clear expired entries, and then further call _getitem
+        c2.load()
+
+        assert len(c2) == 1 and c2["a"] == 1 and c2._getitem_non_locking("a") == 1
+
+    def test_broken_pickle_objects(self, tmpdir):
+        cache_path = os.path.join(tmpdir, "cache.txt")
+        c1 = NeverSaveSFDictFileCache(file_path=cache_path)
+        c1["key"] = BrokenReadingPickleObject()
+        assert c1.save()
+        assert os.path.exists(cache_path) and os.path.isfile(cache_path)
+
+        c2 = NeverSaveSFDictFileCache(file_path=cache_path)
+        assert not c2._load()  # load should return false due to ModuleNotFound error
+
+        cache_path = os.path.join(tmpdir, "cache2.txt")
+        c1 = NeverSaveSFDictFileCache(file_path=cache_path)
+        c1["key"] = BrokenWritingPickleObject()
+        assert not c1.save()
+        assert not os.path.exists(cache_path)
+
+        c2 = NeverSaveSFDictFileCache(file_path=cache_path)
+        assert not c2.load()  # load should return false due to no file
+
+
+def test_file_is_not_updated(tmpdir):
+    tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
+    sfcache = NeverSaveSFDictFileCache(file_path=tmp_cache_file, entry_lifetime=1)
+    sfcache.update({"key": "value"})
+    assert sfcache._cache_modified
+    sfcache.save()  # this save call will dump cache to file because item was added
+    assert not sfcache._cache_modified
+    updated_time = os.path.getmtime(tmp_cache_file)
+    sfcache.save()  # this save call will be a no-op since there is no update
+    assert os.path.getmtime(tmp_cache_file) == updated_time
+    sfcache.update({"key": "value2"})
+    assert sfcache._cache_modified
+    time.sleep(0.1)  # sleep 0.1 to avoid flushing too fast
+    sfcache.save()  # this save call will dump cache to file
+    assert not sfcache._cache_modified
+    second_updated_time = os.path.getmtime(tmp_cache_file)
+    assert second_updated_time > updated_time
+    assert sfcache["key"] == "value2"
+    assert not sfcache._cache_modified
+    sfcache.save()  # this save call will be a no-op since there is no update
+    assert not sfcache._cache_modified
+    assert os.path.getmtime(tmp_cache_file) == second_updated_time
+    time.sleep(1)
+    sfcache.save()  # this save call will dump cache because cache item is expired
+    assert not sfcache._cache_modified
+    assert os.path.getmtime(tmp_cache_file) > second_updated_time
+
+    cache3 = NeverSaveSFDictFileCache(file_path=tmp_cache_file, entry_lifetime=1)
+    assert len(cache3) == 0
+    os.unlink(tmp_cache_file)
+
+
+def test_cache_do_not_write_while_set_item(tmpdir):
+    tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
+    sfcache = NeverSaveSFDictFileCache(tmp_cache_file)
+    to_update_dict = {}
+    for i in range(1000):
+        to_update_dict[i] = i
+    sfcache.update(to_update_dict)
+    # there should be no file created as setting item won't trigger creation
+    assert sfcache._cache_modified
+    assert not os.path.exists(tmp_cache_file)
+    sfcache.save()
+    assert not sfcache._cache_modified
+    assert os.path.exists(tmp_cache_file)
+    file_modified_time = os.path.getmtime(tmp_cache_file)
+    sfcache2 = NeverSaveSFDictFileCache(tmp_cache_file)
+    time.sleep(0.01)
+    for i in range(1000):
+        assert sfcache2[i] == i
+    assert not sfcache2._cache_modified
+    sfcache2.save()  # this save should be a no-op since there is no change
+    assert os.path.getmtime(tmp_cache_file) == file_modified_time

--- a/test/unit_async/test_compute_chunk_size.py
+++ b/test/unit_async/test_compute_chunk_size.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+pytestmark = pytest.mark.skipolddriver
+
+
+def test_check_chunk_size():
+    from snowflake.connector.constants import (
+        S3_MAX_OBJECT_SIZE,
+        S3_MAX_PART_SIZE,
+        S3_MIN_PART_SIZE,
+    )
+    from snowflake.connector.file_transfer_agent import _chunk_size_calculator
+
+    expected_chunk_size = 8 * 1024**2
+    sample_file_size_2gb = 2 * 1024**3
+    sample_file_size_under_5tb = 4.9 * 1024**4
+    sample_file_size_6tb = 6 * 1024**4
+    sample_chunk_size_4mb = 4 * 1024**2
+
+    chunk_size_1 = _chunk_size_calculator(sample_file_size_2gb)
+    assert chunk_size_1 == expected_chunk_size
+
+    chunk_size_2 = _chunk_size_calculator(int(sample_file_size_under_5tb))
+    assert chunk_size_2 <= S3_MAX_PART_SIZE
+
+    with pytest.raises(ValueError) as exc:
+        _chunk_size_calculator(sample_file_size_6tb)
+    assert (
+        f"File size {sample_file_size_6tb} exceeds the maximum file size {S3_MAX_OBJECT_SIZE} allowed in S3."
+        in str(exc)
+    )
+
+    chunk_size_1 = _chunk_size_calculator(sample_chunk_size_4mb)
+    assert chunk_size_1 >= S3_MIN_PART_SIZE

--- a/test/unit_async/test_configmanager.py
+++ b/test/unit_async/test_configmanager.py
@@ -1,0 +1,706 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import os.path
+import re
+import shutil
+import stat
+import string
+import warnings
+from pathlib import Path
+from test.randomize import random_string
+from textwrap import dedent
+from typing import Callable, Dict, Union
+from unittest import mock
+
+import pytest
+from pytest import raises
+
+from snowflake.connector.compat import IS_WINDOWS
+
+try:
+    from snowflake.connector.config_manager import (
+        CONFIG_MANAGER,
+        ConfigManager,
+        ConfigOption,
+        ConfigSlice,
+        ConfigSliceOptions,
+    )
+    from snowflake.connector.errors import (
+        ConfigManagerError,
+        ConfigSourceError,
+        MissingConfigOptionError,
+    )
+    from snowflake.connector.sf_dirs import SFPlatformDirs, _resolve_platform_dirs
+except ImportError:
+    # olddriver tests
+    pass
+
+
+def tmp_files_helper(cwd: Path, to_create: files) -> None:
+    for k, v in to_create.items():
+        new_file = cwd / k
+        if isinstance(v, str):
+            new_file.touch()
+            new_file.write_text(v)
+        else:
+            new_file.mkdir()
+            tmp_files_helper(new_file, v)
+
+
+files = Dict[str, Union[str, "files"]]
+
+
+@pytest.fixture
+def tmp_files(tmp_path: Path) -> Callable[[files], Path]:
+    def create_tmp_files(to_create: files) -> Path:
+        tmp_files_helper(tmp_path, to_create)
+        return tmp_path
+
+    return create_tmp_files
+
+
+def test_incorrect_config_read(tmp_files):
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """
+                [connections.defa
+                """
+            )
+        }
+    )
+    config_file = tmp_folder / "config.toml"
+    with raises(
+        ConfigSourceError,
+        match=re.escape(
+            f"An unknown error happened while loading '{str(config_file)}'"
+        ),
+    ):
+        ConfigManager(name="test", file_path=config_file).read_config()
+
+
+def test_simple_config_read(tmp_files):
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """\
+                [connections.snowflake]
+                account = "snowflake"
+                user = "snowball"
+                password = "password"
+
+                [settings]
+                output_format = "yaml"
+                """
+            )
+        }
+    )
+    config_file = tmp_folder / "config.toml"
+    TEST_PARSER = ConfigManager(
+        name="test",
+        file_path=config_file,
+    )
+    from tomlkit import parse
+
+    TEST_PARSER.add_option(
+        name="connections",
+        parse_str=parse,
+    )
+    settings_parser = ConfigManager(
+        name="settings",
+    )
+    settings_parser.add_option(
+        name="output_format",
+        choices=("json", "yaml", "toml"),
+    )
+    TEST_PARSER.add_subparser(settings_parser)
+    assert TEST_PARSER["connections"] == {
+        "snowflake": {
+            "account": "snowflake",
+            "user": "snowball",
+            "password": "password",
+        }
+    }
+    assert TEST_PARSER["settings"]["output_format"] == "yaml"
+
+
+def test_simple_config_read_sliced(tmp_files):
+    """Same test_simple_config_read, but rerads part of the config from another file."""
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """\
+                [settings]
+                output_format = "json"
+                """
+            ),
+            "connections.toml": dedent(
+                """\
+                [snowflake]
+                account = "snowflake"
+                user = "snowball"
+                password = "password"
+                """
+            ),
+        }
+    )
+    TEST_PARSER = ConfigManager(
+        name="root_parser",
+        file_path=tmp_folder / "config.toml",
+        _slices=(
+            ConfigSlice(
+                tmp_folder / "connections.toml", ConfigSliceOptions(), "connections"
+            ),
+        ),
+    )
+    from tomlkit import parse
+
+    TEST_PARSER.add_option(
+        name="connections",
+        parse_str=parse,
+    )
+    settings_parser = ConfigManager(
+        name="settings",
+    )
+    settings_parser.add_option(
+        name="output_format",
+        choices=("json", "yaml", "toml"),
+    )
+    TEST_PARSER.add_subparser(settings_parser)
+    assert TEST_PARSER["connections"] == {
+        "snowflake": {
+            "account": "snowflake",
+            "user": "snowball",
+            "password": "password",
+        }
+    }
+    assert TEST_PARSER["settings"]["output_format"] == "json"
+
+
+def test_missing_value(tmp_files):
+    """Test that we handle a missing configuration option gracefully."""
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """\
+                [connections.snowflake]
+                account = "snowflake"
+                user = "snowball"
+                password = "password"
+                """
+            ),
+        }
+    )
+    TEST_PARSER = ConfigManager(
+        name="root_parser",
+        file_path=tmp_folder / "config.toml",
+    )
+    TEST_PARSER.add_option(
+        name="connections",
+    )
+    settings_parser = ConfigManager(
+        name="settings",
+    )
+    settings_parser.add_option(
+        name="output_format",
+        choices=("json", "yaml", "toml"),
+    )
+    TEST_PARSER.add_subparser(settings_parser)
+    assert TEST_PARSER["connections"] == {
+        "snowflake": {
+            "account": "snowflake",
+            "user": "snowball",
+            "password": "password",
+        }
+    }
+    with pytest.raises(
+        MissingConfigOptionError,
+        match=re.escape(
+            "Configuration option 'settings.output_format' is not defined anywhere, "
+            "have you forgotten to set it in a configuration file, or "
+            "environmental variable?"
+        ),
+    ):
+        TEST_PARSER["settings"]["output_format"]
+
+
+def test_missing_value_sliced(tmp_files):
+    """Test that we handle a missing configuration option gracefully across multiple files."""
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """\
+                [settings]
+                """
+            ),
+            "connections.toml": dedent(
+                """\
+                [snowflake]
+                account = "snowflake"
+                user = "snowball"
+                password = "password"
+                """
+            ),
+        }
+    )
+    TEST_PARSER = ConfigManager(
+        name="root_parser",
+        file_path=tmp_folder / "config.toml",
+        _slices=(
+            ConfigSlice(
+                tmp_folder / "connections.toml", ConfigSliceOptions(), "connections"
+            ),
+        ),
+    )
+    TEST_PARSER.add_option(
+        name="connections",
+    )
+    settings_parser = ConfigManager(
+        name="settings",
+    )
+    settings_parser.add_option(
+        name="output_format",
+        choices=("json", "yaml", "toml"),
+    )
+    TEST_PARSER.add_subparser(settings_parser)
+    assert TEST_PARSER["connections"] == {
+        "snowflake": {
+            "account": "snowflake",
+            "user": "snowball",
+            "password": "password",
+        }
+    }
+    with pytest.raises(
+        MissingConfigOptionError,
+        match=re.escape(
+            "Configuration option 'settings.output_format' is not defined anywhere, "
+            "have you forgotten to set it in a configuration file, or "
+            "environmental variable?"
+        ),
+    ):
+        TEST_PARSER["settings"]["output_format"]
+
+
+def test_only_in_slice(tmp_files):
+    tmp_folder = tmp_files(
+        {
+            "config.toml": dedent(
+                """\
+                [settings]
+                [connections.snowflake]
+                account = "snowflake"
+                user = "snowball"
+                password = "password"
+                """
+            ),
+        }
+    )
+    TEST_PARSER = ConfigManager(
+        name="root_parser",
+        file_path=tmp_folder / "config.toml",
+        _slices=(
+            ConfigSlice(
+                tmp_folder / "connections.toml",
+                ConfigSliceOptions(
+                    only_in_slice=True,
+                ),
+                "connections",
+            ),
+        ),
+    )
+    TEST_PARSER.add_option(
+        name="connections",
+    )
+    settings_parser = ConfigManager(
+        name="settings",
+    )
+    settings_parser.add_option(
+        name="output_format",
+        choices=("json", "yaml", "toml"),
+    )
+    TEST_PARSER.add_subparser(settings_parser)
+    with pytest.raises(
+        ConfigSourceError,
+        match="Configuration option 'connections' is not defined.*",
+    ):
+        TEST_PARSER["connections"]
+
+
+def test_simple_nesting(monkeypatch, tmp_path):
+    c1 = ConfigManager(name="test", file_path=tmp_path / "config.toml")
+    c2 = ConfigManager(name="sb")
+    c3 = ConfigManager(name="sb")
+    c3.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c2.add_subparser(c3)
+    c1.add_subparser(c2)
+    with monkeypatch.context() as m:
+        m.setenv("SNOWFLAKE_SB_SB_B", "TrUe")
+        assert c1["sb"]["sb"]["b"] is True
+
+
+def test_complicated_nesting(monkeypatch, tmp_path):
+    c_file = tmp_path / "config.toml"
+    c1 = ConfigManager(file_path=c_file, name="root_parser")
+    c2 = ConfigManager(file_path=tmp_path / "config2.toml", name="sp")
+    c2.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c1.add_subparser(c2)
+    c_file.write_text(
+        dedent(
+            """\
+            [connections.default]
+            user="testuser"
+            account="testaccount"
+            password="testpassword"
+
+            [sp]
+            b = true
+            """
+        )
+    )
+    assert c1["sp"]["b"] is True
+
+
+def test_error_missing_file_path():
+    with pytest.raises(
+        ConfigManagerError,
+        match="ConfigManager is trying to read config file," " but it doesn't have one",
+    ):
+        ConfigManager(name="test_parser").read_config()
+
+
+def test_error_invalid_toml(tmp_path):
+    c_file = tmp_path / "c.toml"
+    c_file.write_text(
+        dedent(
+            """\
+            invalid toml file
+            """
+        )
+    )
+    with pytest.raises(
+        ConfigSourceError,
+        match=re.escape(f"An unknown error happened while loading '{str(c_file)}'"),
+    ):
+        ConfigManager(
+            name="test_parser",
+            file_path=c_file,
+        ).read_config()
+
+
+def test_error_child_conflict():
+    cp = ConfigManager(name="test_parser")
+    cp.add_subparser(ConfigManager(name="b"))
+    with pytest.raises(
+        ConfigManagerError,
+        match="'b' sub-manager, or option conflicts with a child element of 'test_parser'",
+    ):
+        cp.add_option(name="b")
+
+
+def test_explicit_env_name(monkeypatch):
+    rnd_string = random_string(5)
+    toml_value = dedent(
+        f"""\
+        text = "{rnd_string}"
+        """
+    )
+    TEST_PARSER = ConfigManager(
+        name="test_parser",
+    )
+
+    from tomlkit import parse
+
+    TEST_PARSER.add_option(name="connections", parse_str=parse, env_name="CONNECTIONS")
+    with monkeypatch.context() as m:
+        m.setenv("CONNECTIONS", toml_value)
+        assert TEST_PARSER["connections"] == {"text": rnd_string}
+
+
+def test_error_contains(monkeypatch):
+    tp = ConfigManager(
+        name="test_parser",
+    )
+    tp.add_option(name="output_format", choices=("json", "csv"))
+    with monkeypatch.context() as m:
+        m.setenv("SNOWFLAKE_OUTPUT_FORMAT", "toml")
+        with pytest.raises(
+            ConfigSourceError,
+            match="The value of output_format read from environment variable "
+            "is not part of",
+        ):
+            tp["output_format"]
+
+
+def test_error_missing_item():
+    tp = ConfigManager(
+        name="test_parser",
+    )
+    with pytest.raises(
+        ConfigSourceError,
+        match="No ConfigManager, or ConfigOption can be found with the name 'asd'",
+    ):
+        tp["asd"]
+
+
+def test_error_missing_fp():
+    tp = ConfigManager(
+        name="test_parser",
+    )
+    with pytest.raises(
+        ConfigManagerError,
+        match="ConfigManager is trying to read config file, but it doesn't have one",
+    ):
+        tp.read_config()
+
+
+def test_missing_config_file(tmp_path):
+    config_file = tmp_path / "config.toml"
+    cm = ConfigManager(name="test", file_path=config_file)
+    cm.add_option(name="output_format", choices=("json", "yaml"))
+    with raises(
+        MissingConfigOptionError,
+        match="Configuration option 'output_format' is not defined anywhere.*",
+    ):
+        cm["output_format"]
+
+
+def test_missing_config_files_sliced(tmp_path):
+    config_file = tmp_path / "config.toml"
+    connections_file = tmp_path / "connections.toml"
+    cm = ConfigManager(
+        name="test",
+        file_path=config_file,
+        _slices=(ConfigSlice(connections_file, ConfigSliceOptions(), "connections"),),
+    )
+    cm.add_option(
+        name="connections",
+    )
+    with raises(
+        MissingConfigOptionError,
+        match="Configuration option 'connections' is not defined anywhere.*",
+    ):
+        cm["connections"]
+
+
+def test_error_missing_fp_retrieve():
+    tp = ConfigManager(
+        name="test_parser",
+    )
+    tp.add_option(name="option")
+    with pytest.raises(
+        ConfigManagerError,
+        match="Root manager 'test_parser' is missing file_path",
+    ):
+        tp["option"]
+
+
+@pytest.mark.parametrize("version", (None, "1"))
+def test_sf_dirs(tmp_path, version):
+    appname = random_string(5)
+    assert (
+        SFPlatformDirs(
+            str(tmp_path),
+            appname=appname,
+            appauthor=False,
+            version=version,
+            ensure_exists=True,
+        ).user_config_path
+        == tmp_path
+    )
+
+
+def test_config_file_resolution_sfdirs_default():
+    default_loc = os.path.expanduser("~/.snowflake")
+    existed_before = os.path.exists(default_loc)
+    os.makedirs(default_loc, exist_ok=True)
+    try:
+        assert isinstance(_resolve_platform_dirs(), SFPlatformDirs)
+    finally:
+        if not existed_before:
+            shutil.rmtree(default_loc)
+
+
+def test_config_file_resolution_sfdirs_nondefault(tmp_path, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv("SNOWFLAKE_HOME", str(tmp_path))
+        assert isinstance(_resolve_platform_dirs(), SFPlatformDirs)
+
+
+def test_config_file_resolution_non_sfdirs(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_HOME", raising=False)
+        assert not isinstance(_resolve_platform_dirs(), SFPlatformDirs)
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no getuid on Windows")
+def test_warn_config_file_owner(tmp_path, monkeypatch):
+    c_file = tmp_path / "config.toml"
+    c1 = ConfigManager(file_path=c_file, name="root_parser")
+    c1.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c_file.write_text(
+        dedent(
+            """\
+            b = true
+            """
+        )
+    )
+    c_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    with mock.patch("os.getuid", return_value=os.getuid() + 1):
+        with warnings.catch_warnings(record=True) as c:
+            assert c1["b"] is True
+        assert len(c) == 1
+        assert (
+            str(c[0].message)
+            == f"Bad owner or permissions on {str(c_file)}"
+            + f". To change owner, run `chown $USER {str(c_file)}`. To restrict permissions, run `chmod 0600 {str(c_file)}`."
+        )
+
+
+def test_warn_config_file_permissions(tmp_path):
+    c_file = tmp_path / "config.toml"
+    c1 = ConfigManager(file_path=c_file, name="root_parser")
+    c1.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c_file.write_text(
+        dedent(
+            """\
+            b = true
+            """
+        )
+    )
+    c_file.chmod(stat.S_IMODE(c_file.stat().st_mode) | stat.S_IROTH)
+    with warnings.catch_warnings(record=True) as c:
+        assert c1["b"] is True
+    assert len(c) == 1
+    chmod_message = (
+        f". To change owner, run `chown $USER {str(c_file)}`. To restrict permissions, run `chmod 0600 {str(c_file)}`."
+        if not IS_WINDOWS
+        else ""
+    )
+    assert (
+        str(c[0].message)
+        == f"Bad owner or permissions on {str(c_file)}" + chmod_message
+    )
+
+
+def test_configoption_missing_root_manager():
+    with pytest.raises(
+        TypeError,
+        match="_root_manager cannot be None",
+    ):
+        ConfigOption(
+            name="test_option",
+            _nest_path=["test_option"],
+            _root_manager=None,
+        )
+
+
+def test_configoption_missing_nest_path():
+    with pytest.raises(
+        TypeError,
+        match="_nest_path cannot be None",
+    ):
+        ConfigOption(
+            name="test_option",
+            _nest_path=None,
+            _root_manager=ConfigManager(name="test_manager"),
+        )
+
+
+def test_deprecationwarning_sub_parsers():
+    with warnings.catch_warnings(record=True) as w:
+        assert ConfigManager(name="test_cm")._sub_managers == {}
+        assert len(w) == 0
+        assert ConfigManager(name="test_cm")._sub_parsers == {}
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "_sub_parsers has been deprecated, use _sub_managers instead"
+    )
+
+
+def test_deprecationwarning_add_subparser():
+    with warnings.catch_warnings(record=True) as w:
+        ConfigManager(name="test_cm").add_submanager(ConfigManager(name="test_cm2"))
+        assert len(w) == 0
+        ConfigManager(name="test_cm").add_subparser(ConfigManager(name="test_cm3"))
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "add_subparser has been deprecated, use add_submanager instead"
+    )
+
+
+def test_deprecationwarning_config_parser():
+    from snowflake.connector import config_manager
+
+    with warnings.catch_warnings(record=True) as w:
+        config_manager.CONFIG_MANAGER
+        assert len(w) == 0
+        config_manager.CONFIG_PARSER
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert (
+        str(w[-1].message)
+        == "CONFIG_PARSER has been deprecated, use CONFIG_MANAGER instead"
+    )
+    assert config_manager.CONFIG_MANAGER is config_manager.CONFIG_PARSER
+
+
+def test_configoption_default_value(tmp_path, monkeypatch):
+    env_name = random_string(
+        5,
+        "SF_TEST_OPTION_",
+        choices=string.ascii_uppercase,
+    )
+    conf_val = random_string(5)
+    cm = ConfigManager(
+        name="test_manager",
+        file_path=tmp_path / "config.toml",
+    )
+    cm.add_option(
+        name="test_option",
+        env_name=env_name,
+        default=conf_val,
+    )
+    assert cm["test_option"] == conf_val
+    env_value = random_string(5)
+    with monkeypatch.context() as c:
+        c.setenv(env_name, env_value)
+        assert cm["test_option"] == env_value
+
+
+def test_defaultconnectionname(tmp_path, monkeypatch):
+    c_file = tmp_path / "config.toml"
+    old_path = CONFIG_MANAGER.file_path
+    CONFIG_MANAGER.file_path = c_file
+    CONFIG_MANAGER.conf_file_cache = None
+    try:
+        with monkeypatch.context() as m:
+            m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+            assert CONFIG_MANAGER["default_connection_name"] == "default"
+        env_val = random_string(5, "DEF_CONN_")
+        with monkeypatch.context() as m:
+            m.setenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", env_val)
+            assert CONFIG_MANAGER["default_connection_name"] == env_val
+        assert CONFIG_MANAGER.file_path is not None
+        con_name = random_string(5, "conn_")
+        c_file.write_text(
+            dedent(
+                f"""\
+                default_connection_name = "{con_name}"
+                """
+            )
+        )
+        # re-cache config file from disk
+        CONFIG_MANAGER.file_path = c_file
+        CONFIG_MANAGER.conf_file_cache = None
+        assert CONFIG_MANAGER["default_connection_name"] == con_name
+    finally:
+        CONFIG_MANAGER.file_path = old_path
+        CONFIG_MANAGER.conf_file_cache = None

--- a/test/unit_async/test_connection.py
+++ b/test/unit_async/test_connection.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from textwrap import dedent
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import snowflake.connector
+from snowflake.connector.errors import (
+    Error,
+    ForbiddenError,
+    OperationalError,
+    ProgrammingError,
+)
+
+from ..randomize import random_string
+from .mock_utils import mock_request_with_action, zero_backoff
+
+try:
+    from snowflake.connector.auth import (
+        AuthByDefault,
+        AuthByOAuth,
+        AuthByOkta,
+        AuthByWebBrowser,
+    )
+except ImportError:
+    AuthByDefault = AuthByOkta = AuthByOAuth = AuthByWebBrowser = MagicMock
+
+try:  # pragma: no cover
+    from snowflake.connector.auth import AuthByUsrPwdMfa
+    from snowflake.connector.config_manager import CONFIG_MANAGER
+    from snowflake.connector.constants import ENV_VAR_PARTNER, QueryStatus
+except ImportError:
+    ENV_VAR_PARTNER = "SF_PARTNER"
+    QueryStatus = CONFIG_MANAGER = None
+
+    class AuthByUsrPwdMfa(AuthByDefault):
+        def __init__(self, password: str, mfa_token: str) -> None:
+            pass
+
+
+def fake_connector(**kwargs) -> snowflake.connector.SnowflakeConnection:
+    return snowflake.connector.connect(
+        user="user",
+        account="account",
+        password="testpassword",
+        database="TESTDB",
+        warehouse="TESTWH",
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def mock_post_requests(monkeypatch):
+    request_body = {}
+
+    def mock_post_request(request, url, headers, json_body, **kwargs):
+        nonlocal request_body
+        request_body.update(json.loads(json_body))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+                "idToken": None,
+                "parameters": [{"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}],
+            },
+        }
+
+    monkeypatch.setattr(
+        snowflake.connector.network.SnowflakeRestful, "_post_request", mock_post_request
+    )
+
+    return request_body
+
+
+def test_connect_with_service_name(mock_post_requests):
+    assert fake_connector().service_name == "FAKE_SERVICE_NAME"
+
+
+@pytest.mark.skip(reason="Mock doesn't work as expected.")
+@patch("snowflake.connector.network.SnowflakeRestful._post_request")
+def test_connection_ignore_exception(mockSnowflakeRestfulPostRequest):
+    def mock_post_request(url, headers, json_body, **kwargs):
+        global mock_cnt
+        ret = None
+        if mock_cnt == 0:
+            # return from /v1/login-request
+            ret = {
+                "success": True,
+                "message": None,
+                "data": {
+                    "token": "TOKEN",
+                    "masterToken": "MASTER_TOKEN",
+                    "idToken": None,
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}
+                    ],
+                },
+            }
+        elif mock_cnt == 1:
+            ret = {
+                "success": False,
+                "message": "Session gone",
+                "data": None,
+                "code": 390111,
+            }
+        mock_cnt += 1
+        return ret
+
+    # POST requests mock
+    mockSnowflakeRestfulPostRequest.side_effect = mock_post_request
+
+    global mock_cnt
+    mock_cnt = 0
+
+    account = "testaccount"
+    user = "testuser"
+
+    # connection
+    con = snowflake.connector.connect(
+        account=account,
+        user=user,
+        password="testpassword",
+        database="TESTDB",
+        warehouse="TESTWH",
+    )
+    # Test to see if closing connection works or raises an exception. If an exception is raised, test will fail.
+    con.close()
+
+
+@pytest.mark.skipolddriver
+def test_is_still_running():
+    """Checks that is_still_running returns expected results."""
+    statuses = [
+        (QueryStatus.RUNNING, True),
+        (QueryStatus.ABORTING, False),
+        (QueryStatus.SUCCESS, False),
+        (QueryStatus.FAILED_WITH_ERROR, False),
+        (QueryStatus.ABORTED, False),
+        (QueryStatus.QUEUED, True),
+        (QueryStatus.FAILED_WITH_INCIDENT, False),
+        (QueryStatus.DISCONNECTED, False),
+        (QueryStatus.RESUMING_WAREHOUSE, True),
+        (QueryStatus.QUEUED_REPARING_WAREHOUSE, True),
+        (QueryStatus.RESTARTED, False),
+        (QueryStatus.BLOCKED, True),
+        (QueryStatus.NO_DATA, True),
+    ]
+    for status, expected_result in statuses:
+        assert (
+            snowflake.connector.SnowflakeConnection.is_still_running(status)
+            == expected_result
+        )
+
+
+@pytest.mark.skipolddriver
+def test_partner_env_var(mock_post_requests):
+    PARTNER_NAME = "Amanda"
+
+    with patch.dict(os.environ, {ENV_VAR_PARTNER: PARTNER_NAME}):
+        assert fake_connector().application == PARTNER_NAME
+
+    assert (
+        mock_post_requests["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"] == PARTNER_NAME
+    )
+
+
+@pytest.mark.skipolddriver
+def test_imported_module(mock_post_requests):
+    with patch.dict(sys.modules, {"streamlit": "foo"}):
+        assert fake_connector().application == "streamlit"
+
+    assert (
+        mock_post_requests["data"]["CLIENT_ENVIRONMENT"]["APPLICATION"] == "streamlit"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_class",
+    (
+        pytest.param(
+            type("auth_class", (AuthByDefault,), {})("my_secret_password"),
+            id="AuthByDefault",
+        ),
+        pytest.param(
+            type("auth_class", (AuthByOAuth,), {})("my_token"),
+            id="AuthByOAuth",
+        ),
+        pytest.param(
+            type("auth_class", (AuthByOkta,), {})("Python connector"),
+            id="AuthByOkta",
+        ),
+        pytest.param(
+            type("auth_class", (AuthByUsrPwdMfa,), {})("password", "mfa_token"),
+            id="AuthByUsrPwdMfa",
+        ),
+        pytest.param(
+            type("auth_class", (AuthByWebBrowser,), {})(None, None),
+            id="AuthByWebBrowser",
+        ),
+    ),
+)
+def test_negative_custom_auth(auth_class):
+    """Tests that non-AuthByKeyPair custom auth is not allowed."""
+    with pytest.raises(
+        TypeError,
+        match="auth_class must be a child class of AuthByKeyPair",
+    ):
+        snowflake.connector.connect(
+            account="account",
+            user="user",
+            auth_class=auth_class,
+        )
+
+
+def test_missing_default_connection(monkeypatch, tmp_path):
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match="Default connection with name 'default' cannot be found, known ones are \\[\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conf_file(monkeypatch, tmp_path):
+    connection_name = random_string(5)
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        dedent(
+            f"""\
+            default_connection_name = "{connection_name}"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match=f"Default connection with name '{connection_name}' cannot be found, known ones are \\[\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conn_file(monkeypatch, tmp_path):
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    connections_file.write_text(
+        dedent(
+            """\
+            [con_a]
+            user = "test user"
+            account = "test account"
+            password = "test password"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match="Default connection with name 'default' cannot be found, known ones are \\['con_a'\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+def test_missing_default_connection_conf_conn_file(monkeypatch, tmp_path):
+    connection_name = random_string(5)
+    connections_file = tmp_path / "connections.toml"
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        dedent(
+            f"""\
+            default_connection_name = "{connection_name}"
+            """
+        )
+    )
+    connections_file.write_text(
+        dedent(
+            """\
+            [con_a]
+            user = "test user"
+            account = "test account"
+            password = "test password"
+            """
+        )
+    )
+    with monkeypatch.context() as m:
+        m.delenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", raising=False)
+        m.delenv("SNOWFLAKE_CONNECTIONS", raising=False)
+        m.setattr(CONFIG_MANAGER, "conf_file_cache", None)
+        m.setattr(CONFIG_MANAGER, "file_path", config_file)
+
+        with pytest.raises(
+            Error,
+            match=f"Default connection with name '{connection_name}' cannot be found, known ones are \\['con_a'\\]",
+        ):
+            snowflake.connector.connect(connections_file_path=connections_file)
+
+
+@pytest.mark.asyncio
+def test_invalid_backoff_policy():
+    with pytest.raises(ProgrammingError):
+        # zero_backoff() is a generator, not a generator function
+        _ = fake_connector(backoff_policy=zero_backoff())
+
+    with pytest.raises(ProgrammingError):
+        # passing a non-generator function should not work
+        _ = fake_connector(backoff_policy=lambda: None)
+
+    with pytest.raises(ForbiddenError):
+        # passing a generator function should make it pass config and error during connection
+        _ = fake_connector(backoff_policy=zero_backoff)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("next_action", ("RETRY", "ERROR"))
+@patch("aiohttp.ClientSession.request")
+def test_handle_timeout(mockSessionRequest, next_action):
+    mockSessionRequest.side_effect = mock_request_with_action(next_action, sleep=5)
+
+    with pytest.raises(OperationalError):
+        # no backoff for testing
+        _ = fake_connector(
+            login_timeout=9,
+            backoff_policy=zero_backoff,
+        )
+
+    # authenticator should be the only retry mechanism for login requests
+    # 9 seconds should be enough for authenticator to attempt twice
+    # however, loosen restrictions to avoid thread scheduling causing failure
+    assert 1 < mockSessionRequest.call_count < 4
+
+
+def test__get_private_bytes_from_file(tmp_path: Path):
+    private_key_file = tmp_path / "key.pem"
+
+    private_key = rsa.generate_private_key(
+        backend=default_backend(), public_exponent=65537, key_size=2048
+    )
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    pkb = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    private_key_file.write_bytes(private_key_pem)
+
+    private_key = snowflake.connector.connection._get_private_bytes_from_file(
+        private_key_file=str(private_key_file)
+    )
+
+    assert pkb == private_key
+
+
+def test_private_key_file_reading(tmp_path: Path):
+    key_file = tmp_path / "key.pem"
+
+    private_key = rsa.generate_private_key(
+        backend=default_backend(), public_exponent=65537, key_size=2048
+    )
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    key_file.write_bytes(private_key_pem)
+
+    pkb = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    exc_msg = "stop execution"
+
+    with mock.patch(
+        "snowflake.connector.auth.keypair.AuthByKeyPair.__init__",
+        side_effect=Exception(exc_msg),
+    ) as m:
+        with pytest.raises(
+            Exception,
+            match=exc_msg,
+        ):
+            snowflake.connector.connect(
+                account="test_account",
+                user="test_user",
+                private_key_file=str(key_file),
+            )
+    assert m.call_count == 1
+    assert m.call_args_list[0].kwargs["private_key"] == pkb

--- a/test/unit_async/test_connection_diagnostic.py
+++ b/test/unit_async/test_connection_diagnostic.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.skipolddriver  # old test driver tests won't run this module
+
+
+import snowflake.connector
+
+try:
+    from snowflake.connector.connection_diagnostic import (
+        ConnectionDiagnostic,
+        _decode_dict,
+    )
+except ImportError:
+    pass
+
+
+def test_https_host_report(caplog):
+    connection_diag = ConnectionDiagnostic(
+        account="test", host="test.snowflakecomputing.com"
+    )
+    https_host_report = connection_diag._ConnectionDiagnostic__https_host_report
+    https_host_report(
+        host="client-telemetry.snowflakecomputing.com",
+        port=443,
+        host_type="OUT_OF_BAND_TELEMETRY",
+    )
+
+    assert "DNS:client-telemetry.snowflakecomputing.com" in ".".join(
+        connection_diag.test_results["OUT_OF_BAND_TELEMETRY"]
+    )
+
+
+def test_decode_dict():
+    test_dict = {b"CN": b"client-telemetry.snowflakecomputing.com"}
+    result = _decode_dict(test_dict)
+
+    assert result == {
+        "CN": "client-telemetry.snowflakecomputing.com"
+    }, "_decode_dict method failed, binary dict not converted."
+
+
+@pytest.mark.asyncio
+def test_exception_raise_during_diag_fail(monkeypatch, caplog):
+    def mock_run_post_test(self):
+        raise ValueError("Diagnostic Test Failure")
+
+    monkeypatch.setattr(
+        snowflake.connector.connection_diagnostic.ConnectionDiagnostic,
+        "run_post_test",
+        mock_run_post_test,
+    )
+
+    try:
+        snowflake.connector.connect(
+            account="testaccount",
+            user="testuser",
+            password="testpassword",
+            database="TESTDB",
+            warehouse="TESTWH",
+            enable_connection_diag=True,
+        )
+    except BaseException:
+        pass
+
+    assert "Diagnostic Test Failure" in caplog.text

--- a/test/unit_async/test_construct_hostname.py
+++ b/test/unit_async/test_construct_hostname.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from snowflake.connector.util_text import construct_hostname
+
+
+def test_construct_hostname_basic():
+    assert (
+        construct_hostname("eu-central-1", "account1")
+        == "account1.eu-central-1.snowflakecomputing.com"
+    )
+
+    assert construct_hostname("", "account1") == "account1.snowflakecomputing.com"
+
+    assert construct_hostname(None, "account1") == "account1.snowflakecomputing.com"
+
+    assert (
+        construct_hostname("as-east-3", "account1")
+        == "account1.as-east-3.snowflakecomputing.com"
+    )
+
+    assert (
+        construct_hostname("as-east-3", "account1.eu-central-1")
+        == "account1.as-east-3.snowflakecomputing.com"
+    )
+
+    assert (
+        construct_hostname("", "account1.eu-central-1")
+        == "account1.eu-central-1.snowflakecomputing.com"
+    )
+
+    assert (
+        construct_hostname(None, "account1.eu-central-1")
+        == "account1.eu-central-1.snowflakecomputing.com"
+    )
+
+    assert (
+        construct_hostname(None, "account1-jkabfvdjisoa778wqfgeruishafeuw89q.global")
+        == "account1-jkabfvdjisoa778wqfgeruishafeuw89q.global.snowflakecomputing.com"
+    )

--- a/test/unit_async/test_converter.py
+++ b/test/unit_async/test_converter.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from logging import getLogger
+
+import pytest
+
+from snowflake.connector import ProgrammingError
+from snowflake.connector.connection import DefaultConverterClass
+from snowflake.connector.converter import SnowflakeConverter
+from snowflake.connector.converter_snowsql import SnowflakeConverterSnowSQL
+
+logger = getLogger(__name__)
+
+ConverterSnowSQL = SnowflakeConverterSnowSQL
+
+
+def test_is_dst():
+    """SNOW-6020: Failed to convert to local time during DST is being changed."""
+    # DST to non-DST
+    convClass = DefaultConverterClass()
+    conv = convClass()
+    conv.set_parameter("TIMEZONE", "America/Los_Angeles")
+
+    col_meta = {
+        "name": "CREATED_ON",
+        "type": 6,
+        "length": None,
+        "precision": None,
+        "scale": 3,
+        "nullable": True,
+    }
+    m = conv.to_python_method("TIMESTAMP_LTZ", col_meta)
+    ret = m("1414890189.000")
+
+    assert (
+        str(ret) == "2014-11-01 18:03:09-07:00"
+    ), "Timestamp during from DST to non-DST"
+
+    # non-DST to DST
+    col_meta = {
+        "name": "CREATED_ON",
+        "type": 6,
+        "length": None,
+        "precision": None,
+        "scale": 3,
+        "nullable": True,
+    }
+    m = conv.to_python_method("TIMESTAMP_LTZ", col_meta)
+    ret = m("1425780189.000")
+
+    assert (
+        str(ret) == "2015-03-07 18:03:09-08:00"
+    ), "Timestamp during from non-DST to DST"
+
+
+def test_more_timestamps():
+    conv = ConverterSnowSQL()
+    conv.set_parameter("TIMESTAMP_NTZ_OUTPUT_FORMAT", "YYYY-MM-DD HH24:MI:SS.FF9")
+    m = conv.to_python_method("TIMESTAMP_NTZ", {"scale": 9})
+    assert m("-2208943503.876543211") == "1900-01-01 12:34:56.123456789"
+    assert m("-2208943503.000000000") == "1900-01-01 12:34:57.000000000"
+    assert m("-2208943503.012000000") == "1900-01-01 12:34:56.988000000"
+
+    conv.set_parameter("TIMESTAMP_NTZ_OUTPUT_FORMAT", "YYYY-MM-DD HH24:MI:SS.FF9")
+    m = conv.to_python_method("TIMESTAMP_NTZ", {"scale": 7})
+    assert m("-2208943503.8765432") == "1900-01-01 12:34:56.123456800"
+    assert m("-2208943503.0000000") == "1900-01-01 12:34:57.000000000"
+    assert m("-2208943503.0120000") == "1900-01-01 12:34:56.988000000"
+
+
+def test_converter_to_snowflake_error():
+    converter = SnowflakeConverter()
+    with pytest.raises(
+        ProgrammingError, match=r"Binding data in type \(bogus\) is not supported"
+    ):
+        converter._bogus_to_snowflake("Bogus")
+
+
+def test_converter_to_snowflake_bindings_error():
+    converter = SnowflakeConverter()
+    with pytest.raises(
+        ProgrammingError,
+        match=r"Binding data in type \(somethingsomething\) is not supported",
+    ):
+        converter._somethingsomething_to_snowflake_bindings("Bogus")

--- a/test/unit_async/test_cursor.py
+++ b/test/unit_async/test_cursor.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snowflake.connector.connection import SnowflakeConnection
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.errors import ServiceUnavailableError
+
+try:
+    from snowflake.connector.constants import FileTransferType
+except ImportError:
+    from enum import Enum
+
+    class FileTransferType(Enum):
+        GET = "get"
+        PUT = "put"
+
+
+class FakeConnection(SnowflakeConnection):
+    def __init__(self):
+        self._log_max_query_length = 0
+        self._reuse_results = None
+
+
+@pytest.mark.parametrize(
+    "sql,_type",
+    (
+        ("", None),
+        ("select 1;", None),
+        ("PUT file:///tmp/data/mydata.csv @my_int_stage;", FileTransferType.PUT),
+        ("GET @%mytable file:///tmp/data/;", FileTransferType.GET),
+        ("/**/PUT file:///tmp/data/mydata.csv @my_int_stage;", FileTransferType.PUT),
+        ("/**/ GET @%mytable file:///tmp/data/;", FileTransferType.GET),
+        pytest.param(
+            "/**/\n"
+            + "\t/*/get\t*/\t/**/\n" * 10000
+            + "\t*/get @~/test.csv file:///tmp\n",
+            None,
+            id="long_incorrect",
+        ),
+        pytest.param(
+            "/**/\n" + "\t/*/put\t*/\t/**/\n" * 10000 + "put file:///tmp/data.csv @~",
+            FileTransferType.PUT,
+            id="long_correct",
+        ),
+    ),
+)
+def test_get_filetransfer_type(sql, _type):
+    assert SnowflakeCursor.get_file_transfer_type(sql) == _type
+
+
+def test_cursor_attribute():
+    fake_conn = FakeConnection()
+    cursor = SnowflakeCursor(fake_conn)
+    assert cursor.lastrowid is None
+
+
+@patch("snowflake.connector.cursor.SnowflakeCursor._SnowflakeCursor__cancel_query")
+def test_cursor_execute_timeout(mockCancelQuery):
+    def mock_cmd_query(*args, **kwargs):
+        time.sleep(10)
+        raise ServiceUnavailableError()
+
+    fake_conn = FakeConnection()
+    fake_conn.cmd_query = mock_cmd_query
+    fake_conn._rest = MagicMock()
+    fake_conn._paramstyle = MagicMock()
+    fake_conn._next_sequence_counter = MagicMock()
+
+    cursor = SnowflakeCursor(fake_conn)
+
+    with pytest.raises(ServiceUnavailableError):
+        cursor.execute(
+            command="SELECT * FROM nonexistent",
+            timeout=1,
+        )
+
+    # query cancel request should be sent upon timeout
+    assert mockCancelQuery.called

--- a/test/unit_async/test_datetime.py
+++ b/test/unit_async/test_datetime.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+
+import pytest
+
+from snowflake.connector.compat import IS_WINDOWS
+from snowflake.connector.sfdatetime import SnowflakeDateTime, SnowflakeDateTimeFormat
+
+
+def test_basic_datetime_format():
+    """Datetime format basic tests."""
+    # date
+    value = datetime(2014, 11, 30)
+    formatter = SnowflakeDateTimeFormat("YYYY-MM-DD")
+    assert formatter.format(value) == "2014-11-30"
+
+    # date time => date
+    value = datetime(2014, 11, 30, 12, 31, 45)
+    formatter = SnowflakeDateTimeFormat("YYYY-MM-DD")
+    assert formatter.format(value) == "2014-11-30"
+
+    # date time => date time
+    value = datetime(2014, 11, 30, 12, 31, 45)
+    formatter = SnowflakeDateTimeFormat('YYYY-MM-DD"T"HH24:MI:SS')
+    assert formatter.format(value) == "2014-11-30T12:31:45"
+
+    # date time => date time in microseconds with 4 precision
+    value = datetime(2014, 11, 30, 12, 31, 45, microsecond=987654)
+    formatter = SnowflakeDateTimeFormat('YYYY-MM-DD"T"HH24:MI:SS.FF4')
+    assert formatter.format(value) == "2014-11-30T12:31:45.9876"
+
+    # date time => date time in microseconds with full precision up to
+    # microseconds
+    value = datetime(2014, 11, 30, 12, 31, 45, microsecond=987654)
+    formatter = SnowflakeDateTimeFormat('YYYY-MM-DD"T"HH24:MI:SS.FF')
+    assert formatter.format(value) == "2014-11-30T12:31:45.987654"
+
+
+def test_datetime_with_smaller_milliseconds():
+    # date time => date time in microseconds with full precision up to
+    # microseconds
+    value = datetime(2014, 11, 30, 12, 31, 45, microsecond=123)
+    formatter = SnowflakeDateTimeFormat('YYYY-MM-DD"T"HH24:MI:SS.FF9')
+    assert formatter.format(value) == "2014-11-30T12:31:45.000123"
+
+
+def test_datetime_format_negative():
+    """Datetime format negative."""
+    value = datetime(2014, 11, 30, 12, 31, 45, microsecond=987654)
+    formatter = SnowflakeDateTimeFormat('YYYYYYMMMDDDDD"haha"hoho"hihi"H12HHH24MI')
+    assert formatter.format(value) == "20141411M3030DhahaHOHOhihiH1212H2431"
+
+
+def test_struct_time_format():
+    # struct_time for general use
+    value = time.strptime("30 Sep 01 11:20:30", "%d %b %y %H:%M:%S")
+    formatter = SnowflakeDateTimeFormat('YYYY-MM-DD"T"HH24:MI:SS.FF')
+    assert formatter.format(value) == "2001-09-30T11:20:30.0"
+
+    # struct_time encapsulated in SnowflakeDateTime. Mainly used by SnowSQL
+    value = SnowflakeDateTime(
+        time.strptime("30 Sep 01 11:20:30", "%d %b %y %H:%M:%S"), nanosecond=0, scale=1
+    )
+    formatter = SnowflakeDateTimeFormat(
+        'YYYY-MM-DD"T"HH24:MI:SS.FF', datetime_class=SnowflakeDateTime
+    )
+    assert formatter.format(value) == "2001-09-30T11:20:30.0"
+
+    # format without fraction of seconds
+    formatter = SnowflakeDateTimeFormat(
+        'YYYY-MM-DD"T"HH24:MI:SS', datetime_class=SnowflakeDateTime
+    )
+    assert formatter.format(value) == "2001-09-30T11:20:30"
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="not supported yet")
+def test_struct_time_format_extreme_large():
+    # extreme large epoch time
+    value = SnowflakeDateTime(time.gmtime(14567890123567), nanosecond=0, scale=1)
+    formatter = SnowflakeDateTimeFormat(
+        'YYYY-MM-DD"T"HH24:MI:SS.FF', datetime_class=SnowflakeDateTime
+    )
+    assert formatter.format(value) == "463608-01-23T09:26:07.0"

--- a/test/unit_async/test_dbapi.py
+++ b/test/unit_async/test_dbapi.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from snowflake.connector.dbapi import Binary
+
+
+def test_Binary():
+    assert Binary(b"foo") == b"foo"

--- a/test/unit_async/test_encryption_util.py
+++ b/test/unit_async/test_encryption_util.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import codecs
+import glob
+import os
+from os import path
+
+from snowflake.connector import encryption_util
+from snowflake.connector.constants import UTF8
+from snowflake.connector.encryption_util import SnowflakeEncryptionUtil
+from snowflake.connector.file_util import SnowflakeFileUtil
+
+try:  # pragma: no cover
+    from snowflake.connector.storage_client import SnowflakeFileEncryptionMaterial
+except ImportError:  # keep olddrivertest from breaking
+    from snowflake.connector.remote_storage_util import (
+        SnowflakeFileEncryptionMaterial,
+    )
+
+from ..generate_test_files import generate_k_lines_of_n_files
+
+THIS_DIR = path.dirname(path.realpath(__file__))
+
+
+def test_encrypt_decrypt_file(tmp_path):
+    """Encrypts and Decrypts a file."""
+    encryption_material = SnowflakeFileEncryptionMaterial(
+        query_stage_master_key="ztke8tIdVt1zmlQIZm0BMA==",
+        query_id="123873c7-3a66-40c4-ab89-e3722fbccce1",
+        smk_id=3112,
+    )
+    data = "test data"
+    input_file = tmp_path / "test_encrypt_decrypt_file"
+    encrypted_file = None
+    decrypted_file = None
+    try:
+        with input_file.open("w", encoding=UTF8) as fd:
+            fd.write(data)
+
+        (metadata, encrypted_file) = SnowflakeEncryptionUtil.encrypt_file(
+            encryption_material, input_file
+        )
+        decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
+            metadata, encryption_material, encrypted_file
+        )
+
+        contents = ""
+        with codecs.open(decrypted_file, "r", encoding=UTF8) as fd:
+            for line in fd:
+                contents += line
+        assert data == contents, "encrypted and decrypted contents"
+    finally:
+        input_file.unlink()
+        if encrypted_file:
+            os.remove(encrypted_file)
+        if decrypted_file:
+            os.remove(decrypted_file)
+
+
+def test_encrypt_decrypt_large_file(tmpdir):
+    """Encrypts and Decrypts a large file."""
+    encryption_material = SnowflakeFileEncryptionMaterial(
+        query_stage_master_key="ztke8tIdVt1zmlQIZm0BMA==",
+        query_id="123873c7-3a66-40c4-ab89-e3722fbccce1",
+        smk_id=3112,
+    )
+
+    # generates N files
+    number_of_files = 1
+    number_of_lines = 100_000
+    tmp_dir = generate_k_lines_of_n_files(
+        number_of_lines, number_of_files, tmp_dir=str(tmpdir.mkdir("data"))
+    )
+
+    files = glob.glob(os.path.join(tmp_dir, "file*"))
+    input_file = files[0]
+    encrypted_file = None
+    decrypted_file = None
+    try:
+        digest_in, size_in = SnowflakeFileUtil.get_digest_and_size_for_file(input_file)
+        for run_count in range(2):
+            # Test padding cases when size is and is not multiple of block_size
+            if run_count == 1:
+                # second time run, truncate the file to test a different padding case
+                with open(input_file, "wb") as f_in:
+                    if size_in % encryption_util.block_size == 0:
+                        size_in -= 3
+                    else:
+                        size_in -= size_in % encryption_util.block_size
+                    f_in.truncate(size_in)
+                digest_in, size_in = SnowflakeFileUtil.get_digest_and_size_for_file(
+                    input_file
+                )
+
+            (metadata, encrypted_file) = SnowflakeEncryptionUtil.encrypt_file(
+                encryption_material, input_file
+            )
+            decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
+                metadata, encryption_material, encrypted_file
+            )
+
+            digest_dec, size_dec = SnowflakeFileUtil.get_digest_and_size_for_file(
+                decrypted_file
+            )
+            assert size_in == size_dec
+            assert digest_in == digest_dec
+
+    finally:
+        os.remove(input_file)
+        if encrypted_file:
+            os.remove(encrypted_file)
+        if decrypted_file:
+            os.remove(decrypted_file)

--- a/test/unit_async/test_error_arrow_stream.py
+++ b/test/unit_async/test_error_arrow_stream.py
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+from ..helpers import (
+    _arrow_error_stream_chunk_remove_random_length_bytes_test,
+    _arrow_error_stream_chunk_remove_single_byte_test,
+    _arrow_error_stream_random_input_test,
+)
+
+
+@pytest.mark.skipolddriver
+def test_connector_error_base64_stream_chunk_remove_single_byte():
+    _arrow_error_stream_chunk_remove_single_byte_test(use_table_iterator=False)
+
+
+@pytest.mark.skipolddriver
+def test_connector_error_base64_stream_chunk_remove_random_length_bytes():
+    _arrow_error_stream_chunk_remove_random_length_bytes_test(use_table_iterator=False)
+
+
+@pytest.mark.skipolddriver
+def test_connector_error_random_input():
+    _arrow_error_stream_random_input_test(use_table_iterator=False)

--- a/test/unit_async/test_errors.py
+++ b/test/unit_async/test_errors.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from snowflake.connector import errors
+
+
+def test_detecting_duplicate_detail_insertion():
+    sfqid = str(uuid.uuid4())
+    query = "select something_really_buggy from buggy_table"
+    sqlstate = "24000"
+    errno = 123456
+    msg = "Some error happened"
+    expected_msg = re.compile(rf"{errno} \({sqlstate}\): {sfqid}: {msg}")
+    original_ex = errors.ProgrammingError(
+        sqlstate=sqlstate,
+        sfqid=sfqid,
+        query=query,
+        errno=errno,
+        msg=msg,
+    )
+    # Test whether regular exception confirms to what we expect to see
+    assert expected_msg.fullmatch(original_ex.msg)
+
+    # Test whether exception with flag confirms to what we expect to see
+    assert errors.ProgrammingError(
+        msg=original_ex.msg,
+        done_format_msg=True,
+    )
+    # Test whether exception with auto detection confirms to what we expect to see
+    assert errors.ProgrammingError(
+        msg=original_ex.msg,
+    )
+
+
+def test_args():
+    assert errors.Error("msg").args == ("msg",)

--- a/test/unit_async/test_gcs_client.py
+++ b/test/unit_async/test_gcs_client.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+from os import path
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+
+from snowflake.connector import SnowflakeConnection
+from snowflake.connector.constants import SHA256_DIGEST, ResultStatus
+
+try:
+    from snowflake.connector.util_text import random_string
+except ImportError:
+    from ..randomize import random_string
+
+try:
+    from snowflake.connector.errors import RequestExceedMaxRetryError
+    from snowflake.connector.file_transfer_agent import (
+        SnowflakeFileMeta,
+        SnowflakeFileTransferAgent,
+        StorageCredential,
+    )
+    from snowflake.connector.storage_client import METHODS
+    from snowflake.connector.vendored.requests import Response
+except ImportError:
+    # Compatibility for olddriver tests
+    from requests import Response
+
+    SnowflakeFileMeta = dict
+    RequestExceedMaxRetryError = None
+    METHODS = {}
+    megabytes = 1024 * 1024
+
+try:  # pragma: no cover
+    from snowflake.connector.gcs_storage_client import SnowflakeGCSRestClient
+except ImportError:
+    SnowflakeGCSRestClient = None
+
+# We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
+try:
+    from snowflake.connector.vendored import requests
+
+    vendored_request = True
+except ImportError:  # pragma: no cover
+    import requests
+
+    vendored_request = False
+
+THIS_DIR = path.dirname(path.realpath(__file__))
+
+
+@pytest.mark.parametrize("errno", [408, 429, 500, 503])
+def test_upload_retry_errors(errno, tmpdir):
+    """Tests whether retryable errors are handled correctly when upploading."""
+    f_name = str(tmpdir.join("some_file.txt"))
+    resp = requests.Response()
+    resp.status_code = errno
+    meta = SnowflakeFileMeta(
+        name=f_name,
+        src_file_name=f_name,
+        stage_location_type="GCS",
+        presigned_url="some_url",
+        sha256_digest="asd",
+    )
+    if RequestExceedMaxRetryError is not None:
+        mock_connection = mock.create_autospec(SnowflakeConnection)
+        client = SnowflakeGCSRestClient(
+            meta,
+            StorageCredential({}, mock_connection, ""),
+            {},
+            mock_connection,
+            "",
+        )
+    with open(f_name, "w") as f:
+        f.write(random_string(15))
+    if RequestExceedMaxRetryError is None:
+        with mock.patch(
+            "snowflake.connector.vendored.requests.put"
+            if vendored_request
+            else "requests.put",
+            side_effect=requests.exceptions.HTTPError(response=resp),
+        ):
+            SnowflakeGCSUtil.upload_file(f_name, meta, None, 99, 64000)
+            assert isinstance(meta.last_error, requests.exceptions.HTTPError)
+            assert meta.result_status == ResultStatus.NEED_RETRY
+    else:
+        client.data_file = f_name
+
+        if vendored_request:
+            with mock.patch.dict(
+                METHODS,
+                {"PUT": lambda *a, **kw: resp},
+            ):
+                with pytest.raises(RequestExceedMaxRetryError):
+                    # Retry quickly during unit tests
+                    client.SLEEP_UNIT = 0.0
+                    client.upload_chunk(0)
+        else:
+            # Old Driver test specific code
+            with mock.patch("requests.put"):
+                SnowflakeGCSUtil.upload_file(f_name, meta, None, 99, 64000)
+                assert isinstance(meta.last_error, requests.exceptions.HTTPError)
+                assert meta.result_status == ResultStatus.NEED_RETRY
+
+
+def test_upload_uncaught_exception(tmpdir):
+    """Tests whether non-retryable errors are handled correctly when uploading."""
+    f_name = str(tmpdir.join("some_file.txt"))
+    resp = requests.Response()
+    resp.status_code = 501
+    exc = requests.exceptions.HTTPError(response=resp)
+    with open(f_name, "w") as f:
+        f.write(random_string(15))
+    agent = SnowflakeFileTransferAgent(
+        mock.MagicMock(),
+        f"put {f_name} @~",
+        {
+            "data": {
+                "command": "UPLOAD",
+                "src_locations": [f_name],
+                "stageInfo": {
+                    "locationType": "GCS",
+                    "location": "",
+                    "creds": {"AWS_SECRET_KEY": "", "AWS_KEY_ID": ""},
+                    "region": "test",
+                    "endPoint": None,
+                },
+                "localLocation": "/tmp",
+            }
+        },
+    )
+    with mock.patch(
+        "snowflake.connector.gcs_storage_client.SnowflakeGCSRestClient.get_file_header",
+    ), mock.patch(
+        "snowflake.connector.gcs_storage_client.SnowflakeGCSRestClient._upload_chunk",
+        side_effect=exc,
+    ):
+        agent.execute()
+    assert agent._file_metadata[0].error_details is exc
+
+
+@pytest.mark.parametrize("errno", [403, 408, 429, 500, 503])
+def test_download_retry_errors(errno, tmp_path):
+    """Tests whether retryable errors are handled correctly when downloading."""
+    resp = requests.Response()
+    resp.status_code = errno
+    if errno == 403:
+        pytest.skip("This behavior has changed in the move from SDKs")
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": ""}
+    cnx = mock.MagicMock(autospec=SnowflakeConnection)
+    rest_client = SnowflakeGCSRestClient(
+        meta,
+        StorageCredential(
+            creds,
+            cnx,
+            "GET file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        cnx,
+        "GET file:///tmp/file.txt @~",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    rest_client.SLEEP_UNIT = 0
+    with mock.patch.dict(METHODS, GET=mock.MagicMock(return_value=resp)):
+        with pytest.raises(
+            RequestExceedMaxRetryError,
+            match="GET with url .* failed for exceeding maximum retries",
+        ):
+            rest_client.download_chunk(0)
+
+
+@pytest.mark.parametrize("errno", (501, 403))
+def test_download_uncaught_exception(tmp_path, errno):
+    """Tests whether non-retryable errors are handled correctly when downloading."""
+    resp = requests.Response()
+    resp.status_code = errno
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": ""}
+    cnx = mock.MagicMock(autospec=SnowflakeConnection)
+    rest_client = SnowflakeGCSRestClient(
+        meta,
+        StorageCredential(
+            creds,
+            cnx,
+            "GET file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        cnx,
+        "GET file:///tmp/file.txt @~",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    rest_client.SLEEP_UNIT = 0
+    with mock.patch.dict(METHODS, GET=mock.MagicMock(return_value=resp)):
+        with pytest.raises(
+            requests.exceptions.HTTPError,
+        ):
+            rest_client.download_chunk(0)
+
+
+def test_upload_put_timeout(tmp_path, caplog):
+    """Tests whether timeout error is handled correctly when uploading."""
+    caplog.set_level(logging.DEBUG, "snowflake.connector")
+    f_name = str(tmp_path / "some_file.txt")
+    resp = requests.Response()
+    with open(f_name, "w") as f:
+        f.write(random_string(15))
+    agent = SnowflakeFileTransferAgent(
+        mock.Mock(autospec=SnowflakeConnection, connection=None),
+        f"put {f_name} @~",
+        {
+            "data": {
+                "command": "UPLOAD",
+                "src_locations": [f_name],
+                "stageInfo": {
+                    "locationType": "GCS",
+                    "location": "",
+                    "creds": {"AWS_SECRET_KEY": "", "AWS_KEY_ID": ""},
+                    "region": "test",
+                    "endPoint": None,
+                },
+                "localLocation": "/tmp",
+            }
+        },
+    )
+    mocked_put, mocked_head = mock.MagicMock(), mock.MagicMock()
+    mocked_put.side_effect = requests.exceptions.Timeout(response=resp)
+    resp = Response()
+    resp.status_code = 404
+    mocked_head.return_value = resp
+    SnowflakeGCSRestClient.SLEEP_UNIT = 0
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, {"PUT": mocked_put, "HEAD": mocked_head}):
+        agent.execute()
+    assert (
+        "snowflake.connector.storage_client",
+        logging.WARNING,
+        "PUT with url https://storage.googleapis.com//some_file.txt.gz failed for transient error: ",
+    ) in caplog.record_tuples
+    assert (
+        "snowflake.connector.file_transfer_agent",
+        logging.DEBUG,
+        "Chunk 0 of file some_file.txt failed to transfer for unexpected exception PUT with url https://storage.googleapis.com//some_file.txt.gz failed for exceeding maximum retries.",
+    ) in caplog.record_tuples
+
+
+def test_download_timeout(tmp_path, caplog):
+    """Tests whether timeout error is handled correctly when downloading."""
+    timeout_exc = requests.exceptions.Timeout(response=requests.Response())
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": ""}
+    cnx = mock.MagicMock(autospec=SnowflakeConnection)
+    rest_client = SnowflakeGCSRestClient(
+        meta,
+        StorageCredential(
+            creds,
+            cnx,
+            "GET file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        cnx,
+        "GET file:///tmp/file.txt @~",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    rest_client.SLEEP_UNIT = 0
+    with mock.patch.dict(METHODS, GET=mock.MagicMock(side_effect=timeout_exc)):
+        exc = Exception("stop execution")
+        with mock.patch.object(rest_client.credentials, "update", side_effect=exc):
+            with pytest.raises(RequestExceedMaxRetryError):
+                rest_client.download_chunk(0)
+
+
+def test_get_file_header_none_with_presigned_url(tmp_path):
+    """Tests whether default file handle created by get_file_header is as expected."""
+    meta = SnowflakeFileMeta(
+        name=str(tmp_path / "some_file"),
+        src_file_name=str(tmp_path / "some_file"),
+        stage_location_type="GCS",
+        presigned_url="www.example.com",
+    )
+    storage_credentials = Mock()
+    storage_credentials.creds = {}
+    stage_info = Mock()
+    connection = Mock()
+    client = SnowflakeGCSRestClient(
+        meta, storage_credentials, stage_info, connection, ""
+    )
+    file_header = client.get_file_header(meta.name)
+    assert file_header is None

--- a/test/unit_async/test_linux_local_file_cache.py
+++ b/test/unit_async/test_linux_local_file_cache.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import snowflake.connector.auth as auth
+from snowflake.connector.compat import IS_LINUX
+
+HOST_0 = "host_0"
+HOST_1 = "host_1"
+USER_0 = "user_0"
+USER_1 = "user_1"
+CRED_0 = "cred_0"
+CRED_1 = "cred_1"
+
+CRED_TYPE_0 = "ID_TOKEN"
+CRED_TYPE_1 = "MFA_TOKEN"
+
+
+def get_credential(sys, user):
+    return auth._auth.TEMPORARY_CREDENTIAL.get(sys.upper(), {}).get(user.upper())
+
+
+@pytest.mark.skipif(not IS_LINUX, reason="The test is only for Linux platform")
+def test_basic_store(tmpdir):
+    os.environ["SF_TEMPORARY_CREDENTIAL_CACHE_DIR"] = str(tmpdir)
+
+    auth._auth.delete_temporary_credential_file()
+    auth._auth.TEMPORARY_CREDENTIAL.clear()
+
+    auth._auth.read_temporary_credential_file()
+    assert not auth._auth.TEMPORARY_CREDENTIAL
+
+    auth._auth.write_temporary_credential_file(HOST_0, USER_0, CRED_0)
+    auth._auth.write_temporary_credential_file(HOST_1, USER_1, CRED_1)
+    auth._auth.write_temporary_credential_file(HOST_0, USER_1, CRED_1)
+
+    auth._auth.read_temporary_credential_file()
+    assert auth._auth.TEMPORARY_CREDENTIAL
+    assert get_credential(HOST_0, USER_0) == CRED_0
+    assert get_credential(HOST_1, USER_1) == CRED_1
+    assert get_credential(HOST_0, USER_1) == CRED_1
+
+    auth._auth.delete_temporary_credential_file()
+
+
+def test_delete_specific_item():
+    """The old behavior of delete cache is deleting the whole cache file. Now we change it to partially deletion."""
+    auth._auth.write_temporary_credential_file(
+        HOST_0,
+        auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_0),
+        CRED_0,
+    )
+    auth._auth.write_temporary_credential_file(
+        HOST_0,
+        auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_1),
+        CRED_1,
+    )
+    auth._auth.read_temporary_credential_file()
+
+    assert auth._auth.TEMPORARY_CREDENTIAL
+    assert (
+        get_credential(
+            HOST_0,
+            auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_0),
+        )
+        == CRED_0
+    )
+    assert (
+        get_credential(
+            HOST_0,
+            auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_1),
+        )
+        == CRED_1
+    )
+
+    auth._auth.temporary_credential_file_delete_password(HOST_0, USER_0, CRED_TYPE_0)
+    auth._auth.read_temporary_credential_file()
+    assert not get_credential(
+        HOST_0, auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_0)
+    )
+    assert (
+        get_credential(
+            HOST_0,
+            auth._auth.build_temporary_credential_name(HOST_0, USER_0, CRED_TYPE_1),
+        )
+        == CRED_1
+    )
+
+    auth._auth.delete_temporary_credential_file()

--- a/test/unit_async/test_local_storage_client.py
+++ b/test/unit_async/test_local_storage_client.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import random
+import string
+import tempfile
+from pathlib import Path
+
+import pytest
+
+try:
+    from snowflake.connector.constants import LOCAL_FS
+    from snowflake.connector.file_transfer_agent import SnowflakeFileMeta
+    from snowflake.connector.local_storage_client import SnowflakeLocalStorageClient
+except ImportError:
+    LOCAL_FS = None
+    SnowflakeFileMeta = None
+    SnowflakeLocalStorageClient = None
+
+
+@pytest.mark.parametrize("multipart_threshold", [0, 67108864])
+def test_multi_chunk_upload(multipart_threshold):
+    file_content = "".join(
+        [random.choice(string.ascii_letters) for _ in range(300)]
+    ).encode()
+    file_name = "test_file"
+    with tempfile.TemporaryDirectory() as stage_dir, tempfile.TemporaryDirectory() as local_dir:
+        stage_file = Path(stage_dir) / file_name
+        local_file = Path(local_dir) / file_name
+        Path(local_file).write_bytes(file_content)
+
+        meta = SnowflakeFileMeta(
+            name=file_name,
+            src_file_name=str(local_file),
+            stage_location_type=LOCAL_FS,
+            dst_file_name=file_name,
+            multipart_threshold=multipart_threshold,
+        )
+        client = SnowflakeLocalStorageClient(meta, {"location": stage_dir}, 10)
+        client.prepare_upload()
+        for chunk_id in range(client.num_of_chunks):
+            client.upload_chunk(chunk_id)
+
+        assert Path(stage_file).read_bytes() == file_content
+
+
+@pytest.mark.parametrize("multipart_threshold", [0, 67108864])
+def test_multi_chunk_download(multipart_threshold):
+    file_content = "".join(
+        [random.choice(string.ascii_letters) for _ in range(300)]
+    ).encode()
+    file_name = "test_file"
+    with tempfile.TemporaryDirectory() as stage_dir, tempfile.TemporaryDirectory() as local_dir:
+        stage_file = Path(stage_dir) / file_name
+        local_file = Path(local_dir) / file_name
+        Path(stage_file).write_bytes(file_content)
+
+        meta = SnowflakeFileMeta(
+            name=file_name,
+            src_file_name=str(stage_file),
+            stage_location_type=LOCAL_FS,
+            dst_file_name=file_name,
+            local_location=local_dir,
+            multipart_threshold=multipart_threshold,
+        )
+        client = SnowflakeLocalStorageClient(meta, {"location": stage_dir}, 10)
+        client.prepare_download()
+        for chunk_id in range(client.num_of_chunks):
+            client.download_chunk(chunk_id)
+        client.finish_download()
+
+        assert Path(local_file).read_bytes() == file_content

--- a/test/unit_async/test_log_secret_detector.py
+++ b/test/unit_async/test_log_secret_detector.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+from snowflake.connector.secret_detector import SecretDetector
+
+
+def basic_masking(test_str):
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_str)
+    assert not masked
+    assert err_str is None
+    assert masked_str == test_str
+
+
+def test_none_string():
+    basic_masking(None)
+
+
+def test_empty_string():
+    basic_masking("")
+
+
+def test_no_masking():
+    basic_masking("This string is innocuous")
+
+
+@mock.patch.object(
+    SecretDetector,
+    "mask_connection_token",
+    mock.Mock(side_effect=Exception("Test exception")),
+)
+def test_exception_in_masking():
+    test_str = "This string will raise an exception"
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_str)
+    assert masked
+    assert err_str == "Test exception"
+    assert masked_str == "Test exception"
+
+
+def exception_in_log_masking():
+    test_str = "This string will raise an exception"
+    log_record = logging.LogRecord(
+        SecretDetector.__name__,
+        logging.DEBUG,
+        "test_unit_log_secret_detector.py",
+        45,
+        test_str,
+        list(),
+        None,
+    )
+    log_record.asctime = "2003-07-08 16:49:45,896"
+    secret_detector = SecretDetector()
+    sanitized_log = secret_detector.format(log_record)
+    assert "Test exception" in sanitized_log
+    assert "secret_detector.py" in sanitized_log
+    assert "sanitize_log_str" in sanitized_log
+    assert test_str not in sanitized_log
+
+
+@mock.patch.object(
+    SecretDetector,
+    "mask_connection_token",
+    mock.Mock(side_effect=Exception("Test exception")),
+)
+def test_exception_in_secret_detector_while_log_masking():
+    exception_in_log_masking()
+
+
+@mock.patch.object(
+    SecretDetector, "mask_secrets", mock.Mock(side_effect=Exception("Test exception"))
+)
+def test_exception_while_log_masking():
+    exception_in_log_masking()
+
+
+def test_mask_token():
+    long_token = (
+        "_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U"
+        "KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj"
+        "OLLFZKOE26LXHDt3pTi4iI1qwKuSpf/F"
+        "mClCMBSissVsU3Ei590FP0lPQQhcSGcD"
+        "u69ZL_1X6e9h5z62t/iY7ZkII28n2qU="
+        "nrBJUgPRCIbtJQkVJXIuOHjX4G5yUEKj"
+        "ZBAx4w6=_lqtt67bIA=o7D=oUSjfywsR"
+        "FoloNIkBPXCwFTv+1RVUHgVA2g8A9Lw5"
+        "XdJYuI8vhg=f0bKSq7AhQ2Bh"
+    )
+
+    token_str_w_prefix = "Token =" + long_token
+    masked, masked_str, err_str = SecretDetector.mask_secrets(token_str_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "Token =****"
+
+    id_token_str_w_prefix = "idToken : " + long_token
+    masked, masked_str, err_str = SecretDetector.mask_secrets(id_token_str_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "idToken : ****"
+
+    session_token_w_prefix = "sessionToken : " + long_token
+    masked, masked_str, err_str = SecretDetector.mask_secrets(session_token_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "sessionToken : ****"
+
+    master_token_w_prefix = "masterToken : " + long_token
+    masked, masked_str, err_str = SecretDetector.mask_secrets(master_token_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "masterToken : ****"
+
+    assertion_w_prefix = "assertion content:" + long_token
+    masked, masked_str, err_str = SecretDetector.mask_secrets(assertion_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "assertion content:****"
+
+
+def test_token_false_positives():
+    false_positive_token_str = (
+        "2020-04-30 23:06:04,069 - MainThread auth.py:397"
+        " - write_temporary_credential() - DEBUG - no ID "
+        "token is given when try to store temporary credential"
+    )
+
+    masked, masked_str, err_str = SecretDetector.mask_secrets(false_positive_token_str)
+    assert not masked
+    assert err_str is None
+    assert masked_str == false_positive_token_str
+
+
+def test_password():
+    random_password = "Fh[+2J~AcqeqW%?"
+    random_password_w_prefix = "password:" + random_password
+    masked, masked_str, err_str = SecretDetector.mask_secrets(random_password_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "password:****"
+
+    random_password_caps = "PASSWORD:" + random_password
+    masked, masked_str, err_str = SecretDetector.mask_secrets(random_password_caps)
+    assert masked
+    assert err_str is None
+    assert masked_str == "PASSWORD:****"
+
+    random_password_mix_case = "PassWorD:" + random_password
+    masked, masked_str, err_str = SecretDetector.mask_secrets(random_password_mix_case)
+    assert masked
+    assert err_str is None
+    assert masked_str == "PassWorD:****"
+
+    random_password_equal_sign = "password = " + random_password
+    masked, masked_str, err_str = SecretDetector.mask_secrets(
+        random_password_equal_sign
+    )
+    assert masked
+    assert err_str is None
+    assert masked_str == "password = ****"
+
+    random_password = "Fh[+2J~AcqeqW%?"
+    random_password_w_prefix = "pwd:" + random_password
+    masked, masked_str, err_str = SecretDetector.mask_secrets(random_password_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "pwd:****"
+
+
+def test_token_password():
+    long_token = (
+        "_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U"
+        "KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj"
+        "OLLFZKOE26LXHDt3pTi4iI1qwKuSpf/F"
+        "mClCMBSissVsU3Ei590FP0lPQQhcSGcD"
+        "u69ZL_1X6e9h5z62t/iY7ZkII28n2qU="
+        "nrBJUgPRCIbtJQkVJXIuOHjX4G5yUEKj"
+        "ZBAx4w6=_lqtt67bIA=o7D=oUSjfywsR"
+        "FoloNIkBPXCwFTv+1RVUHgVA2g8A9Lw5"
+        "XdJYuI8vhg=f0bKSq7AhQ2Bh"
+    )
+
+    long_token2 = (
+        "ktL57KJemuq4-M+Q0pdRjCIMcf1mzcr"
+        "MwKteDS5DRE/Pb+5MzvWjDH7LFPV5b_"
+        "/tX/yoLG3b4TuC6Q5qNzsARPPn_zs/j"
+        "BbDOEg1-IfPpdsbwX6ETeEnhxkHIL4H"
+        "sP-V"
+    )
+
+    random_pwd = "Fh[+2J~AcqeqW%?"
+    random_pwd2 = random_pwd + "vdkav13"
+
+    test_string_w_prefix = (
+        "token=" + long_token + " random giberish " + "password:" + random_pwd
+    )
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_string_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "token=****" + " random giberish " + "password:****"
+
+    # order reversed
+    test_string_w_prefix = (
+        "password:" + random_pwd + " random giberish " + "token=" + long_token
+    )
+
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_string_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "password:****" + " random giberish " + "token=****"
+
+    # multiple tokens and password
+    test_string_w_prefix = (
+        "token="
+        + long_token
+        + " random giberish "
+        + "password:"
+        + random_pwd
+        + " random giberish "
+        + "idToken:"
+        + long_token2
+    )
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_string_w_prefix)
+    assert masked
+    assert err_str is None
+    assert (
+        masked_str
+        == "token=****"
+        + " random giberish "
+        + "password:****"
+        + " random giberish "
+        + "idToken:****"
+    )
+
+    # multiple passwords
+    test_string_w_prefix = (
+        "password=" + random_pwd + " random giberish " + "pwd:" + random_pwd2
+    )
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_string_w_prefix)
+    assert masked
+    assert err_str is None
+    assert masked_str == "password=" + "****" + " random giberish " + "pwd:" + "****"
+
+    test_string_w_prefix = (
+        "password="
+        + random_pwd
+        + " random giberish "
+        + "password="
+        + random_pwd2
+        + " random giberish "
+        + "password="
+        + random_pwd
+    )
+    masked, masked_str, err_str = SecretDetector.mask_secrets(test_string_w_prefix)
+    assert masked
+    assert err_str is None
+    assert (
+        masked_str
+        == "password="
+        + "****"
+        + " random giberish "
+        + "password="
+        + "****"
+        + " random giberish "
+        + "password="
+        + "****"
+    )

--- a/test/unit_async/test_mfa_no_cache.py
+++ b/test/unit_async/test_mfa_no_cache.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import snowflake.connector
+from snowflake.connector.compat import IS_LINUX
+
+try:
+    from snowflake.connector.options import installed_keyring
+except ImportError:
+    # if installed_keyring is unavailable, we set it as True to skip the test
+    installed_keyring = True
+try:
+    from snowflake.connector.auth import delete_temporary_credential
+except ImportError:
+    delete_temporary_credential = None
+
+MFA_TOKEN = "MFATOKEN"
+
+
+@pytest.mark.skipif(
+    IS_LINUX or installed_keyring or not delete_temporary_credential,
+    reason="Required test env is Mac/Win with no pre-installed keyring package"
+    "and available delete_temporary_credential.",
+)
+@patch("snowflake.connector.network.SnowflakeRestful._post_request")
+def test_mfa_no_local_secure_storage(mockSnowflakeRestfulPostRequest):
+    """Test whether username_password_mfa authenticator can work when no local secure storage is available."""
+    global mock_post_req_cnt
+    mock_post_req_cnt = 0
+
+    # This test requires Mac/Win and no keyring lib is installed
+    assert not installed_keyring
+
+    def mock_post_request(url, headers, json_body, **kwargs):
+        global mock_post_req_cnt
+        ret = None
+        body = json.loads(json_body)
+        if mock_post_req_cnt == 0:
+            # issue MFA token for a succeeded login
+            assert (
+                body["data"]["SESSION_PARAMETERS"].get("CLIENT_REQUEST_MFA_TOKEN")
+                is True
+            )
+            ret = {
+                "success": True,
+                "message": None,
+                "data": {
+                    "token": "TOKEN",
+                    "masterToken": "MASTER_TOKEN",
+                    "mfaToken": "MFA_TOKEN",
+                },
+            }
+        elif mock_post_req_cnt == 2:
+            # No local secure storage available, so no mfa cache token should be provided
+            assert (
+                body["data"]["SESSION_PARAMETERS"].get("CLIENT_REQUEST_MFA_TOKEN")
+                is True
+            )
+            assert "TOKEN" not in body["data"]
+            ret = {
+                "success": True,
+                "message": None,
+                "data": {
+                    "token": "NEW_TOKEN",
+                    "masterToken": "NEW_MASTER_TOKEN",
+                },
+            }
+        elif mock_post_req_cnt in [1, 3]:
+            # connection.close()
+            ret = {"success": True}
+        mock_post_req_cnt += 1
+        return ret
+
+    # POST requests mock
+    mockSnowflakeRestfulPostRequest.side_effect = mock_post_request
+
+    conn_cfg = {
+        "account": "testaccount",
+        "user": "testuser",
+        "password": "testpwd",
+        "authenticator": "username_password_mfa",
+        "host": "testaccount.snowflakecomputing.com",
+    }
+
+    delete_temporary_credential(
+        host=conn_cfg["host"], user=conn_cfg["user"], cred_type=MFA_TOKEN
+    )
+
+    # first connection, no mfa token cache
+    con = snowflake.connector.connect(**conn_cfg)
+    assert con._rest.token == "TOKEN"
+    assert con._rest.master_token == "MASTER_TOKEN"
+    assert con._rest.mfa_token == "MFA_TOKEN"
+    con.close()
+
+    # second connection, no mfa token should be issued as well since no available local secure storage
+    con = snowflake.connector.connect(**conn_cfg)
+    assert con._rest.token == "NEW_TOKEN"
+    assert con._rest.master_token == "NEW_MASTER_TOKEN"
+    assert not con._rest.mfa_token
+    con.close()

--- a/test/unit_async/test_ocsp.py
+++ b/test/unit_async/test_ocsp.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
+from os import environ, path
+from unittest import mock
+
+import pytest
+
+import snowflake.connector.ocsp_snowflake
+from snowflake.connector import OperationalError
+from snowflake.connector.errors import RevocationCheckError
+from snowflake.connector.ocsp_asn1crypto import SnowflakeOCSPAsn1Crypto as SFOCSP
+from snowflake.connector.ocsp_snowflake import OCSPCache, OCSPServer, SnowflakeOCSP
+from snowflake.connector.ssl_wrap_socket import _openssl_connect
+
+try:
+    from snowflake.connector.cache import SFDictFileCache
+    from snowflake.connector.errorcode import (
+        ER_OCSP_RESPONSE_CERT_STATUS_REVOKED,
+        ER_OCSP_RESPONSE_FETCH_FAILURE,
+    )
+    from snowflake.connector.ocsp_snowflake import OCSP_CACHE
+
+    @pytest.fixture(autouse=True)
+    def overwrite_ocsp_cache(tmpdir):
+        """This fixture swaps out the actual OCSP cache for a temprary one."""
+        if OCSP_CACHE is not None:
+            tmp_cache_file = os.path.join(tmpdir, "tmp_cache")
+            with mock.patch(
+                "snowflake.connector.ocsp_snowflake.OCSP_CACHE",
+                SFDictFileCache(file_path=tmp_cache_file),
+            ):
+                yield
+            os.unlink(tmp_cache_file)
+
+except ImportError:
+    ER_OCSP_RESPONSE_CERT_STATUS_REVOKED = None
+    ER_OCSP_RESPONSE_FETCH_FAILURE = None
+    OCSP_CACHE = None
+
+TARGET_HOSTS = [
+    "ocspssd.us-east-1.snowflakecomputing.com",
+    "sqs.us-west-2.amazonaws.com",
+    "sfcsupport.us-east-1.snowflakecomputing.com",
+    "sfcsupport.eu-central-1.snowflakecomputing.com",
+    "sfc-eng-regression.s3.amazonaws.com",
+    "sfctest0.snowflakecomputing.com",
+    "sfc-ds2-customer-stage.s3.amazonaws.com",
+    "snowflake.okta.com",
+    "sfcdev1.blob.core.windows.net",
+    "sfc-aus-ds1-customer-stage.s3-ap-southeast-2.amazonaws.com",
+]
+
+THIS_DIR = path.dirname(path.realpath(__file__))
+
+
+def test_ocsp():
+    """OCSP tests."""
+    # reset the memory cache
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP()
+    for url in TARGET_HOSTS:
+        connection = _openssl_connect(url, timeout=5)
+        assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+
+
+def test_ocsp_wo_cache_server():
+    """OCSP Tests with Cache Server Disabled."""
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP(use_ocsp_cache_server=False)
+    for url in TARGET_HOSTS:
+        connection = _openssl_connect(url)
+        assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+
+
+def test_ocsp_wo_cache_file():
+    """OCSP tests without File cache.
+
+    Notes:
+        Use /etc as a readonly directory such that no cache file is used.
+    """
+    # reset the memory cache
+    SnowflakeOCSP.clear_cache()
+    OCSPCache.del_cache_file()
+    environ["SF_OCSP_RESPONSE_CACHE_DIR"] = "/etc"
+    OCSPCache.reset_cache_dir()
+
+    try:
+        ocsp = SFOCSP()
+        for url in TARGET_HOSTS:
+            connection = _openssl_connect(url)
+            assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+    finally:
+        del environ["SF_OCSP_RESPONSE_CACHE_DIR"]
+        OCSPCache.reset_cache_dir()
+
+
+def test_ocsp_fail_open_w_single_endpoint():
+    SnowflakeOCSP.clear_cache()
+
+    OCSPCache.del_cache_file()
+
+    environ["SF_OCSP_TEST_MODE"] = "true"
+    environ["SF_TEST_OCSP_URL"] = "http://httpbin.org/delay/10"
+    environ["SF_TEST_CA_OCSP_RESPONDER_CONNECTION_TIMEOUT"] = "5"
+
+    ocsp = SFOCSP(use_ocsp_cache_server=False)
+    connection = _openssl_connect("snowflake.okta.com")
+
+    try:
+        assert ocsp.validate(
+            "snowflake.okta.com", connection
+        ), "Failed to validate: {}".format("snowflake.okta.com")
+    finally:
+        del environ["SF_OCSP_TEST_MODE"]
+        del environ["SF_TEST_OCSP_URL"]
+        del environ["SF_TEST_CA_OCSP_RESPONDER_CONNECTION_TIMEOUT"]
+
+
+@pytest.mark.skipif(
+    ER_OCSP_RESPONSE_CERT_STATUS_REVOKED is None,
+    reason="No ER_OCSP_RESPONSE_CERT_STATUS_REVOKED is available.",
+)
+def test_ocsp_fail_close_w_single_endpoint():
+    SnowflakeOCSP.clear_cache()
+
+    environ["SF_OCSP_TEST_MODE"] = "true"
+    environ["SF_TEST_OCSP_URL"] = "http://httpbin.org/delay/10"
+    environ["SF_TEST_CA_OCSP_RESPONDER_CONNECTION_TIMEOUT"] = "5"
+
+    OCSPCache.del_cache_file()
+
+    ocsp = SFOCSP(use_ocsp_cache_server=False, use_fail_open=False)
+    connection = _openssl_connect("snowflake.okta.com")
+
+    with pytest.raises(RevocationCheckError) as ex:
+        ocsp.validate("snowflake.okta.com", connection)
+
+    try:
+        assert (
+            ex.value.errno == ER_OCSP_RESPONSE_FETCH_FAILURE
+        ), "Connection should have failed"
+    finally:
+        del environ["SF_OCSP_TEST_MODE"]
+        del environ["SF_TEST_OCSP_URL"]
+        del environ["SF_TEST_CA_OCSP_RESPONDER_CONNECTION_TIMEOUT"]
+
+
+def test_ocsp_bad_validity():
+    SnowflakeOCSP.clear_cache()
+
+    environ["SF_OCSP_TEST_MODE"] = "true"
+    environ["SF_TEST_OCSP_FORCE_BAD_RESPONSE_VALIDITY"] = "true"
+
+    OCSPCache.del_cache_file()
+
+    ocsp = SFOCSP(use_ocsp_cache_server=False)
+    connection = _openssl_connect("snowflake.okta.com")
+
+    assert ocsp.validate(
+        "snowflake.okta.com", connection
+    ), "Connection should have passed with fail open"
+    del environ["SF_OCSP_TEST_MODE"]
+    del environ["SF_TEST_OCSP_FORCE_BAD_RESPONSE_VALIDITY"]
+
+
+def test_ocsp_single_endpoint():
+    environ["SF_OCSP_ACTIVATE_NEW_ENDPOINT"] = "True"
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP()
+    ocsp.OCSP_CACHE_SERVER.NEW_DEFAULT_CACHE_SERVER_BASE_URL = "https://snowflake.preprod3.us-west-2-dev.external-zone.snowflakecomputing.com:8085/ocsp/"
+    connection = _openssl_connect("snowflake.okta.com")
+    assert ocsp.validate(
+        "snowflake.okta.com", connection
+    ), "Failed to validate: {}".format("snowflake.okta.com")
+
+    del environ["SF_OCSP_ACTIVATE_NEW_ENDPOINT"]
+
+
+def test_ocsp_by_post_method():
+    """OCSP tests."""
+    # reset the memory cache
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP(use_post_method=True)
+    for url in TARGET_HOSTS:
+        connection = _openssl_connect(url)
+        assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+
+
+def test_ocsp_with_file_cache(tmpdir):
+    """OCSP tests and the cache server and file."""
+    tmp_dir = str(tmpdir.mkdir("ocsp_response_cache"))
+    cache_file_name = path.join(tmp_dir, "cache_file.txt")
+
+    # reset the memory cache
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP(ocsp_response_cache_uri="file://" + cache_file_name)
+    for url in TARGET_HOSTS:
+        connection = _openssl_connect(url)
+        assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+
+
+@pytest.mark.skipolddriver
+def test_ocsp_with_bogus_cache_files(tmpdir):
+    from snowflake.connector.ocsp_snowflake import OCSPResponseValidationResult
+
+    """Attempts to use bogus OCSP response data."""
+    cache_file_name, target_hosts = _store_cache_in_file(tmpdir)
+
+    ocsp = SFOCSP()
+    OCSPCache.read_ocsp_response_cache_file(ocsp, cache_file_name)
+    cache_data = snowflake.connector.ocsp_snowflake.OCSP_RESPONSE_VALIDATION_CACHE
+    assert cache_data, "more than one cache entries should be stored."
+
+    # setting bogus data
+    current_time = int(time.time())
+    for k, _ in cache_data.items():
+        cache_data[k] = OCSPResponseValidationResult(
+            ocsp_response=b"bogus",
+            ts=current_time,
+            validated=True,
+        )
+
+    # write back the cache file
+    OCSPCache.CACHE = cache_data
+    OCSPCache.write_ocsp_response_cache_file(ocsp, cache_file_name)
+
+    # forces to use the bogus cache file but it should raise errors
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP()
+    for hostname in target_hosts:
+        connection = _openssl_connect(hostname)
+        assert ocsp.validate(hostname, connection), "Failed to validate: {}".format(
+            hostname
+        )
+
+
+@pytest.mark.skipolddriver
+def test_ocsp_with_outdated_cache(tmpdir):
+    from snowflake.connector.ocsp_snowflake import OCSPResponseValidationResult
+
+    """Attempts to use outdated OCSP response cache file."""
+    cache_file_name, target_hosts = _store_cache_in_file(tmpdir)
+
+    ocsp = SFOCSP()
+
+    # reading cache file
+    OCSPCache.read_ocsp_response_cache_file(ocsp, cache_file_name)
+    cache_data = snowflake.connector.ocsp_snowflake.OCSP_RESPONSE_VALIDATION_CACHE
+    assert cache_data, "more than one cache entries should be stored."
+
+    # setting outdated data
+    current_time = int(time.time())
+    for k, v in cache_data.items():
+        cache_data[k] = OCSPResponseValidationResult(
+            ocsp_response=v.ocsp_response,
+            ts=current_time - 144 * 60 * 60,
+            validated=True,
+        )
+
+    # write back the cache file
+    OCSPCache.CACHE = cache_data
+    OCSPCache.write_ocsp_response_cache_file(ocsp, cache_file_name)
+
+    # forces to use the bogus cache file but it should raise errors
+    SnowflakeOCSP.clear_cache()  # reset the memory cache
+    SFOCSP()
+    assert (
+        SnowflakeOCSP.cache_size() == 0
+    ), "must be empty. outdated cache should not be loaded"
+
+
+def _store_cache_in_file(tmpdir, target_hosts=None):
+    if target_hosts is None:
+        target_hosts = TARGET_HOSTS
+    os.environ["SF_OCSP_RESPONSE_CACHE_DIR"] = str(tmpdir)
+    OCSPCache.reset_cache_dir()
+    filename = path.join(str(tmpdir), "ocsp_response_cache.json")
+
+    # cache OCSP response
+    SnowflakeOCSP.clear_cache()
+    ocsp = SFOCSP(
+        ocsp_response_cache_uri="file://" + filename, use_ocsp_cache_server=False
+    )
+    for hostname in target_hosts:
+        connection = _openssl_connect(hostname)
+        assert ocsp.validate(hostname, connection), "Failed to validate: {}".format(
+            hostname
+        )
+    assert path.exists(filename), "OCSP response cache file"
+    return filename, target_hosts
+
+
+def test_ocsp_with_invalid_cache_file():
+    """OCSP tests with an invalid cache file."""
+    SnowflakeOCSP.clear_cache()  # reset the memory cache
+    ocsp = SFOCSP(ocsp_response_cache_uri="NEVER_EXISTS")
+    for url in TARGET_HOSTS[0:1]:
+        connection = _openssl_connect(url)
+        assert ocsp.validate(url, connection), f"Failed to validate: {url}"
+
+
+@mock.patch(
+    "snowflake.connector.ocsp_snowflake.SnowflakeOCSP._fetch_ocsp_response",
+    side_effect=BrokenPipeError("fake error"),
+)
+def test_ocsp_cache_when_server_is_down(mock_fetch_ocsp_response, tmpdir):
+    ocsp = SFOCSP()
+
+    """Attempts to use outdated OCSP response cache file."""
+    cache_file_name, target_hosts = _store_cache_in_file(tmpdir)
+
+    # reading cache file
+    OCSPCache.read_ocsp_response_cache_file(ocsp, cache_file_name)
+    cache_data = snowflake.connector.ocsp_snowflake.OCSP_RESPONSE_VALIDATION_CACHE
+    assert not cache_data, "no cache should present because of broken pipe"
+
+
+def test_concurrent_ocsp_requests(tmpdir):
+    """Run OCSP revocation checks in parallel. The memory and file caches are deleted randomly."""
+    cache_file_name = path.join(str(tmpdir), "cache_file.txt")
+    SnowflakeOCSP.clear_cache()  # reset the memory cache
+
+    target_hosts = TARGET_HOSTS * 5
+    pool = ThreadPoolExecutor(len(target_hosts))
+    for hostname in target_hosts:
+        pool.submit(_validate_certs_using_ocsp, hostname, cache_file_name)
+    pool.shutdown()
+
+
+def _validate_certs_using_ocsp(url, cache_file_name):
+    """Validate OCSP response. Deleting memory cache and file cache randomly."""
+    logger = logging.getLogger("test")
+    import random
+    import time
+
+    time.sleep(random.randint(0, 3))
+    if random.random() < 0.2:
+        logger.info("clearing up cache: OCSP_VALIDATION_CACHE")
+        SnowflakeOCSP.clear_cache()
+    if random.random() < 0.05:
+        logger.info("deleting a cache file: %s", cache_file_name)
+        SnowflakeOCSP.delete_cache_file()
+
+    connection = _openssl_connect(url)
+    ocsp = SFOCSP(ocsp_response_cache_uri="file://" + cache_file_name)
+    ocsp.validate(url, connection)
+
+
+@pytest.mark.skip(reason="certificate expired.")
+def test_ocsp_revoked_certificate():
+    """Tests revoked certificate."""
+    revoked_cert = path.join(THIS_DIR, "../data", "cert_tests", "revoked_certs.pem")
+
+    SnowflakeOCSP.clear_cache()  # reset the memory cache
+    ocsp = SFOCSP()
+
+    with pytest.raises(OperationalError) as ex:
+        ocsp.validate_certfile(revoked_cert)
+    assert ex.value.errno == ex.value.errno == ER_OCSP_RESPONSE_CERT_STATUS_REVOKED
+
+
+def test_ocsp_incomplete_chain():
+    """Tests incomplete chained certificate."""
+    incomplete_chain_cert = path.join(
+        THIS_DIR, "../data", "cert_tests", "incomplete-chain.pem"
+    )
+
+    SnowflakeOCSP.clear_cache()  # reset the memory cache
+    ocsp = SFOCSP()
+
+    with pytest.raises(OperationalError) as ex:
+        ocsp.validate_certfile(incomplete_chain_cert)
+    assert "CA certificate is NOT found" in ex.value.msg
+
+
+def test_building_retry_url():
+    # privatelink retry url
+    OCSP_SERVER = OCSPServer()
+    OCSP_SERVER.OCSP_RETRY_URL = None
+    OCSP_SERVER.CACHE_SERVER_URL = (
+        "http://ocsp.us-east-1.snowflakecomputing.com/ocsp_response_cache.json"
+    )
+    OCSP_SERVER.reset_ocsp_dynamic_cache_server_url(None)
+    assert (
+        OCSP_SERVER.OCSP_RETRY_URL
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/{0}/{1}"
+    )
+
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com/", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com/ocsp", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com/ocsp/1234"
+    )
+
+    # ensure we also handle port
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080/", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/1234"
+    )
+    assert (
+        OCSP_SERVER.generate_get_url("http://oneocsp.microsoft.com:8080/ocsp", "1234")
+        == "http://ocsp.us-east-1.snowflakecomputing.com/retry/oneocsp.microsoft.com:8080/ocsp/1234"
+    )
+
+    # privatelink retry url with port
+    OCSP_SERVER.OCSP_RETRY_URL = None
+    OCSP_SERVER.CACHE_SERVER_URL = (
+        "http://ocsp.us-east-1.snowflakecomputing.com:80/ocsp_response_cache" ".json"
+    )
+    OCSP_SERVER.reset_ocsp_dynamic_cache_server_url(None)
+    assert (
+        OCSP_SERVER.OCSP_RETRY_URL
+        == "http://ocsp.us-east-1.snowflakecomputing.com:80/retry/{0}/{1}"
+    )
+
+    # non-privatelink retry url
+    OCSP_SERVER.OCSP_RETRY_URL = None
+    OCSP_SERVER.CACHE_SERVER_URL = (
+        "http://ocsp.snowflakecomputing.com/ocsp_response_cache.json"
+    )
+    OCSP_SERVER.reset_ocsp_dynamic_cache_server_url(None)
+    assert OCSP_SERVER.OCSP_RETRY_URL is None
+
+    # non-privatelink retry url with port
+    OCSP_SERVER.OCSP_RETRY_URL = None
+    OCSP_SERVER.CACHE_SERVER_URL = (
+        "http://ocsp.snowflakecomputing.com:80/ocsp_response_cache.json"
+    )
+    OCSP_SERVER.reset_ocsp_dynamic_cache_server_url(None)
+    assert OCSP_SERVER.OCSP_RETRY_URL is None
+
+
+def test_building_new_retry():
+    OCSP_SERVER = OCSPServer()
+    OCSP_SERVER.OCSP_RETRY_URL = None
+    hname = "a1.us-east-1.snowflakecomputing.com"
+    os.environ["SF_OCSP_ACTIVATE_NEW_ENDPOINT"] = "true"
+    OCSP_SERVER.reset_ocsp_endpoint(hname)
+    assert (
+        OCSP_SERVER.CACHE_SERVER_URL
+        == "https://ocspssd.us-east-1.snowflakecomputing.com/ocsp/fetch"
+    )
+
+    assert (
+        OCSP_SERVER.OCSP_RETRY_URL
+        == "https://ocspssd.us-east-1.snowflakecomputing.com/ocsp/retry"
+    )
+
+    hname = "a1-12345.global.snowflakecomputing.com"
+    OCSP_SERVER.reset_ocsp_endpoint(hname)
+    assert (
+        OCSP_SERVER.CACHE_SERVER_URL
+        == "https://ocspssd-12345.global.snowflakecomputing.com/ocsp/fetch"
+    )
+
+    assert (
+        OCSP_SERVER.OCSP_RETRY_URL
+        == "https://ocspssd-12345.global.snowflakecomputing.com/ocsp/retry"
+    )
+
+    hname = "snowflake.okta.com"
+    OCSP_SERVER.reset_ocsp_endpoint(hname)
+    assert (
+        OCSP_SERVER.CACHE_SERVER_URL
+        == "https://ocspssd.snowflakecomputing.com/ocsp/fetch"
+    )
+
+    assert (
+        OCSP_SERVER.OCSP_RETRY_URL
+        == "https://ocspssd.snowflakecomputing.com/ocsp/retry"
+    )
+
+    del os.environ["SF_OCSP_ACTIVATE_NEW_ENDPOINT"]

--- a/test/unit_async/test_oob_secret_detector.py
+++ b/test/unit_async/test_oob_secret_detector.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import random
+import string
+
+from snowflake.connector.secret_detector import SecretDetector
+
+
+def test_mask_aws_secret():
+    sql = (
+        "copy into 's3://xxxx/test' from \n"
+        "(select seq1(), random()\n"
+        ", random(), random(), random(), random()\n"
+        ", random(), random(), random(), random()\n"
+        ", random() , random(), random(), random()\n"
+        "\tfrom table(generator(rowcount => 10000)))\n"
+        "credentials=(\n"
+        "  aws_key_id='xxdsdfsafds'\n"
+        "  aws_secret_key='safas+asfsad+safasf'\n"
+        "  )\n"
+        "OVERWRITE = TRUE \n"
+        "MAX_FILE_SIZE = 500000000 \n"
+        "HEADER = TRUE \n"
+        "FILE_FORMAT = (TYPE = PARQUET SNAPPY_COMPRESSION = TRUE )\n"
+        ";"
+    )
+
+    correct = (
+        "copy into 's3://xxxx/test' from \n"
+        "(select seq1(), random()\n"
+        ", random(), random(), random(), random()\n"
+        ", random(), random(), random(), random()\n"
+        ", random() , random(), random(), random()\n"
+        "\tfrom table(generator(rowcount => 10000)))\n"
+        "credentials=(\n"
+        "  aws_key_id='****'\n"
+        "  aws_secret_key='****'\n"
+        "  )\n"
+        "OVERWRITE = TRUE \n"
+        "MAX_FILE_SIZE = 500000000 \n"
+        "HEADER = TRUE \n"
+        "FILE_FORMAT = (TYPE = PARQUET SNAPPY_COMPRESSION = TRUE )\n"
+        ";"
+    )
+
+    # Mask an aws key id and secret key
+    _, masked_sql, _ = SecretDetector.mask_secrets(sql)
+    assert masked_sql == correct
+
+
+def test_mask_sas_token():
+    azure_sas_token = (
+        "https://someaccounts.blob.core.windows.net/results/018b90ab-0033-"
+        "5f8e-0000-14f1000bd376_0/main/data_0_0_1?sv=2015-07-08&amp;"
+        "sig=iCvQmdZngZNW%2F4vw43j6%2BVz6fndHF5LI639QJba4r8o%3D&amp;"
+        "spr=https&amp;st=2016-04-12T03%3A24%3A31Z&amp;"
+        "se=2016-04-13T03%3A29%3A31Z&amp;srt=s&amp;ss=bf&amp;sp=rwl"
+    )
+
+    masked_azure_sas_token = (
+        "https://someaccounts.blob.core.windows.net/results/018b90ab-0033-"
+        "5f8e-0000-14f1000bd376_0/main/data_0_0_1?sv=2015-07-08&amp;"
+        "sig=****&amp;"
+        "spr=https&amp;st=2016-04-12T03%3A24%3A31Z&amp;"
+        "se=2016-04-13T03%3A29%3A31Z&amp;srt=s&amp;ss=bf&amp;sp=rwl"
+    )
+
+    s3_sas_token = (
+        "https://somebucket.s3.amazonaws.com/vzy1-s-va_demo0/results/018b92f3"
+        "-01c2-02dd-0000-03d5000c8066_0/main/data_0_0_1?"
+        "x-amz-server-side-encryption-customer-algorithm=AES256&"
+        "response-content-encoding=gzip&AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE"
+        "&Expires=1555481960&Signature=zFiRkdB9RtRRYomppVes4fQ%2ByWw%3D"
+    )
+
+    masked_s3_sas_token = (
+        "https://somebucket.s3.amazonaws.com/vzy1-s-va_demo0/results/018b92f3"
+        "-01c2-02dd-0000-03d5000c8066_0/main/data_0_0_1?"
+        "x-amz-server-side-encryption-customer-algorithm=AES256&"
+        "response-content-encoding=gzip&AWSAccessKeyId=****"
+        "&Expires=1555481960&Signature=****"
+    )
+
+    # Mask azure token
+    _, masked_text, _ = SecretDetector.mask_secrets(azure_sas_token)
+    assert masked_text == masked_azure_sas_token
+
+    # Mask s3 token
+    _, masked_text, _ = SecretDetector.mask_secrets(s3_sas_token)
+    assert masked_text == masked_s3_sas_token
+
+    text = "".join([random.choice(string.ascii_lowercase) for i in range(200)])
+    _, masked_text, _ = SecretDetector.mask_secrets(text)
+    # Randomly generated string should cause no substitutions
+    assert masked_text == text
+
+    # Mask multiple azure tokens
+    _, masked_text, _ = SecretDetector.mask_secrets(
+        azure_sas_token + "\n" + azure_sas_token
+    )
+    assert masked_text == masked_azure_sas_token + "\n" + masked_azure_sas_token
+
+    # Mask multiple s3 tokens
+    _, masked_text, _ = SecretDetector.mask_secrets(s3_sas_token + "\n" + s3_sas_token)
+    assert masked_text == masked_s3_sas_token + "\n" + masked_s3_sas_token
+
+    # Mask azure and s3 token
+    _, masked_text, _ = SecretDetector.mask_secrets(
+        azure_sas_token + "\n" + s3_sas_token
+    )
+    assert masked_text == masked_azure_sas_token + "\n" + masked_s3_sas_token
+
+
+def test_mask_secrets():
+    sql = (
+        "create stage mystage "
+        "URL = 's3://mybucket/mypath/' "
+        "credentials = (aws_key_id = 'AKIAIOSFODNN7EXAMPLE' "
+        "aws_secret_key = 'frJIUN8DYpKDtOLCwo//yllqDzg='); "
+        "create stage mystage2 "
+        "URL = 'azure//mystorage.blob.core.windows.net/cont' "
+        "credentials = (azure_sas_token = "
+        "'?sv=2016-05-31&ss=b&srt=sco&sp=rwdl&se=2018-06-27T10:05:50Z&"
+        "st=2017-06-27T02:05:50Z&spr=https,http&"
+        "sig=bgqQwoXwxzuD2GJfagRg7VOS8hzNr3QLT7rhS8OFRLQ%3D')"
+    )
+
+    masked_sql = (
+        "create stage mystage "
+        "URL = 's3://mybucket/mypath/' "
+        "credentials = (aws_key_id='****' "
+        "aws_secret_key='****'); "
+        "create stage mystage2 "
+        "URL = 'azure//mystorage.blob.core.windows.net/cont' "
+        "credentials = (azure_sas_token = "
+        "'?sv=2016-05-31&ss=b&srt=sco&sp=rwdl&se=2018-06-27T10:05:50Z&"
+        "st=2017-06-27T02:05:50Z&spr=https,http&"
+        "sig=****')"
+    )
+
+    # Test masking all kinds of secrets
+    _, masked_text, _ = SecretDetector.mask_secrets(sql)
+    assert masked_text == masked_sql
+
+    text = "".join([random.choice(string.ascii_lowercase) for i in range(500)])
+    _, masked_text, _ = SecretDetector.mask_secrets(text)
+    # Randomly generated string should cause no substitutions
+    assert masked_text == text
+
+
+def test_mask_private_keys():
+    text = '"privateKeyData": "aslkjdflasjf"'
+
+    filtered_text = '"privateKeyData": "XXXX"'
+
+    _, result, _ = SecretDetector.mask_secrets(text)
+    assert result == filtered_text

--- a/test/unit_async/test_parse_account.py
+++ b/test/unit_async/test_parse_account.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from snowflake.connector.util_text import parse_account
+
+
+def test_parse_account_basic():
+    assert parse_account("account1") == "account1"
+
+    assert parse_account("account1.eu-central-1") == "account1"
+
+    assert (
+        parse_account("account1-jkabfvdjisoa778wqfgeruishafeuw89q.global") == "account1"
+    )

--- a/test/unit_async/test_proxies.py
+++ b/test/unit_async/test_proxies.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+import os
+import unittest.mock
+
+import pytest
+
+import snowflake.connector
+from snowflake.connector.errors import OperationalError
+
+
+def test_set_proxies():
+    from snowflake.connector.proxy import set_proxies
+
+    assert set_proxies("proxyhost", "8080") == {
+        "http": "http://proxyhost:8080",
+        "https": "http://proxyhost:8080",
+    }
+    assert set_proxies("http://proxyhost", "8080") == {
+        "http": "http://proxyhost:8080",
+        "https": "http://proxyhost:8080",
+    }
+    assert set_proxies("http://proxyhost", "8080", "testuser", "testpass") == {
+        "http": "http://testuser:testpass@proxyhost:8080",
+        "https": "http://testuser:testpass@proxyhost:8080",
+    }
+    assert set_proxies("proxyhost", "8080", "testuser", "testpass") == {
+        "http": "http://testuser:testpass@proxyhost:8080",
+        "https": "http://testuser:testpass@proxyhost:8080",
+    }
+
+    # NOTE environment variable is set if the proxy parameter is specified.
+    del os.environ["HTTP_PROXY"]
+    del os.environ["HTTPS_PROXY"]

--- a/test/unit_async/test_put_get.py
+++ b/test/unit_async/test_put_get.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from os import chmod, path
+from unittest import mock
+
+import pytest
+
+from snowflake.connector import OperationalError
+from snowflake.connector.compat import IS_WINDOWS
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.errors import Error
+from snowflake.connector.file_transfer_agent import (
+    SnowflakeAzureProgressPercentage,
+    SnowflakeFileTransferAgent,
+    SnowflakeS3ProgressPercentage,
+)
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="permission model is different")
+def test_put_error(tmpdir):
+    """Tests for raise_put_get_error flag (now turned on by default) in SnowflakeFileTransferAgent."""
+    tmp_dir = str(tmpdir.mkdir("putfiledir"))
+    file1 = path.join(tmp_dir, "file1")
+    remote_location = path.join(tmp_dir, "remote_loc")
+    with open(file1, "w") as f:
+        f.write("test1")
+
+    con = mock.MagicMock()
+    cursor = con.cursor()
+    cursor.errorhandler = Error.default_errorhandler
+    query = "PUT something"
+    ret = {
+        "data": {
+            "command": "UPLOAD",
+            "autoCompress": False,
+            "src_locations": [file1],
+            "sourceCompression": "none",
+            "stageInfo": {
+                "creds": {},
+                "location": remote_location,
+                "locationType": "LOCAL_FS",
+                "path": "remote_loc",
+            },
+        },
+        "success": True,
+    }
+
+    agent_class = SnowflakeFileTransferAgent
+
+    # no error is raised
+    sf_file_transfer_agent = agent_class(cursor, query, ret, raise_put_get_error=False)
+    sf_file_transfer_agent.execute()
+    sf_file_transfer_agent.result()
+
+    # nobody can read now.
+    chmod(file1, 0o000)
+    # Permission error should be raised
+    sf_file_transfer_agent = agent_class(cursor, query, ret, raise_put_get_error=True)
+    sf_file_transfer_agent.execute()
+    with pytest.raises(OperationalError, match="PermissionError"):
+        sf_file_transfer_agent.result()
+
+    # unspecified, should fail because flag is on by default now
+    sf_file_transfer_agent = agent_class(cursor, query, ret)
+    sf_file_transfer_agent.execute()
+    with pytest.raises(OperationalError, match="PermissionError"):
+        sf_file_transfer_agent.result()
+
+    chmod(file1, 0o700)
+
+
+def test_get_empty_file(tmpdir):
+    """Tests for error message when retrieving missing file."""
+    tmp_dir = str(tmpdir.mkdir("getfiledir"))
+
+    con = mock.MagicMock()
+    cursor = con.cursor()
+    cursor.errorhandler = Error.default_errorhandler
+    query = f"GET something file:\\{tmp_dir}"
+    ret = {
+        "data": {
+            "localLocation": tmp_dir,
+            "command": "DOWNLOAD",
+            "autoCompress": False,
+            "src_locations": [],
+            "sourceCompression": "none",
+            "stageInfo": {
+                "creds": {},
+                "location": "",
+                "locationType": "S3",
+                "path": "remote_loc",
+            },
+        },
+        "success": True,
+    }
+
+    sf_file_transfer_agent = SnowflakeFileTransferAgent(
+        cursor, query, ret, raise_put_get_error=True
+    )
+    with pytest.raises(OperationalError, match=".*the file does not exist.*$"):
+        sf_file_transfer_agent.execute()
+    assert not sf_file_transfer_agent.result()["rowset"]
+
+
+@pytest.mark.skipolddriver
+def test_percentage(tmp_path):
+    """Tests for ProgressPercentage classes."""
+    from snowflake.connector.file_transfer_agent import percent
+
+    assert 1.0 == percent(0, 0)
+    assert 1.0 == percent(20, 0)
+    assert 1.0 == percent(40, 20)
+    assert 0.5 == percent(14, 28)
+
+    file_path = tmp_path / "zero_file1"
+    file_path.touch()
+    func_callback = SnowflakeS3ProgressPercentage(str(file_path), 0)
+    func_callback(1)
+    func_callback = SnowflakeAzureProgressPercentage(str(file_path), 0)
+    func_callback(1)
+
+
+@pytest.mark.skipolddriver
+def test_upload_file_with_azure_upload_failed_error(tmp_path):
+    """Tests Upload file with expired Azure storage token."""
+    file1 = tmp_path / "file1"
+    with file1.open("w") as f:
+        f.write("test1")
+    rest_client = SnowflakeFileTransferAgent(
+        mock.MagicMock(autospec=SnowflakeCursor),
+        "PUT some_file.txt",
+        {
+            "data": {
+                "command": "UPLOAD",
+                "src_locations": [file1],
+                "sourceCompression": "none",
+                "stageInfo": {
+                    "creds": {
+                        "AZURE_SAS_TOKEN": "sas_token",
+                    },
+                    "location": "some_bucket",
+                    "region": "no_region",
+                    "locationType": "AZURE",
+                    "path": "remote_loc",
+                    "endPoint": "",
+                    "storageAccount": "storage_account",
+                },
+            },
+            "success": True,
+        },
+    )
+    exc = Exception("Stop executing")
+    with mock.patch(
+        "snowflake.connector.azure_storage_client.SnowflakeAzureRestClient._has_expired_token",
+        return_value=True,
+    ):
+        with mock.patch(
+            "snowflake.connector.file_transfer_agent.StorageCredential.update",
+            side_effect=exc,
+        ) as mock_update:
+            rest_client.execute()
+            assert mock_update.called
+            assert rest_client._results[0].error_details is exc

--- a/test/unit_async/test_query_context_cache.py
+++ b/test/unit_async/test_query_context_cache.py
@@ -1,0 +1,456 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+import json
+from random import shuffle
+
+import pytest
+
+try:
+    from snowflake.connector._query_context_cache import (
+        QueryContextCache,
+        QueryContextElement,
+    )
+except ImportError:
+
+    class QueryContextCache:
+        def __init__(self, capacity):
+            pass
+
+    class QueryContextElement:
+        def __init__(self, id, read_timestamp, priority, context):
+            pass
+
+
+MAX_CAPACITY = 5
+BASE_ID = 0
+BASE_READ_TIMESTAMP = 1668727958
+BASE_PRIORITY = 0
+CONTEXT = "////Some query context"
+
+
+class ExpectedQCCData:
+    def __init__(self, capacity, context=CONTEXT) -> None:
+        self.capacity = capacity
+        self.ids = [BASE_ID + i for i in range(capacity)]
+        self.timestamps = [BASE_READ_TIMESTAMP + i for i in range(capacity)]
+        self.priorities = [BASE_PRIORITY + i for i in range(capacity)]
+        self.contexts = [context for _ in range(capacity)]
+
+    def shuffle_data(self) -> None:
+        random_order = list(range(self.capacity))
+        shuffle(random_order)
+        self.ids = [BASE_ID + i for i in random_order]
+        self.timestamps = [BASE_READ_TIMESTAMP + i for i in random_order]
+        self.priorities = [BASE_PRIORITY + i for i in random_order]
+
+    def reset_data(self):
+        self.ids = [BASE_ID + i for i in range(self.capacity)]
+        self.timestamps = [BASE_READ_TIMESTAMP + i for i in range(self.capacity)]
+        self.priorities = [BASE_PRIORITY + i for i in range(self.capacity)]
+
+
+def serialize_to_json(qcc: QueryContextCache) -> str:
+    """
+    This function is used for testing the deserialize_to_dict function is correct. Note that `QueryContextCache::serialize_to_dict` function is used in sending the query context back to GS.
+    It has slight difference with this function on `context` field.
+    """
+    with qcc._lock:
+        qcc.log_cache_entries()
+
+        if len(qcc._tree_set) == 0:
+            return ""
+
+        try:
+            data = {
+                "entries": [
+                    {
+                        "id": qce.id,
+                        "timestamp": qce.read_timestamp,
+                        "priority": qce.priority,
+                        "context": qce.context,
+                    }
+                    for qce in qcc._tree_set
+                ]
+            }
+            # Serialize the data to JSON
+            serialized_data = json.dumps(data)
+
+            return serialized_data
+        except Exception:
+            return ""
+
+
+@pytest.fixture()
+def expected_data() -> ExpectedQCCData:
+    data = ExpectedQCCData(MAX_CAPACITY)
+    yield data
+    data.reset_data()
+
+
+@pytest.fixture()
+def expected_data_with_null_context() -> ExpectedQCCData:
+    data = ExpectedQCCData(MAX_CAPACITY, context=None)
+    yield data
+    data.reset_data()
+
+
+@pytest.fixture()
+def qcc_with_no_data() -> QueryContextCache:
+    return QueryContextCache(MAX_CAPACITY)
+
+
+@pytest.fixture()
+def qcc_with_data(
+    qcc_with_no_data: QueryContextCache, expected_data: ExpectedQCCData
+) -> QueryContextCache:
+    for i in range(MAX_CAPACITY):
+        qcc_with_no_data.insert(
+            expected_data.ids[i],
+            expected_data.timestamps[i],
+            expected_data.priorities[i],
+            expected_data.contexts[i],
+        )
+    qcc_with_no_data._sync_priority_map()
+    yield qcc_with_no_data
+    qcc_with_no_data.clear_cache()
+
+
+@pytest.fixture()
+def qcc_with_data_random_order(
+    qcc_with_no_data: QueryContextCache,
+    expected_data: ExpectedQCCData,
+) -> QueryContextCache:
+    expected_data.shuffle_data()
+    for i in range(MAX_CAPACITY):
+        qcc_with_no_data.insert(
+            expected_data.ids[i],
+            expected_data.timestamps[i],
+            expected_data.priorities[i],
+            expected_data.contexts[i],
+        )
+    qcc_with_no_data._sync_priority_map()
+    yield qcc_with_no_data
+    qcc_with_no_data.clear_cache()
+
+
+@pytest.fixture()
+def qcc_with_data_null_context(
+    qcc_with_no_data: QueryContextCache,
+    expected_data_with_null_context: ExpectedQCCData,
+):
+    for i in range(MAX_CAPACITY):
+        qcc_with_no_data.insert(
+            expected_data_with_null_context.ids[i],
+            expected_data_with_null_context.timestamps[i],
+            expected_data_with_null_context.priorities[i],
+            expected_data_with_null_context.contexts[i],
+        )
+    qcc_with_no_data._sync_priority_map()
+    yield qcc_with_no_data
+    qcc_with_no_data.clear_cache()
+
+
+def assert_cache_with_data(
+    qcc: QueryContextCache, expected_data: ExpectedQCCData
+) -> None:
+    assert len(qcc) == MAX_CAPACITY
+
+    for idx, qce in enumerate(qcc._get_elements()):
+        assert expected_data.ids[idx] == qce.id
+        assert expected_data.timestamps[idx] == qce.read_timestamp
+        assert expected_data.priorities[idx] == qce.priority
+        assert expected_data.contexts[idx] == qce.context
+
+
+def test_is_empty(qcc_with_no_data: QueryContextCache):
+    assert len(qcc_with_no_data) == 0
+
+
+def test_deserialize_type_error():
+    json_string = """{ "entries": null }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 0  # because of TypeError, the qcc is cleared
+
+    json_string = """{
+        "entries":[
+            {
+            "id": "abc",
+            "read_timestamp": 1629456000,
+            "priority": 0,
+            "context": "sample_base64_encoded_context"
+            }
+        ]
+    }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)  # convert JSON to dict
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 0  # because of TypeError, the qcc is cleared
+
+    json_string = """{
+        "entries":[
+            {
+            "id": 0,
+            "timestamp": 111.111,
+            "priority": 0,
+            "context": "sample_base64_encoded_context"
+            }
+        ]
+    }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)  # convert JSON to dict
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 0  # because of TypeError, the qcc is cleared
+
+    json_string = """{
+        "entries":[
+            {
+            "id": 0,
+            "timestamp": 123412123,
+            "priority": "main",
+            "context": "sample_base64_encoded_context"
+            }
+        ]
+    }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)  # convert JSON to dict
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 0  # because of TypeError, the qcc is cleared
+
+    json_string = """{
+        "entries":[
+            {
+            "id": 0,
+            "timestamp": 1112314121,
+            "priority": 0,
+            "context": 1231412
+            }
+        ]
+    }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)  # convert JSON to dict
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 0  # because of TypeError, the qcc is cleared
+
+    json_string = """{
+        "entries":[
+            {
+            "id": 0,
+            "timestamp": 123142341,
+            "priority": 0,
+            "context": "sample_base64_encoded_context"
+            }
+        ]
+    }"""
+    qcc = QueryContextCache(MAX_CAPACITY)
+    data = json.loads(json_string)  # convert JSON to dict
+    qcc.deserialize_json_dict(data)
+    assert len(qcc) == 1  # because this time the input is correct, qcc size should be 1
+
+
+def test_with_data(qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData):
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_with_data_in_random_order(
+    qcc_with_data_random_order: QueryContextCache, expected_data: ExpectedQCCData
+):
+    expected_data.reset_data()
+    assert_cache_with_data(qcc_with_data_random_order, expected_data)
+
+
+def test_trim_cache(qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData):
+    qcc_with_data.insert(
+        BASE_ID + MAX_CAPACITY,
+        BASE_READ_TIMESTAMP + MAX_CAPACITY,
+        BASE_PRIORITY + MAX_CAPACITY,
+        CONTEXT,
+    )
+    qcc_with_data._sync_priority_map()
+    qcc_with_data.trim_cache()
+
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_update_timestamp(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    update_id = 1
+    qcc_with_data.insert(
+        BASE_ID + update_id,
+        BASE_READ_TIMESTAMP + update_id + 10,
+        BASE_PRIORITY + update_id,
+        CONTEXT,
+    )
+    qcc_with_data._sync_priority_map()
+    expected_data.timestamps[update_id] = BASE_READ_TIMESTAMP + update_id + 10
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_update_priority(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    update_id = 3
+    updated_priority = BASE_PRIORITY + update_id + 7
+    qcc_with_data.insert(
+        BASE_ID + update_id, BASE_READ_TIMESTAMP + update_id, updated_priority, CONTEXT
+    )
+    qcc_with_data._sync_priority_map()
+
+    for i in range(update_id, MAX_CAPACITY - 1):
+        expected_data.ids[i] = expected_data.ids[i + 1]
+        expected_data.timestamps[i] = expected_data.timestamps[i + 1]
+        expected_data.priorities[i] = expected_data.priorities[i + 1]
+    expected_data.ids[MAX_CAPACITY - 1] = BASE_ID + update_id
+    expected_data.timestamps[MAX_CAPACITY - 1] = BASE_READ_TIMESTAMP + update_id
+    expected_data.priorities[MAX_CAPACITY - 1] = updated_priority
+
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_add_same_priority(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    i = MAX_CAPACITY
+    updated_priority = BASE_PRIORITY + 1
+    qcc_with_data.insert(
+        BASE_ID + i, BASE_READ_TIMESTAMP + i, updated_priority, CONTEXT
+    )
+    qcc_with_data._sync_priority_map()
+
+    expected_data.ids[1] = BASE_ID + i
+    expected_data.timestamps[1] = BASE_READ_TIMESTAMP + i
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+# helper function to shuffle priorities in all entries
+def random_priority_shuffle(num_entries: int):
+    id_list = list(range(BASE_ID, BASE_ID + num_entries))
+    priority_list = list(range(BASE_PRIORITY, BASE_PRIORITY + num_entries))
+    # Shuffle priorities randomly
+    shuffle(priority_list)
+
+    # Create a dictionary mapping IDs to their new random priorities
+    id_to_priority = dict(zip(id_list, priority_list))
+    return id_to_priority
+
+
+def test_priority_switch_randomized(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    num_retry = MAX_CAPACITY * 5
+    for _ in range(num_retry):
+        # for each iteration, we simulate randomized priority switch for the batch of QCEs.
+        id_to_priority = random_priority_shuffle(MAX_CAPACITY)
+
+        # Update priorities using the random shuffle
+        for id, priority in id_to_priority.items():
+            qcc_with_data.insert(
+                id, BASE_READ_TIMESTAMP + MAX_CAPACITY + 10, priority, CONTEXT
+            )
+
+        qcc_with_data._sync_priority_map()
+
+        # Check if the inner priority map has been correctly updated
+        for id, priority in id_to_priority.items():
+            assert qcc_with_data._priority_map[priority].id == id
+        # Check if the inner id map has been correctly updated
+        for id in range(MAX_CAPACITY):
+            assert qcc_with_data._id_map[id].id == id
+        # Update expected_data
+        for idx, id in enumerate(
+            sorted(id_to_priority.keys(), key=lambda x: id_to_priority[x])
+        ):
+            expected_data.ids[idx] = id
+            expected_data.timestamps[idx] = BASE_READ_TIMESTAMP + MAX_CAPACITY + 10
+
+        assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_same_id_with_stale_timestamp(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    i = 2
+    qcc_with_data.insert(
+        BASE_ID + i, BASE_READ_TIMESTAMP + i - 10, BASE_PRIORITY + i, CONTEXT
+    )
+    qcc_with_data._sync_priority_map()
+    qcc_with_data.trim_cache()
+
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_empty_cache_with_null_data(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+    qcc_with_data.deserialize_json_dict(None)
+    assert len(qcc_with_data) == 0
+
+
+def test_empty_cache_with_empty_response_data(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+    qcc_with_data.deserialize_json_dict("")
+    assert len(qcc_with_data) == 0
+
+
+def test_serialization_deserialization_with_null_context(
+    qcc_with_data_null_context: QueryContextCache,
+    expected_data_with_null_context: ExpectedQCCData,
+):
+    assert_cache_with_data(qcc_with_data_null_context, expected_data_with_null_context)
+
+    data = serialize_to_json(qcc_with_data_null_context)
+
+    qcc_with_data_null_context.clear_cache()
+    assert len(qcc_with_data_null_context) == 0
+
+    data = json.loads(data)  # convert JSON to dict
+    qcc_with_data_null_context.deserialize_json_dict(data)
+    assert_cache_with_data(qcc_with_data_null_context, expected_data_with_null_context)
+
+
+def test_serialization_deserialization(
+    qcc_with_data: QueryContextCache, expected_data: ExpectedQCCData
+):
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+    data = serialize_to_json(qcc_with_data)
+    qcc_with_data.clear_cache()
+    assert len(qcc_with_data) == 0
+
+    data = json.loads(data)  # convert JSON to dict
+    qcc_with_data.deserialize_json_dict(data)
+    assert_cache_with_data(qcc_with_data, expected_data)
+
+
+def test_eviction_order():
+    qce1 = QueryContextElement(id=1, read_timestamp=13323, priority=1, context=None)
+    qce2 = QueryContextElement(id=2, read_timestamp=15522, priority=4, context="")
+
+    qce3 = QueryContextElement(
+        id=3, read_timestamp=8383, priority=99, context="generic context"
+    )
+
+    qce_list = [qce1, qce2, qce3]
+    qcc = QueryContextCache(5)
+    for qce in qce_list:
+        qcc.insert(qce.id, qce.read_timestamp, qce.priority, qce.context)
+    qcc._sync_priority_map()
+
+    assert len(qcc) == 3
+    assert qcc._last() == qce3
+    qcc._remove_qce(qcc._last())
+    assert qcc._last() == qce2
+    qcc._remove_qce(qcc._last())
+    assert qcc._last() == qce1
+    qcc._remove_qce(qcc._last())
+
+    assert len(qcc) == 0

--- a/test/unit_async/test_renew_session.py
+++ b/test/unit_async/test_renew_session.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest.mock import Mock, PropertyMock
+
+from snowflake.connector.network import SnowflakeRestful
+
+from .mock_utils import mock_connection
+
+
+def test_renew_session():
+    OLD_SESSION_TOKEN = "old_session_token"
+    OLD_MASTER_TOKEN = "old_master_token"
+    NEW_SESSION_TOKEN = "new_session_token"
+    NEW_MASTER_TOKEN = "new_master_token"
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+    type(connection)._probe_connection = PropertyMock(return_value=False)
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+    rest._token = OLD_SESSION_TOKEN
+    rest._master_token = OLD_MASTER_TOKEN
+
+    # inject a fake method (success)
+    def fake_request_exec(**_):
+        return {
+            "success": True,
+            "data": {
+                "sessionToken": NEW_SESSION_TOKEN,
+                "masterToken": NEW_MASTER_TOKEN,
+            },
+        }
+
+    rest._request_exec = fake_request_exec
+
+    rest._renew_session()
+    assert not rest._connection.errorhandler.called  # no error
+    assert rest.master_token == NEW_MASTER_TOKEN
+    assert rest.token == NEW_SESSION_TOKEN
+
+    # inject a fake method (failure)
+    def fake_request_exec(**_):
+        return {"success": False, "message": "failed to renew session", "code": 987654}
+
+    rest._request_exec = fake_request_exec
+
+    rest._renew_session()
+    assert rest._connection.errorhandler.called  # error
+
+    # no master token
+    del rest._master_token
+    rest._renew_session()
+    assert rest._connection.errorhandler.called  # error

--- a/test/unit_async/test_result_batch.py
+++ b/test/unit_async/test_result_batch.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from collections import namedtuple
+from http import HTTPStatus
+from test.helpers import create_mock_response
+from unittest import mock
+
+import pytest
+
+from snowflake.connector import DatabaseError, InterfaceError
+from snowflake.connector.compat import (
+    BAD_GATEWAY,
+    BAD_REQUEST,
+    FORBIDDEN,
+    GATEWAY_TIMEOUT,
+    INTERNAL_SERVER_ERROR,
+    METHOD_NOT_ALLOWED,
+    OK,
+    REQUEST_TIMEOUT,
+    SERVICE_UNAVAILABLE,
+    UNAUTHORIZED,
+)
+from snowflake.connector.errorcode import (
+    ER_FAILED_TO_CONNECT_TO_DB,
+    ER_FAILED_TO_REQUEST,
+)
+from snowflake.connector.errors import (
+    BadGatewayError,
+    BadRequest,
+    ForbiddenError,
+    GatewayTimeoutError,
+    InternalServerError,
+    MethodNotAllowed,
+    OtherHTTPRetryableError,
+    ServiceUnavailableError,
+)
+
+try:
+    from snowflake.connector.compat import TOO_MANY_REQUESTS
+    from snowflake.connector.errors import TooManyRequests
+    from snowflake.connector.result_batch import MAX_DOWNLOAD_RETRY, JSONResultBatch
+    from snowflake.connector.vendored import requests  # NOQA
+
+    REQUEST_MODULE_PATH = "snowflake.connector.vendored.requests"
+except ImportError:
+    MAX_DOWNLOAD_RETRY = None
+    JSONResultBatch = None
+    REQUEST_MODULE_PATH = "requests"
+    TooManyRequests = None
+    TOO_MANY_REQUESTS = None
+from snowflake.connector.sqlstate import (
+    SQLSTATE_CONNECTION_REJECTED,
+    SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+)
+
+MockRemoteChunkInfo = namedtuple("MockRemoteChunkInfo", "url")
+chunk_info = MockRemoteChunkInfo("http://www.chunk-url.com")
+result_batch = (
+    JSONResultBatch(100, None, chunk_info, [], [], True) if JSONResultBatch else None
+)
+
+
+@mock.patch(REQUEST_MODULE_PATH + ".get")
+def test_ok_response_download(mock_get):
+    mock_get.return_value = create_mock_response(200)
+
+    response = result_batch._download()
+
+    # successful on first try
+    assert mock_get.call_count == 1
+    assert response.status_code == 200
+
+
+@pytest.mark.skipolddriver
+@pytest.mark.parametrize(
+    "errcode,error_class",
+    [
+        (BAD_REQUEST, BadRequest),  # 400
+        (FORBIDDEN, ForbiddenError),  # 403
+        (METHOD_NOT_ALLOWED, MethodNotAllowed),  # 405
+        (REQUEST_TIMEOUT, OtherHTTPRetryableError),  # 408
+        (TOO_MANY_REQUESTS, TooManyRequests),  # 429
+        (INTERNAL_SERVER_ERROR, InternalServerError),  # 500
+        (BAD_GATEWAY, BadGatewayError),  # 502
+        (SERVICE_UNAVAILABLE, ServiceUnavailableError),  # 503
+        (GATEWAY_TIMEOUT, GatewayTimeoutError),  # 504
+        (555, OtherHTTPRetryableError),  # random 5xx error
+    ],
+)
+def test_retryable_response_download(errcode, error_class):
+    """This test checks that responses which are deemed 'retryable' are handled correctly."""
+    # retryable exceptions
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(errcode)
+
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(error_class) as ex:
+                _ = result_batch._download()
+            err_msg = ex.value.msg
+            if isinstance(errcode, HTTPStatus):
+                assert str(errcode.value) in err_msg
+            else:
+                assert str(errcode) in err_msg
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+def test_unauthorized_response_download():
+    """This tests that the Unauthorized response (401 status code) is handled correctly."""
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(UNAUTHORIZED)
+
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(DatabaseError) as ex:
+                _ = result_batch._download()
+            error = ex.value
+            assert error.errno == ER_FAILED_TO_CONNECT_TO_DB
+            assert error.sqlstate == SQLSTATE_CONNECTION_REJECTED
+            assert "401" in error.msg
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+@pytest.mark.parametrize("status_code", [201, 302])
+def test_non_200_response_download(status_code):
+    """This test checks that "success" codes which are not 200 still retry."""
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        mock_get.return_value = create_mock_response(status_code)
+
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(InterfaceError) as ex:
+                _ = result_batch._download()
+            error = ex.value
+            assert error.errno == ER_FAILED_TO_REQUEST
+            assert error.sqlstate == SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
+        assert mock_get.call_count == MAX_DOWNLOAD_RETRY
+
+
+def test_retries_until_success():
+    with mock.patch(REQUEST_MODULE_PATH + ".get") as mock_get:
+        error_codes = [BAD_REQUEST, UNAUTHORIZED, 201]
+        # There is an OK added to the list of responses so that there is a success
+        # and the retry loop ends.
+        mock_responses = [create_mock_response(code) for code in error_codes + [OK]]
+        mock_get.side_effect = mock_responses
+
+        with mock.patch("time.sleep", return_value=None):
+            res = result_batch._download()
+            assert res.raw == "success"
+        # call `get` once for each error and one last time when it succeeds
+        assert mock_get.call_count == len(error_codes) + 1

--- a/test/unit_async/test_retry_network.py
+++ b/test/unit_async/test_retry_network.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import time
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from uuid import uuid4
+
+import OpenSSL.SSL
+import pytest
+
+import snowflake.connector
+from snowflake.connector.compat import (
+    BAD_GATEWAY,
+    BAD_REQUEST,
+    FORBIDDEN,
+    GATEWAY_TIMEOUT,
+    INTERNAL_SERVER_ERROR,
+    OK,
+    SERVICE_UNAVAILABLE,
+    UNAUTHORIZED,
+    BadStatusLine,
+    IncompleteRead,
+)
+from snowflake.connector.errors import (
+    DatabaseError,
+    Error,
+    ForbiddenError,
+    InterfaceError,
+    OperationalError,
+    OtherHTTPRetryableError,
+    ServiceUnavailableError,
+)
+from snowflake.connector.network import (
+    STATUS_TO_EXCEPTION,
+    RetryRequest,
+    SnowflakeRestful,
+)
+from snowflake.connector.network_async import SnowflakeRestfulAsync
+
+from .mock_utils import mock_connection, mock_request_with_action, zero_backoff
+
+# We need these for our OldDriver tests. We run most up to date tests with the oldest supported driver version
+try:
+    import snowflake.connector.vendored.urllib3.contrib.pyopenssl
+    from snowflake.connector.vendored import requests, urllib3
+except ImportError:  # pragma: no cover
+    import requests
+    import urllib3
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+class Cnt:
+    def __init__(self):
+        self.c = 0
+
+    def set(self, cnt):
+        self.c = cnt
+
+    def reset(self):
+        self.set(0)
+
+
+def fake_connector() -> snowflake.connector.SnowflakeConnection:
+    return snowflake.connector.connect(
+        user="user",
+        account="account",
+        password="testpassword",
+        database="TESTDB",
+        warehouse="TESTWH",
+    )
+
+
+@patch("snowflake.connector.network_async.SnowflakeRestfulAsync._request_exec_async")
+def test_retry_reason(mockRequestExec):
+    url = ""
+    cnt = Cnt()
+
+    async def mock_exec(session, method, full_url, headers, data, token, **kwargs):
+        # take actions based on data["sqlText"]
+        nonlocal url
+        url = full_url
+        data = json.loads(data)
+        sql = data.get("sqlText", "default")
+        success_result = {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+                "idToken": None,
+                "parameters": [{"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}],
+            },
+        }
+        cnt.c += 1
+        if "retry" in sql:
+            # error = HTTP Error 429
+            if cnt.c < 3:  # retry twice for 429 error
+                raise RetryRequest(OtherHTTPRetryableError(errno=429))
+            return success_result
+        elif "unknown error" in sql:
+            # Raise unknown http error
+            if cnt.c == 1:  # retry once for 100 error
+                raise RetryRequest(OtherHTTPRetryableError(errno=100))
+            return success_result
+        elif "flip" in sql:
+            if cnt.c == 1:  # retry first with 100
+                raise RetryRequest(OtherHTTPRetryableError(errno=100))
+            elif cnt.c == 2:  # then with 429
+                raise RetryRequest(OtherHTTPRetryableError(errno=429))
+            return success_result
+
+        return success_result
+
+    conn = fake_connector()
+    mockRequestExec.side_effect = mock_exec
+
+    # ensure query requests don't have the retryReason if retryCount == 0
+    cnt.reset()
+    conn.cmd_query("success", 0, uuid4())
+    assert "retryReason" not in url
+    assert "retryCount" not in url
+
+    # ensure query requests have correct retryReason when retry reason is sent by server
+    cnt.reset()
+    conn.cmd_query("retry", 0, uuid4())
+    assert "retryReason=429" in url
+    assert "retryCount=2" in url
+
+    cnt.reset()
+    conn.cmd_query("unknown error", 0, uuid4())
+    assert "retryReason=100" in url
+    assert "retryCount=1" in url
+
+    # ensure query requests have retryReason reset to 0 when no reason is given
+    cnt.reset()
+    conn.cmd_query("success", 0, uuid4())
+    assert "retryReason" not in url
+    assert "retryCount" not in url
+
+    # ensure query requests have retryReason gets updated with updated error code
+    cnt.reset()
+    conn.cmd_query("flip", 0, uuid4())
+    assert "retryReason=429" in url
+    assert "retryCount=2" in url
+
+    # ensure that disabling works and only suppresses retryReason
+    conn._enable_retry_reason_in_query_response = False
+
+    cnt.reset()
+    conn.cmd_query("retry", 0, uuid4())
+    assert "retryReason" not in url
+    assert "retryCount=2" in url
+
+    cnt.reset()
+    conn.cmd_query("unknown error", 0, uuid4())
+    assert "retryReason" not in url
+    assert "retryCount=1" in url
+
+
+def test_request_exec():
+    connection = mock_connection()
+    connection.errorhandler = Error.default_errorhandler
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com",
+        port=443,
+        connection=connection,
+    )
+
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": '{"code": 12345}',
+        "token": None,
+    }
+
+    login_parameters = {
+        **default_parameters,
+        "full_url": "https://bad_id.snowflakecomputing.com:443/session/v1/login-request?request_id=s0m3-r3a11Y-rAnD0m-reqID&request_guid=s0m3-r3a11Y-rAnD0m-reqGUID",
+    }
+
+    # request mock
+    output_data = {"success": True, "code": 12345}
+    request_mock = MagicMock()
+    type(request_mock).status_code = PropertyMock(return_value=OK)
+    request_mock.json.return_value = output_data
+
+    # session mock
+    session = MagicMock()
+    session.request.return_value = request_mock
+
+    # success
+    ret = rest._request_exec(session=session, **default_parameters)
+    assert ret == output_data, "output data"
+
+    # retryable exceptions
+    for errcode in [
+        BAD_REQUEST,  # 400
+        FORBIDDEN,  # 403
+        INTERNAL_SERVER_ERROR,  # 500
+        BAD_GATEWAY,  # 502
+        SERVICE_UNAVAILABLE,  # 503
+        GATEWAY_TIMEOUT,  # 504
+        555,  # random 5xx error
+    ]:
+        type(request_mock).status_code = PropertyMock(return_value=errcode)
+        try:
+            rest._request_exec(session=session, **default_parameters)
+            pytest.fail("should fail")
+        except RetryRequest as e:
+            cls = STATUS_TO_EXCEPTION.get(errcode, OtherHTTPRetryableError)
+            assert isinstance(e.args[0], cls), "must be internal error exception"
+
+    # unauthorized
+    type(request_mock).status_code = PropertyMock(return_value=UNAUTHORIZED)
+    with pytest.raises(InterfaceError):
+        rest._request_exec(session=session, **default_parameters)
+
+    # unauthorized with catch okta unauthorized error
+    # TODO: what is the difference to InterfaceError?
+    type(request_mock).status_code = PropertyMock(return_value=UNAUTHORIZED)
+    with pytest.raises(DatabaseError):
+        rest._request_exec(
+            session=session, catch_okta_unauthorized_error=True, **default_parameters
+        )
+
+    # forbidden on login-request raises ForbiddenError
+    type(request_mock).status_code = PropertyMock(return_value=FORBIDDEN)
+    with pytest.raises(ForbiddenError):
+        rest._request_exec(session=session, **login_parameters)
+
+    class IncompleteReadMock(IncompleteRead):
+        def __init__(self):
+            IncompleteRead.__init__(self, "")
+
+    # handle retryable exception
+    for exc in [
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ReadTimeout,
+        IncompleteReadMock,
+        urllib3.exceptions.ProtocolError,
+        requests.exceptions.ConnectionError,
+        AttributeError,
+    ]:
+        session = MagicMock()
+        session.request = Mock(side_effect=exc)
+
+        try:
+            rest._request_exec(session=session, **default_parameters)
+            pytest.fail("should fail")
+        except RetryRequest as e:
+            cause = e.args[0]
+            assert isinstance(cause, exc), "same error class"
+
+    # handle OpenSSL errors and BadStateLine
+    for exc in [
+        OpenSSL.SSL.SysCallError(errno.ECONNRESET),
+        OpenSSL.SSL.SysCallError(errno.ETIMEDOUT),
+        OpenSSL.SSL.SysCallError(errno.EPIPE),
+        OpenSSL.SSL.SysCallError(-1),  # unknown
+        # TODO: should we keep this?
+        # urllib3.exceptions.ReadTimeoutError(None, None, None),
+        BadStatusLine("fake"),
+    ]:
+        session = MagicMock()
+        session.request = Mock(side_effect=exc)
+        try:
+            rest._request_exec(session=session, **default_parameters)
+            pytest.fail("should fail")
+        except RetryRequest as e:
+            assert e.args[0] == exc, "same error instance"
+
+
+def test_fetch():
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    cnt = Cnt()
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {"cnt": cnt},
+        "data": '{"code": 12345}',
+    }
+
+    NOT_RETRYABLE = 1000
+
+    class NotRetryableException(Exception):
+        pass
+
+    def fake_request_exec(**kwargs):
+        headers = kwargs.get("headers")
+        cnt = headers["cnt"]
+        time.sleep(3)
+        if cnt.c <= 1:
+            # the first two raises failure
+            cnt.c += 1
+            raise RetryRequest(Exception("can retry"))
+        elif cnt.c == NOT_RETRYABLE:
+            # not retryable exception
+            raise NotRetryableException("cannot retry")
+        else:
+            # return success in the third attempt
+            return {"success": True, "data": "valid data"}
+
+    # inject a fake method
+    rest._request_exec = fake_request_exec
+
+    # first two attempts will fail but third will success
+    cnt.reset()
+    ret = rest.fetch(timeout=10, **default_parameters)
+    assert ret == {"success": True, "data": "valid data"}
+    assert not rest._connection.errorhandler.called  # no error
+
+    # first attempt to reach timeout even if the exception is retryable
+    cnt.reset()
+    ret = rest.fetch(timeout=1, **default_parameters)
+    assert ret == {}
+    assert rest._connection.errorhandler.called  # error
+
+    # not retryable excpetion
+    cnt.set(NOT_RETRYABLE)
+    with pytest.raises(NotRetryableException):
+        rest.fetch(timeout=7, **default_parameters)
+
+    # first attempt fails and will not retry
+    cnt.reset()
+    default_parameters["no_retry"] = True
+    ret = rest.fetch(timeout=10, **default_parameters)
+    assert ret == {}
+    assert cnt.c == 1  # failed on first call - did not retry
+    assert rest._connection.errorhandler.called  # error
+
+
+def test_secret_masking(caplog):
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    data = (
+        '{"code": 12345,'
+        ' "data": {"TOKEN": "_Y1ZNETTn5/qfUWj3Jedb", "PASSWORD": "dummy_pass"}'
+        "}"
+    )
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": data,
+    }
+
+    class NotRetryableException(Exception):
+        pass
+
+    def fake_request_exec(**kwargs):
+        return None
+
+    # inject a fake method
+    rest._request_exec = fake_request_exec
+
+    # first two attempts will fail but third will success
+    with caplog.at_level(logging.ERROR):
+        ret = rest.fetch(timeout=10, **default_parameters)
+    assert '"TOKEN": "****' in caplog.text
+    assert '"PASSWORD": "****' in caplog.text
+    assert ret == {}
+
+
+def test_retry_connection_reset_error(caplog):
+    connection = mock_connection()
+    connection.errorhandler = Mock(return_value=None)
+
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    data = (
+        '{"code": 12345,'
+        ' "data": {"TOKEN": "_Y1ZNETTn5/qfUWj3Jedb", "PASSWORD": "dummy_pass"}'
+        "}"
+    )
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": data,
+    }
+
+    def error_recv_into(*args, **kwargs):
+        raise OSError(104, "ECONNRESET")
+
+    with patch.object(
+        snowflake.connector.vendored.urllib3.contrib.pyopenssl.WrappedSocket,
+        "recv_into",
+        new=error_recv_into,
+    ):
+        with caplog.at_level(logging.DEBUG):
+            rest.fetch(timeout=10, **default_parameters)
+
+        assert (
+            "shutting down requests session adapter due to connection aborted"
+            in caplog.text
+        )
+        assert (
+            "Ignored error caused by closing https connection failure"
+            not in caplog.text
+        )
+        assert caplog.text.count("Starting new HTTPS connection") > 1
+
+
+@pytest.mark.parametrize("next_action", ("RETRY", "ERROR"))
+@patch("snowflake.connector.vendored.requests.sessions.Session.request")
+def test_login_request_timeout(mockSessionRequest, next_action):
+    """For login requests, all errors should be bubbled up as OperationalError for authenticator to handle"""
+    mockSessionRequest.side_effect = mock_request_with_action(next_action)
+
+    connection = mock_connection()
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    with pytest.raises(OperationalError):
+        rest.fetch(
+            method="post",
+            full_url="https://testaccount.snowflakecomputing.com/session/v1/login-request",
+            headers=dict(),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "next_action_result",
+    (("RETRY", ServiceUnavailableError), ("ERROR", OperationalError)),
+)
+@patch("aiohttp.ClientSession.request")
+def test_retry_request_timeout(mockSessionRequest, next_action_result):
+    next_action, next_result = next_action_result
+    mockSessionRequest.side_effect = mock_request_with_action(next_action, 5)
+    # no backoff for testing
+    connection = mock_connection(
+        network_timeout=13,
+        backoff_policy=zero_backoff,
+    )
+    connection.errorhandler = Error.default_errorhandler
+    rest = SnowflakeRestfulAsync(
+        host="testaccount.snowflakecomputing.com", port=443, connection=connection
+    )
+
+    with pytest.raises(next_result):
+        rest.fetch(
+            method="post",
+            full_url="https://testaccount.snowflakecomputing.com/queries/v1/query-request",
+            headers=dict(),
+        )
+
+    # 13 seconds should be enough for authenticator to attempt thrice
+    # however, loosen restrictions to avoid thread scheduling causing failure
+    assert 1 < mockSessionRequest.call_count < 5

--- a/test/unit_async/test_s3_util.py
+++ b/test/unit_async/test_s3_util.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+import re
+from os import path
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from snowflake.connector import SnowflakeConnection
+from snowflake.connector.constants import SHA256_DIGEST
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.file_transfer_agent import SnowflakeFileTransferAgent
+
+from ..helpers import verify_log_tuple
+
+try:
+    from snowflake.connector.constants import megabyte
+    from snowflake.connector.errors import RequestExceedMaxRetryError
+    from snowflake.connector.file_transfer_agent import (
+        SnowflakeFileMeta,
+        StorageCredential,
+    )
+    from snowflake.connector.s3_storage_client import (
+        ERRORNO_WSAECONNABORTED,
+        EXPIRED_TOKEN,
+        SnowflakeS3RestClient,
+    )
+    from snowflake.connector.vendored.requests import HTTPError, Response
+except ImportError:
+    # Compatibility for olddriver tests
+    from requests import HTTPError, Response
+
+    from snowflake.connector.s3_util import ERRORNO_WSAECONNABORTED  # NOQA
+
+    SnowflakeFileMeta = dict
+    SnowflakeS3RestClient = None
+    RequestExceedMaxRetryError = None
+    StorageCredential = None
+    megabytes = 1024 * 1024
+    DEFAULT_MAX_RETRY = 5
+
+THIS_DIR = path.dirname(path.realpath(__file__))
+MINIMAL_METADATA = SnowflakeFileMeta(
+    name="file.txt",
+    stage_location_type="S3",
+    src_file_name="file.txt",
+)
+
+
+@pytest.mark.parametrize(
+    "input, bucket_name, s3path",
+    [
+        ("sfc-eng-regression/test_sub_dir/", "sfc-eng-regression", "test_sub_dir/"),
+        (
+            "sfc-eng-regression/stakeda/test_stg/test_sub_dir/",
+            "sfc-eng-regression",
+            "stakeda/test_stg/test_sub_dir/",
+        ),
+        ("sfc-eng-regression/", "sfc-eng-regression", ""),
+        ("sfc-eng-regression//", "sfc-eng-regression", "/"),
+        ("sfc-eng-regression///", "sfc-eng-regression", "//"),
+    ],
+)
+def test_extract_bucket_name_and_path(input, bucket_name, s3path):
+    """Extracts bucket name and S3 path."""
+    s3_loc = SnowflakeS3RestClient._extract_bucket_name_and_path(input)
+    assert s3_loc.bucket_name == bucket_name
+    assert s3_loc.path == s3path
+
+
+def test_upload_file_with_s3_upload_failed_error(tmp_path):
+    """Tests Upload file with S3UploadFailedError, which could indicate AWS token expires."""
+    file1 = tmp_path / "file1"
+    with file1.open("w") as f:
+        f.write("test1")
+    rest_client = SnowflakeFileTransferAgent(
+        MagicMock(autospec=SnowflakeCursor),
+        "PUT some_file.txt",
+        {
+            "data": {
+                "command": "UPLOAD",
+                "autoCompress": False,
+                "src_locations": [file1],
+                "sourceCompression": "none",
+                "stageInfo": {
+                    "creds": {
+                        "AWS_SECRET_KEY": "secret key",
+                        "AWS_KEY_ID": "secret id",
+                        "AWS_TOKEN": "",
+                    },
+                    "location": "some_bucket",
+                    "region": "no_region",
+                    "locationType": "S3",
+                    "path": "remote_loc",
+                    "endPoint": "",
+                },
+            },
+            "success": True,
+        },
+    )
+    exc = Exception("Stop executing")
+
+    def mock_transfer_accelerate_config(
+        self: SnowflakeS3RestClient,
+        use_accelerate_endpoint: bool | None = None,
+    ) -> bool:
+        self.endpoint = f"https://{self.s3location.bucket_name}.s3.awsamazon.com"
+        return False
+
+    with mock.patch(
+        "snowflake.connector.s3_storage_client.SnowflakeS3RestClient._has_expired_token",
+        return_value=True,
+    ):
+        with mock.patch(
+            "snowflake.connector.s3_storage_client.SnowflakeS3RestClient.transfer_accelerate_config",
+            mock_transfer_accelerate_config,
+        ):
+            with mock.patch(
+                "snowflake.connector.file_transfer_agent.StorageCredential.update",
+                side_effect=exc,
+            ) as mock_update:
+                rest_client.execute()
+                assert mock_update.called
+                assert rest_client._results[0].error_details is exc
+
+
+def test_get_header_expiry_error():
+    """Tests whether token expiry error is handled as expected when getting header."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    resp = MagicMock(
+        autospec=Response,
+        status_code=400,
+        text=f"<Error><Code>{EXPIRED_TOKEN}</Code></Error>",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, HEAD=MagicMock(return_value=resp)):
+        exc = Exception("stop execution")
+        with mock.patch.object(rest_client.credentials, "update", side_effect=exc):
+            with pytest.raises(Exception) as caught_exc:
+                rest_client.get_file_header("file.txt")
+            assert caught_exc.value is exc
+
+
+def test_get_header_unknown_error(caplog):
+    """Tests whether unexpected errors are handled as expected when getting header."""
+    caplog.set_level(logging.DEBUG, "snowflake.connector")
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    resp = Response()
+    # dont' use transient error codes
+    resp.status_code = 555
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, HEAD=MagicMock(return_value=resp)):
+        with pytest.raises(HTTPError, match="555 Server Error"):
+            rest_client.get_file_header("file.txt")
+
+
+def test_upload_expiry_error():
+    """Tests whether token expiry error is handled as expected when uploading."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    resp = MagicMock(
+        autospec=Response,
+        status_code=400,
+        text=f"<Error><Code>{EXPIRED_TOKEN}</Code></Error>",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, PUT=MagicMock(return_value=resp)):
+        exc = Exception("stop execution")
+        with mock.patch.object(rest_client.credentials, "update", side_effect=exc):
+            with mock.patch(
+                "snowflake.connector.storage_client.SnowflakeStorageClient.preprocess"
+            ):
+                rest_client.prepare_upload()
+            with pytest.raises(Exception) as caught_exc:
+                rest_client.upload_chunk(0)
+            assert caught_exc.value is exc
+
+
+def test_upload_unknown_error():
+    """Tests whether unknown errors are handled as expected when uploading."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    resp = Response()
+    resp.status_code = 555
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, PUT=MagicMock(return_value=resp)):
+        exc = Exception("stop execution")
+        with mock.patch.object(rest_client.credentials, "update", side_effect=exc):
+            with mock.patch(
+                "snowflake.connector.storage_client.SnowflakeStorageClient.preprocess"
+            ):
+                rest_client.prepare_upload()
+            with pytest.raises(HTTPError, match="555 Server Error"):
+                rest_client.upload_chunk(0)
+
+
+def test_download_expiry_error():
+    """Tests whether token expiry error is handled as expected when downloading."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": "path/to/put_get_1.txt",
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "GET file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    resp = MagicMock(
+        autospec=Response,
+        status_code=400,
+        text=f"<Error><Code>{EXPIRED_TOKEN}</Code></Error>",
+    )
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, GET=MagicMock(return_value=resp)):
+        exc = Exception("stop execution")
+        with mock.patch.object(rest_client.credentials, "update", side_effect=exc):
+            with pytest.raises(Exception) as caught_exc:
+                rest_client.download_chunk(0)
+            assert caught_exc.value is exc
+
+
+def test_download_unknown_error(caplog):
+    """Tests whether an unknown error is handled as expected when downloading."""
+    caplog.set_level(logging.DEBUG, "snowflake.connector")
+    agent = SnowflakeFileTransferAgent(
+        MagicMock(),
+        "get @~/f /tmp",
+        {
+            "data": {
+                "command": "DOWNLOAD",
+                "src_locations": ["/tmp/a"],
+                "stageInfo": {
+                    "locationType": "S3",
+                    "location": "",
+                    "creds": {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""},
+                    "region": "",
+                    "endPoint": None,
+                },
+                "localLocation": "/tmp",
+            }
+        },
+    )
+    resp = Response()
+    resp.status_code = 400
+    resp.reason = "No, just chuck testing..."
+    with mock.patch(
+        "snowflake.connector.s3_storage_client.SnowflakeS3RestClient._send_request_with_authentication_and_retry",
+        return_value=resp,
+    ), mock.patch(
+        "snowflake.connector.file_transfer_agent.SnowflakeFileTransferAgent._transfer_accelerate_config",
+        side_effect=None,
+    ):
+        agent.execute()
+    assert (
+        str(agent._file_metadata[0].error_details)
+        == "400 Client Error: No, just chuck testing... for url: None"
+    )
+    assert verify_log_tuple(
+        "snowflake.connector.storage_client",
+        logging.ERROR,
+        re.compile("Failed to download a file: .*a"),
+        caplog.record_tuples,
+    )
+
+
+def test_download_retry_exceeded_error():
+    """Tests whether a retry exceeded error is handled as expected when downloading."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": "path/to/put_get_1.txt",
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "", "AWS_KEY_ID": "", "AWS_TOKEN": ""}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "GET file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "test",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+    rest_client.SLEEP_UNIT = 0
+    resp = Response()
+    resp.status_code = 500  # Use a transient error code
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, GET=MagicMock(return_value=resp)):
+        with mock.patch.object(rest_client.credentials, "update"):
+            with pytest.raises(
+                RequestExceedMaxRetryError,
+                match=r"GET with url .* failed for exceeding maximum retries",
+            ):
+                rest_client.download_chunk(0)

--- a/test/unit_async/test_session_manager.py
+++ b/test/unit_async/test_session_manager.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from enum import Enum
+from unittest import mock
+
+from snowflake.connector.network import SnowflakeRestful
+
+try:
+    from snowflake.connector.ssl_wrap_socket import DEFAULT_OCSP_MODE
+except ImportError:
+
+    class OCSPMode(Enum):
+        FAIL_OPEN = "FAIL_OPEN"
+
+    DEFAULT_OCSP_MODE = OCSPMode.FAIL_OPEN
+
+hostname_1 = "sfctest0.snowflakecomputing.com"
+url_1 = f"https://{hostname_1}:443/session/v1/login-request"
+
+hostname_2 = "sfc-ds2-customer-stage.s3.amazonaws.com"
+url_2 = f"https://{hostname_2}/rgm1-s-sfctest0/stages/"
+url_3 = f"https://{hostname_2}/rgm1-s-sfctst0/stages/another-url"
+
+
+mock_conn = mock.Mock()
+mock_conn.disable_request_pooling = False
+mock_conn._ocsp_mode = lambda: DEFAULT_OCSP_MODE
+
+
+def close_sessions(rest: SnowflakeRestful, num_session_pools: int) -> None:
+    """Helper function to call SnowflakeRestful.close(). Asserts close was called on all SessionPools."""
+    with mock.patch("snowflake.connector.network.SessionPool.close") as close_mock:
+        rest.close()
+        assert close_mock.call_count == num_session_pools
+
+
+def create_session(
+    rest: SnowflakeRestful, num_sessions: int = 1, url: str | None = None
+) -> None:
+    """
+    Creates 'num_sessions' sessions to 'url'. This is recursive so that idle sessions
+    are not reused.
+    """
+    if num_sessions == 0:
+        return
+    with rest._use_requests_session(url):
+        create_session(rest, num_sessions - 1, url)
+
+
+@mock.patch("snowflake.connector.network.SnowflakeRestful.make_requests_session")
+def test_no_url_multiple_sessions(make_session_mock):
+    rest = SnowflakeRestful(connection=mock_conn)
+
+    create_session(rest, 2)
+
+    assert make_session_mock.call_count == 2
+
+    assert list(rest._sessions_map.keys()) == [None]
+
+    session_pool = rest._sessions_map[None]
+    assert len(session_pool._idle_sessions) == 2
+    assert len(session_pool._active_sessions) == 0
+
+    close_sessions(rest, 1)
+
+
+@mock.patch("snowflake.connector.network.SnowflakeRestful.make_requests_session")
+def test_multiple_urls_multiple_sessions(make_session_mock):
+    rest = SnowflakeRestful(connection=mock_conn)
+
+    for url in [url_1, url_2, None]:
+        create_session(rest, num_sessions=2, url=url)
+
+    assert make_session_mock.call_count == 6
+
+    hostnames = list(rest._sessions_map.keys())
+    for hostname in [hostname_1, hostname_2, None]:
+        assert hostname in hostnames
+
+    for pool in rest._sessions_map.values():
+        assert len(pool._idle_sessions) == 2
+        assert len(pool._active_sessions) == 0
+
+    close_sessions(rest, 3)
+
+
+@mock.patch("snowflake.connector.network.SnowflakeRestful.make_requests_session")
+def test_multiple_urls_reuse_sessions(make_session_mock):
+    rest = SnowflakeRestful(connection=mock_conn)
+    for url in [url_1, url_2, url_3, None]:
+        # create 10 sessions, one after another
+        for _ in range(10):
+            create_session(rest, url=url)
+
+    # only one session is created and reused thereafter
+    assert make_session_mock.call_count == 3
+
+    hostnames = list(rest._sessions_map.keys())
+    assert len(hostnames) == 3
+    for hostname in [hostname_1, hostname_2, None]:
+        assert hostname in hostnames
+
+    for pool in rest._sessions_map.values():
+        assert len(pool._idle_sessions) == 1
+        assert len(pool._active_sessions) == 0
+
+    close_sessions(rest, 3)

--- a/test/unit_async/test_split_statement.py
+++ b/test/unit_async/test_split_statement.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from io import StringIO
+from textwrap import dedent
+
+import pytest
+
+try:
+    from snowflake.connector.util_text import split_statements
+except ImportError:
+    split_statements = None
+
+try:
+    from snowflake.connector.util_text import SQLDelimiter
+except ImportError:
+    SQLDelimiter = None
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_simple_sql():
+    with StringIO("show tables") as f:
+        itr = split_statements(f)
+        assert next(itr) == ("show tables", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    with StringIO("show tables;") as f:
+        itr = split_statements(f)
+        assert next(itr) == ("show tables;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    with StringIO("select 1;select 2") as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 1;", False)
+        assert next(itr) == ("select 2", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    with StringIO("select 1;select 2;") as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 1;", False)
+        assert next(itr) == ("select 2;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = "select 1; -- test"
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 1; -- test", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 1;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = "select /* test */ 1; -- test comment select 1;"
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select /* test */ 1; -- test comment select 1;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_multiple_line_sql():
+    s = "select /* test */ 1; -- test comment\nselect 23;"
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == (("select /* test */ 1; -- test comment", False))
+        assert next(itr) == ("select 23;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select 23;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select /* test */ 1; -- test comment
+select 23; -- test comment 2"""
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select /* test */ 1; -- test comment", False)
+        assert next(itr) == ("select 23; -- test comment 2", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select 23;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select /* test */ 1; -- test comment
+select 23; /* test comment 2 */ select 3"""
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select /* test */ 1; -- test comment", False)
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("/* test comment 2 */ select 3", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("select 3", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select /* test */ 1; -- test comment
+select 23; /* test comment 2
+*/ select 3;"""
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select /* test */ 1; -- test comment", False)
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("/* test comment 2\n*/ select 3;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("select 3;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select /* test
+    continued comments 1
+    continued comments 2
+    */ 1; -- test comment
+select 23; /* test comment 2
+*/ select 3;"""
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == (
+            "select /* test\n"
+            "    continued comments 1\n"
+            "    continued comments 2\n"
+            "    */ 1; -- test comment",
+            False,
+        )
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("/* test comment 2\n*/ select 3;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select  1;", False)
+        assert next(itr) == ("select 23;", False)
+        assert next(itr) == ("select 3;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_quotes():
+    s = "select 'hello', 1; -- test comment\nselect 23,'hello"
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 'hello', 1; -- test comment", False)
+        assert next(itr) == ("select 23,'hello", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 'hello', 1;", False)
+        assert next(itr) == ("select 23,'hello", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select 'he"llo', 1; -- test comment
+select "23,'hello" """
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 'he\"llo', 1; -- test comment", False)
+        assert next(itr) == ('select "23,\'hello"', False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 'he\"llo', 1;", False)
+        assert next(itr) == ('select "23,\'hello"', False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select 'hello
+', 1; -- test comment
+select "23,'hello" """
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 'hello\n', 1; -- test comment", False)
+        assert next(itr) == ('select "23,\'hello"', False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 'hello\n', 1;", False)
+        assert next(itr) == ('select "23,\'hello"', False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """select 'hello''
+', 1; -- test comment
+select "23,'','hello" """
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 'hello''\n', 1; -- test comment", False)
+        assert next(itr) == ("select \"23,'','hello\"", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 'hello''\n', 1;", False)
+        assert next(itr) == ("select \"23,'','hello\"", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_quotes_in_comments():
+    s = "select 'hello'; -- test comment 'hello2' in comment\n/* comment 'quote'*/ select true\n"
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == (
+            "select 'hello'; -- test comment 'hello2' in comment",
+            False,
+        )
+        assert next(itr) == ("/* comment 'quote'*/ select true", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_backslash():
+    """Tests backslash in a literal.
+
+    Notes:
+        The backslash is escaped in a Python string literal. Double backslashes in a string literal represents a
+        single backslash.
+    """
+    s = "select 'hello\\\\', 1; -- test comment\nselect 23,'\nhello"
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("select 'hello\\\\', 1; -- test comment", False)
+        assert next(itr) == ("select 23,'\nhello", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("select 'hello\\\\', 1;", False)
+        assert next(itr) == ("select 23,'\nhello", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_file_with_slash_star():
+    s = "put file:///tmp/* @%tmp;\nls @%tmp;"
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("put file:///tmp/* @%tmp;", True)
+        assert next(itr) == ("ls @%tmp;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("put file:///tmp/* @%tmp;", True)
+        assert next(itr) == ("ls @%tmp;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+    s = """list @~;
+ -- first half
+put file://$SELF_DIR/staging-test-data/*.csv.gz @~;
+put file://$SELF_DIR/staging-test-data/foo.csv.gz @~;
+put file://$SELF_DIR/staging-test-data/foo.csv.gz @~ overwrite=true;
+-- second half
+put file://$SELF_DIR/staging-test-data/foo.csv.gz @~/foo;
+put file://$SELF_DIR/staging-test-data/bar.csv.gz @~/bar;
+
+list @~;
+remove @~ pattern='.*.csv.gz';
+list @~;
+"""
+
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("list @~;", False)
+        # no comment line is returned
+        assert next(itr) == (
+            "-- first half\n" "put file://$SELF_DIR/staging-test-data/*.csv.gz @~;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~ " "overwrite=true;",
+            True,
+        )
+        # no comment line is returned
+        assert next(itr) == (
+            "-- second half\n"
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~/foo;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/bar.csv.gz @~/bar;",
+            True,
+        )
+        # no empty line is returned
+        assert next(itr) == ("list @~;", False)
+        assert next(itr) == ("remove @~ pattern='.*.csv.gz';", False)
+        assert next(itr) == ("list @~;", False)
+        # last raises StopIteration
+        with pytest.raises(StopIteration):
+            next(itr)
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("list @~;", False)
+        # no comment line is returned
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/*.csv.gz @~;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~ " "overwrite=true;",
+            True,
+        )
+        # no comment line is returned
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/foo.csv.gz @~/foo;",
+            True,
+        )
+        assert next(itr) == (
+            "put file://$SELF_DIR/staging-test-data/bar.csv.gz @~/bar;",
+            True,
+        )
+        # no empty line is returned
+        assert next(itr) == ("list @~;", False)
+        assert next(itr) == ("remove @~ pattern='.*.csv.gz';", False)
+        assert next(itr) == ("list @~;", False)
+        # last raises StopIteration
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_sql_with_commands():
+    with StringIO(
+        """create or replace view aaa
+    as select * from
+    LINEITEM limit 1000;
+!spool $outfile
+show views like 'AAA';
+!spool off
+drop view if exists aaa;
+show tables"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == (
+            """create or replace view aaa
+    as select * from
+    LINEITEM limit 1000;""",
+            False,
+        )
+
+        assert next(itr) == ("""!spool $outfile""", False)
+        assert next(itr) == ("show views like 'AAA';", False)
+        assert next(itr) == ("!spool off", False)
+        assert next(itr) == ("drop view if exists aaa;", False)
+        assert next(itr) == ("show tables", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_sql_example1():
+    with StringIO(
+        """
+create or replace table a(aa int, bb string);
+truncate a;
+rm @%a;
+put file://a.txt @%a;
+copy into a;
+select * from a;
+drop table if exists a;"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("create or replace table a(aa int, bb string);", False)
+        assert next(itr) == ("truncate a;", False)
+        assert next(itr) == ("rm @%a;", False)
+        assert next(itr) == ("put file://a.txt @%a;", True)
+        assert next(itr) == ("copy into a;", False)
+        assert next(itr) == ("select * from a;", False)
+        assert next(itr) == ("drop table if exists a;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+def test_space_before_put():
+    with StringIO(
+        """
+-- sample data uploads
+    PUT file:///tmp/data.txt @%ab;
+SELECT 1; /* 134 */ select /* 567*/ 345;>
+GET @%bcd file:///tmp/aaa.txt;
+"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == (
+            """-- sample data uploads
+    PUT file:///tmp/data.txt @%ab;""",
+            True,
+        )
+        assert next(itr) == ("""SELECT 1;""", False)
+        assert next(itr) == ("""/* 134 */ select /* 567*/ 345;>""", False)
+        assert next(itr) == ("""GET @%bcd file:///tmp/aaa.txt;""", True)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_empty_statement():
+    with StringIO(
+        """select 1;
+-- tail comment1
+-- tail comment2
+"""
+    ) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("""select 1;""", False)
+        assert next(itr) == (
+            """-- tail comment1
+-- tail comment2""",
+            None,
+        )
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_multiple_comments():
+    s = """--- test comment 1
+select /*another test comments*/ 1; -- test comment 2
+-- test comment 3
+select 2;
+"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=False)
+        assert next(itr) == (
+            "--- test comment 1\n"
+            "select /*another test comments*/ 1; -- test comment 2",
+            False,
+        )
+        assert next(itr) == ("-- test comment 3\nselect 2;", False)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_comments_with_semicolon():
+    s = """--test ;
+select 1;
+"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=False)
+        assert next(itr) == ("--test ;\n" "select 1;", False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_remove_comments_end_of_line():
+    with StringIO(
+        dedent(
+            """\
+           select L_ORDERKEY,
+           L_SHIPINSTRUCT-- this is a comment
+           from lineitem
+           where L_ORDERKEY=5795896006;
+           """
+        )
+    ) as f:
+        itr = split_statements(f, remove_comments=True)
+        expected_sql = dedent(
+            """\
+        select L_ORDERKEY,
+        L_SHIPINSTRUCT
+        from lineitem
+        where L_ORDERKEY=5795896006;"""
+        )
+        assert next(itr) == (expected_sql, False)
+        with pytest.raises(StopIteration):
+            next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_comment_in_values():
+    """SNOW-51297: SnowSQL -o remove_comments=True breaks the query."""
+    # no space before a comment
+    s = """INSERT INTO foo
+VALUES (/*TIMEOUT*/ 10);"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("INSERT INTO foo\nVALUES ( 10);", False)
+
+    # no space before and after a comment
+    s = """INSERT INTO foo
+VALUES (/*TIMEOUT*/10);"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("INSERT INTO foo\nVALUES (10);", False)
+
+    # workaround
+    s = """INSERT INTO foo
+VALUES ( /*TIMEOUT*/ 10);"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("INSERT INTO foo\nVALUES (  10);", False)
+
+    # a comment start from the beginning of the line
+    s = """INSERT INTO foo VALUES (
+/*TIMEOUT*/
+10);"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == ("INSERT INTO foo VALUES (\n\n10);", False)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_multiline_double_dollar_experssion_with_removed_comments():
+    s = """CREATE FUNCTION mean(a FLOAT, b FLOAT)
+  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$
+  var c = a + b;
+  return(c / 2);
+  $$;"""
+    with StringIO(s) as f:
+        itr = split_statements(f, remove_comments=True)
+        assert next(itr) == (
+            "CREATE FUNCTION mean(a FLOAT, b FLOAT)\n"
+            "  RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$\n"
+            "  var c = a + b;\n  return(c / 2);\n  $$;",
+            False,
+        )
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_backslash_quote_escape():
+    s = """
+SELECT 1 'Snowflake\\'s 1';
+SELECT 2 'Snowflake\\'s 2'
+"""
+    with StringIO(s) as f:
+        itr = split_statements(f)
+        assert next(itr) == ("SELECT 1 'Snowflake\\'s 1';", False)
+        assert next(itr) == ("SELECT 2 'Snowflake\\'s 2'", False)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_sql_delimiter():
+    """Copy of test_sql_with_commands but with an unconventional sql_delimiter.
+
+    This test should not only verify that a random delimiter splits SQL commands correctly, but
+    also that semi colon gets added for the split statements instead of the reserved custom keywords.
+
+    Since this is a generator function the sql_delimiter cannot be passed in as a string as it might change
+    during execution, so the SnowSQL's cli class is passed in by SnowSQL. This function makes sure that this
+    behaviour is not broken by mistake.
+    """
+    delimiter = SQLDelimiter("imi")
+    with StringIO(
+        (
+            "create or replace view aaa\n"
+            "        as select * from\n"
+            "        LINEITEM limit 1000 {delimiter}\n"
+            "!spool $outfile\n"
+            "show views like 'AAA'{delimiter}\n"
+            "!spool off\n"
+            "drop view if exists aaa {delimiter}\n"
+            "show tables"
+        ).format(delimiter=delimiter.sql_delimiter)
+    ) as f:
+        itr = split_statements(f, delimiter=delimiter)
+        assert next(itr) == (
+            """create or replace view aaa
+        as select * from
+        LINEITEM limit 1000 ;""",
+            False,
+        )
+
+        assert next(itr) == ("""!spool $outfile""", False)
+        assert next(itr) == ("show views like 'AAA';", False)
+        assert next(itr) == ("!spool off", False)
+        assert next(itr) == ("drop view if exists aaa ;", False)
+        assert next(itr) == ("show tables", False)
+    with pytest.raises(StopIteration):
+        next(itr)
+
+
+@pytest.mark.skipif(split_statements is None, reason="No split_statements is available")
+def test_sql_splitting_tokenization():
+    """This tests that sql_delimiter is token sensitive."""
+    raw_sql = "select 123 as asd"
+    for c in set(raw_sql.replace(" ", "")):
+        sql = raw_sql + " " + c + " " + raw_sql
+        with StringIO(sql) as sqlio:
+            s = split_statements(sqlio, delimiter=SQLDelimiter(c))
+            assert next(s)[0] == raw_sql + " ;"
+            assert next(s)[0] == raw_sql
+
+
+@pytest.mark.skipif(
+    split_statements is None or SQLDelimiter is None,
+    reason="No split_statements or SQLDelimiter is available",
+)
+@pytest.mark.parametrize(
+    "sql, delimiter, split_stmnts",
+    [
+        ("select 1 as a__b __ select 1", "__", ["select 1 as a__b ;", "select 1"]),
+        ("select 1 as a__b/", "/", ["select 1 as a__b;"]),
+        ('select 1 as "ab" ab', "ab", ['select 1 as "ab" ;']),
+        ('select 1 as "ab"ab', "ab", ['select 1 as "ab";']),
+        ("select 1 as abab", "ab", ["select 1 as abab"]),
+        ("insert into table t1 values (1)/", "/", ["insert into table t1 values (1);"]),
+        ("select 1 as a$_", "_", ["select 1 as a$_"]),
+        ("select 1 as _$", "_", ["select 1 as _$"]),
+    ],
+)
+def test_sql_splitting_various(sql, delimiter, split_stmnts):
+    """This tests various smaller sql splitting pitfalls."""
+    with StringIO(sql) as sqlio:
+        statements = list(
+            s[0] for s in split_statements(sqlio, delimiter=SQLDelimiter(delimiter))
+        )
+    assert statements == split_stmnts

--- a/test/unit_async/test_storage_client.py
+++ b/test/unit_async/test_storage_client.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#

--- a/test/unit_async/test_telemetry.py
+++ b/test/unit_async/test_telemetry.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import snowflake.connector.telemetry
+from snowflake.connector.description import CLIENT_NAME, SNOWFLAKE_CONNECTOR_VERSION
+
+
+def test_telemetry_data_to_dict():
+    """Tests that TelemetryData instances are properly converted to dicts."""
+    assert snowflake.connector.telemetry.TelemetryData({}, 2000).to_dict() == {
+        "message": {},
+        "timestamp": "2000",
+    }
+
+    d = {"type": "test", "query_id": "1", "value": 20}
+    assert snowflake.connector.telemetry.TelemetryData(d, 1234).to_dict() == {
+        "message": d,
+        "timestamp": "1234",
+    }
+
+
+def get_client_and_mock():
+    rest_call = Mock()
+    rest_call.return_value = {"success": True}
+    rest = Mock()
+    rest.attach_mock(rest_call, "request")
+    client = snowflake.connector.telemetry.TelemetryClient(rest, 2)
+    return client, rest_call
+
+
+def test_telemetry_simple_flush():
+    """Tests that metrics are properly enqueued and sent to telemetry."""
+    client, rest_call = get_client_and_mock()
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert rest_call.call_count == 0
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 3000))
+    assert rest_call.call_count == 1
+
+
+def test_telemetry_close():
+    """Tests that remaining metrics are flushed on close."""
+    client, rest_call = get_client_and_mock()
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert rest_call.call_count == 0
+
+    client.close()
+    assert rest_call.call_count == 1
+    assert client.is_closed
+
+
+def test_telemetry_close_empty():
+    """Tests that no calls are made on close if there are no metrics to flush."""
+    client, rest_call = get_client_and_mock()
+
+    client.close()
+    assert rest_call.call_count == 0
+    assert client.is_closed
+
+
+def test_telemetry_send_batch():
+    """Tests that metrics are sent with the send_batch method."""
+    client, rest_call = get_client_and_mock()
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert rest_call.call_count == 0
+
+    client.send_batch()
+    assert rest_call.call_count == 1
+
+
+def test_telemetry_send_batch_empty():
+    """Tests that send_batch does nothing when there are no metrics to send."""
+    client, rest_call = get_client_and_mock()
+
+    client.send_batch()
+    assert rest_call.call_count == 0
+
+
+def test_telemetry_send_batch_clear():
+    """Tests that send_batch clears the first batch and will not send anything on a second call."""
+    client, rest_call = get_client_and_mock()
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert rest_call.call_count == 0
+
+    client.send_batch()
+    assert rest_call.call_count == 1
+
+    client.send_batch()
+    assert rest_call.call_count == 1
+
+
+def test_telemetry_auto_disable():
+    """Tests that the client will automatically disable itself if a request fails."""
+    client, rest_call = get_client_and_mock()
+    rest_call.return_value = {"success": False}
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert client.is_enabled()
+
+    client.send_batch()
+    assert not client.is_enabled()
+
+
+def test_telemetry_add_batch_disabled():
+    """Tests that the client will not add logs if disabled."""
+    client, _ = get_client_and_mock()
+
+    client.disable()
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+
+    assert client.buffer_size() == 0
+
+
+def test_telemetry_send_batch_disabled():
+    """Tests that the client will not send logs if disabled."""
+    client, rest_call = get_client_and_mock()
+
+    client.add_log_to_batch(snowflake.connector.telemetry.TelemetryData({}, 2000))
+    assert client.buffer_size() == 1
+
+    client.disable()
+
+    client.send_batch()
+    assert client.buffer_size() == 1
+    assert rest_call.call_count == 0
+
+
+def test_generate_telemetry_data_dict_with_basic_info():
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict() == {
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+        snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: CLIENT_NAME,
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(from_dict={}) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+        snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: CLIENT_NAME,
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={"key": "value"}
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+        snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: CLIENT_NAME,
+        "key": "value",
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: "CUSTOM_CLIENT_NAME",
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: "1.2.3",
+            "key": "value",
+        }
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: "CUSTOM_CLIENT_NAME",
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: "1.2.3",
+        snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: CLIENT_NAME,
+        "key": "value",
+    }
+
+    mock_connection = Mock()
+    mock_connection.application = "test_application"
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: "CUSTOM_CLIENT_NAME",
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: "1.2.3",
+            "key": "value",
+        },
+        connection=mock_connection,
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: "CUSTOM_CLIENT_NAME",
+        snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: "1.2.3",
+        snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: mock_connection.application,
+        "key": "value",
+    }
+
+
+def test_generate_telemetry_data():
+    telemetry_data = (
+        snowflake.connector.telemetry.TelemetryData.from_telemetry_data_dict(
+            from_dict={}, timestamp=123
+        )
+    )
+    assert (
+        telemetry_data.message
+        == {
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+            snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: CLIENT_NAME,
+        }
+        and telemetry_data.timestamp == 123
+    )
+
+    mock_connection = Mock()
+    mock_connection.application = "test_application"
+    telemetry_data = (
+        snowflake.connector.telemetry.TelemetryData.from_telemetry_data_dict(
+            from_dict={},
+            timestamp=123,
+            connection=mock_connection,
+        )
+    )
+    assert (
+        telemetry_data.message
+        == {
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+            snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: mock_connection.application,
+        }
+        and telemetry_data.timestamp == 123
+    )
+
+    telemetry_data = (
+        snowflake.connector.telemetry.TelemetryData.from_telemetry_data_dict(
+            from_dict={"key": "value"},
+            timestamp=123,
+            connection=mock_connection,
+        )
+    )
+    assert (
+        telemetry_data.message
+        == {
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_TYPE.value: CLIENT_NAME,
+            snowflake.connector.telemetry.TelemetryField.KEY_DRIVER_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+            snowflake.connector.telemetry.TelemetryField.KEY_SOURCE.value: mock_connection.application,
+            "key": "value",
+        }
+        and telemetry_data.timestamp == 123
+    )

--- a/test/unit_async/test_telemetry_oob.py
+++ b/test/unit_async/test_telemetry_oob.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import snowflake.connector.errorcode
+import snowflake.connector.telemetry
+from snowflake.connector.description import CLIENT_NAME, SNOWFLAKE_CONNECTOR_VERSION
+from snowflake.connector.errorcode import ER_FAILED_TO_REQUEST
+from snowflake.connector.errors import RevocationCheckError
+from snowflake.connector.ocsp_snowflake import OCSPTelemetryData
+from snowflake.connector.sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
+from snowflake.connector.telemetry_oob import TelemetryService
+
+DEV_CONFIG = {
+    "host": "localhost",
+    "port": 8080,
+    "account": "testAccount",
+    "user": "test",
+    "password": "ShouldNotShowUp",
+    "protocol": "http",
+}
+TEST_RACE_CONDITION_THREAD_COUNT = 2
+TEST_RACE_CONDITION_DELAY_SECONDS = 1
+telemetry_data = {}
+exception = RevocationCheckError("Test OCSP Revocation error")
+event_type = "Test OCSP Exception"
+stack_trace = [
+    "Traceback (most recent call last):\n",
+    '  File "<doctest...>", line 10, in <module>\n    lumberjack()\n',
+    '  File "<doctest...>", line 4, in lumberjack\n    bright_side_of_death()\n',
+    '  File "<doctest...>", line 7, in bright_side_of_death\n    return tuple()[0]\n',
+    "IndexError: tuple index out of range\n",
+]
+
+event_name = "HttpRetryTimeout"
+url = "http://localhost:8080/queries/v1/query-request?request_guid=a54a3d70-abf2-4576-bb6f-ddf23999491a"
+method = "POST"
+
+
+@pytest.fixture()
+def telemetry_setup(request):
+    """Sets up the telemetry service by enabling it and flushing any entries."""
+    telemetry = TelemetryService.get_instance()
+    telemetry.update_context(DEV_CONFIG)
+    telemetry.enable()
+    telemetry.flush()
+
+
+def test_telemetry_oob_simple_flush(telemetry_setup, caplog):
+    """Tests capturing and sending a simple OCSP Exception message."""
+    telemetry = TelemetryService.get_instance()
+    telemetry.flush()  # clear the buffer first
+    telemetry.log_ocsp_exception(
+        event_type, telemetry_data, exception=exception, stack_trace=stack_trace
+    )
+    assert telemetry.size() == 1
+    caplog.set_level(logging.DEBUG, "snowflake.connector.telemetry_oob")
+    telemetry.flush()
+    assert (
+        "Failed to generate a JSON dump from the passed in telemetry OOB events"
+        not in caplog.text
+    )
+    # since pytests can run test in parallel and TelemetryService is a singleton, other tests
+    # might encounter error logged into the queue of the OOB Telemetry simultaneously
+    # leading to assert telemetry.size() == 0 failure
+    # here we check that the OCSP exception event in the test is flushed
+    for event in list(telemetry.queue.queue):
+        assert "OCSPException" not in event.name
+
+
+@pytest.mark.flaky(reruns=3)
+def test_telemetry_oob_urgent(telemetry_setup):
+    """Tests sending an urgent OCSP Exception message."""
+    telemetry = TelemetryService.get_instance()
+
+    telemetry.log_ocsp_exception(
+        event_type,
+        telemetry_data,
+        exception=exception,
+        stack_trace=stack_trace,
+        urgent=True,
+    )
+    assert telemetry.size() == 0
+
+
+def test_telemetry_oob_close(telemetry_setup):
+    """Tests closing the Telemetry Service when there are still messages in the queue."""
+    telemetry = TelemetryService.get_instance()
+
+    telemetry.log_ocsp_exception(
+        event_type, telemetry_data, exception=exception, stack_trace=stack_trace
+    )
+    assert telemetry.size() == 1
+    telemetry.close()
+    assert telemetry.size() == 0
+
+
+def test_telemetry_oob_close_empty(telemetry_setup):
+    """Tests closing the Telemetry Service when the queue is empty."""
+    telemetry = TelemetryService.get_instance()
+
+    assert telemetry.size() == 0
+    telemetry.close()
+    assert telemetry.size() == 0
+
+
+def test_telemetry_oob_log_when_disabled(telemetry_setup):
+    """Tests trying to log to the telemetry service when it is disabled."""
+    telemetry = TelemetryService.get_instance()
+
+    assert telemetry.size() == 0
+    telemetry.disable()
+    telemetry.log_ocsp_exception(
+        event_type, telemetry_data, exception=exception, stack_trace=stack_trace
+    )
+    assert telemetry.size() == 0
+    telemetry.enable()
+
+
+def test_telemetry_oob_http_log(telemetry_setup):
+    """Tests sending a simple HTTP request telemetry event."""
+    telemetry = TelemetryService.get_instance()
+
+    telemetry.log_http_request_error(
+        event_name,
+        url,
+        method,
+        SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+        ER_FAILED_TO_REQUEST,
+        exception=exception,
+        stack_trace=stack_trace,
+    )
+    assert telemetry.size() == 1
+    telemetry.flush()
+    assert telemetry.size() == 0
+
+
+def test_telemetry_oob_error_code_mapping():
+    """Tests that all OCSP error codes have a corresponding Telemetry sub event type."""
+    ec_dict = snowflake.connector.errorcode.__dict__
+    for ec, ec_val in ec_dict.items():
+        if not ec.startswith("__") and ec not in ("annotations",):
+            if 254000 <= ec_val < 255000:
+                assert ec_val in OCSPTelemetryData.ERROR_CODE_MAP
+
+
+@pytest.mark.flaky(reruns=3)
+def test_telemetry_oob_http_log_urgent(telemetry_setup):
+    """Tests sending an urgent HTTP request telemetry event."""
+    telemetry = TelemetryService.get_instance()
+
+    assert telemetry.size() == 0
+    telemetry.log_http_request_error(
+        event_name,
+        url,
+        method,
+        SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+        ER_FAILED_TO_REQUEST,
+        exception=exception,
+        stack_trace=stack_trace,
+        urgent=True,
+    )
+    assert telemetry.size() == 0
+
+
+def test_generate_telemetry_with_driver_info():
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        is_oob_telemetry=True
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_DRIVER.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={}, is_oob_telemetry=True
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_DRIVER.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={"key": "value"}, is_oob_telemetry=True
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_DRIVER.value: CLIENT_NAME,
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_VERSION.value: SNOWFLAKE_CONNECTOR_VERSION,
+        "key": "value",
+    }
+
+    assert snowflake.connector.telemetry.generate_telemetry_data_dict(
+        from_dict={
+            snowflake.connector.telemetry.TelemetryField.KEY_OOB_DRIVER.value: "CUSTOM_CLIENT_NAME",
+            snowflake.connector.telemetry.TelemetryField.KEY_OOB_VERSION.value: "1.2.3",
+            "key": "value",
+        },
+        is_oob_telemetry=True,
+    ) == {
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_DRIVER.value: "CUSTOM_CLIENT_NAME",
+        snowflake.connector.telemetry.TelemetryField.KEY_OOB_VERSION.value: "1.2.3",
+        "key": "value",
+    }
+
+
+class MockTelemetryService(TelemetryService):
+    """Mocks a delay in the __init__ of TelemetryService to simulate a race condition"""
+
+    def __init__(self, *args, **kwargs):
+        # this delay all but guarantees enough time to catch multiple threads entering __init__
+        time.sleep(TEST_RACE_CONDITION_DELAY_SECONDS)
+        super().__init__(*args, **kwargs)
+
+
+def test_get_instance_multithreaded():
+    """Tests thread safety of multithreaded calls to TelemetryService.get_instance()"""
+    TelemetryService._TelemetryService__instance = None
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(MockTelemetryService.get_instance)
+            for _ in range(TEST_RACE_CONDITION_THREAD_COUNT)
+        ]
+        for future in futures:
+            # will error if singleton constraint violated
+            future.result()

--- a/test/unit_async/test_url_util.py
+++ b/test/unit_async/test_url_util.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+try:
+    from snowflake.connector.url_util import is_valid_url, url_encode_str
+except ImportError:
+
+    def is_valid_url(s):
+        return False
+
+    def url_encode_str(s):
+        return ""
+
+
+def test_url_validator():
+    assert is_valid_url("https://ssoTestURL.okta.com")
+    assert is_valid_url("https://ssoTestURL.okta.com:8080")
+    assert is_valid_url("https://ssoTestURL.okta.com/testpathvalue")
+
+    assert not is_valid_url("-a Calculator")
+    assert not is_valid_url("This is a random text")
+    assert not is_valid_url("file://TestForFile")
+
+
+def test_encoder():
+    assert url_encode_str("Hello @World") == "Hello+%40World"
+    assert url_encode_str("Test//String") == "Test%2F%2FString"
+    assert url_encode_str(None) == ""

--- a/tox.ini
+++ b/tox.ini
@@ -175,6 +175,7 @@ markers =
     # Test type markers
     integ: integration tests
     unit: unit tests
+    unit_async: async unit tests (mostly duplicated unit tests)
     skipolddriver: skip for old driver tests
     # Other markers
     timeout: tests that need a timeout time


### PR DESCRIPTION
[See the related epic issue here](https://snowflakecomputing.atlassian.net/browse/SNOW-912527).

[See the project doc here (not fully up to date)](https://docs.google.com/document/d/1gGuDv_6p5GsiJw9IaBFdvLpRJHN6-0MxsYzLW8mDQco/edit?usp=sharing).

I ended up doing milestone 3 along with milestone 1 in this PR because the changes were all related.

The relevant issues are:

- [Refactor requests in SnowflakeRestful to aiohttp](https://snowflakecomputing.atlassian.net/browse/SNOW-959901)
- [Refactor requests in SnowflakeStorageClient and SnowflakeS3RestClient to aiohttp](https://snowflakecomputing.atlassian.net/browse/SNOW-986175)
- [Move asyncio event loop execution to separate thread](https://snowflakecomputing.atlassian.net/browse/SNOW-982773)
- [Change SessionPool to support aiohttp ClientSessions](https://snowflakecomputing.atlassian.net/browse/SNOW-959914)
- [Add proxy support to aiohttp in SnowflakeRestful](https://snowflakecomputing.atlassian.net/browse/SNOW-959916)
- [Performance testing for requests via aiohttp & preliminary unit testing](https://snowflakecomputing.atlassian.net/browse/SNOW-973744)

Most changes are explained in comments prefixed with `# YICHUAN: ...`. This pull request is for review purposes only. A formal pull request will be made when merging into main.

This isn't actually a 9000 line PR. Most of the lines are from copied files.

Regarding unit tests, I've currently copied all existing unit tests to `unit_async` and modified broken ones to work with async. Note that unit test coverage is not complete as many unit tests in `unit_async` still test `SnowflakeRestful` instead of `SnowflakeRestfulAsync`; the async unit tests are only to give us some reassurance that **probably** nothing is broken. Full unit testing will be approached at the end of the project and may be out of scope.