### PR TITLE
SNOW-901801: fix flaky test of ocsp cache in regression test

### DIFF
--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -29,7 +29,7 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     echo "[Info] Testing with ${PYTHON_VERSION}"
     SHORT_VERSION=$(python3 -c "print('${PYTHON_VERSION}'.replace('.', ''))")
     CONNECTOR_WHL=$(ls ${CONNECTOR_DIR}/dist/snowflake_connector_python*cp${SHORT_VERSION}*.whl)
-    TEST_ENVLIST=py${SHORT_VERSION}-{unit,integ,pandas,sso}-ci
+    TEST_ENVLIST=fix_lint,py${SHORT_VERSION}-{unit,integ,pandas,sso}-ci,py${SHORT_VERSION}-coverage
     echo "[Info] Running tox for ${TEST_ENVLIST}"
     tox -e ${TEST_ENVLIST} --external_wheels ${CONNECTOR_WHL}
 done


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-901801

in our regression test env, we only have one mac node, and tests of different python versions are paralleled, so race condition takes place when tests are reading/writing the same ocsp cache file on disk leading to flaky behavior.
to fix the issue, in the test we mock patch the module variable cache to use a different file

also we fix the shell script which misses the coverage part

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
