### PR TITLE
SNOW-997139: Support Python 3.12

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -80,7 +80,7 @@ jobs:
             id: macosx_x86_64
           - image: macos-latest
             id: macosx_arm64
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: Build ${{ matrix.os.id }}-py${{ matrix.python-version }}
     runs-on: ${{ matrix.os.image }}
     steps:
@@ -124,7 +124,7 @@ jobs:
            download_name: macosx_x86_64
          - image_name: windows-2019
            download_name: win_amd64
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         cloud-provider: [aws, azure, gcp]
     steps:
       - uses: actions/checkout@v3
@@ -289,7 +289,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         cloud-provider: [aws]
     steps:
       - name: Set shortver

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -96,7 +96,7 @@ jobs:
           platforms: all
       - uses: actions/checkout@v3
       - name: Building wheel
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: cp${{ env.shortver }}-${{ matrix.os.id }}
           MACOSX_DEPLOYMENT_TARGET: 10.14  # Should be kept in sync with ci/build_darwin.sh

--- a/.github/workflows/create_req_files.yml
+++ b/.github/workflows/create_req_files.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Added a new boolean parameter `force_return_table` to `SnowflakeCursor.fetch_arrow_all` to force returning `pyarrow.Table` in case of zero rows.
   - Cleanup some C++ code warnings and performance issues.
+  - Added support for Python 3.12
 
 - v3.6.0(December 09,2023)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ timestamps {
           'Test Python 39': { build job: 'RT-PyConnector39-PC',parameters: params},
           'Test Python 310': { build job: 'RT-PyConnector310-PC',parameters: params},
           'Test Python 311': { build job: 'RT-PyConnector311-PC',parameters: params},
+          'Test Python 312': { build job: 'RT-PyConnector312-PC',parameters: params},
           )
         }
       }

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -5,9 +5,9 @@
 #   - To compile only a specific version(s) pass in versions like: `./build_darwin.sh "3.8 3.9"`
 arch=$(uname -m)
 if [[ "$arch" == "arm64" ]]; then
-  PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11}"
+  PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11 3.12}"
 else
-  PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11}"
+  PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11 3.12}"
 fi
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -7,7 +7,7 @@
 set -o pipefail
 
 U_WIDTH=16
-PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11}"
+PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11 3.12}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="${CONNECTOR_DIR}/dist"

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -6,7 +6,7 @@
 SET SCRIPT_DIR=%~dp0
 SET CONNECTOR_DIR=%~dp0\..\
 
-set python_versions= 3.8 3.9 3.10 3.11
+set python_versions= 3.8 3.9 3.10 3.11 3.12
 
 cd %CONNECTOR_DIR%
 

--- a/ci/docker/connector_build/Dockerfile
+++ b/ci/docker/connector_build/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /home/user
 RUN chmod 777 /home/user
 RUN git clone https://github.com/matthew-brett/multibuild.git && cd /home/user/multibuild && git checkout bfc6d8b82d8c37b8ca1e386081fd800e81c6ab4a
 
-ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin"
+ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/docker/connector_test/Dockerfile
+++ b/ci/docker/connector_test/Dockerfile
@@ -12,6 +12,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 WORKDIR /home/user
 RUN chmod 777 /home/user
-ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin/:/opt/python/cp39-cp39/bin/:/opt/python/cp310-cp310/bin/:/opt/python/cp311-cp311/bin/"
+ENV PATH="${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin/:/opt/python/cp39-cp39/bin/:/opt/python/cp310-cp310/bin/:/opt/python/cp311-cp311/bin/:/opt/python/cp312-cp312/bin/"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/docker/connector_test_lambda/Dockerfile312
+++ b/ci/docker/connector_test_lambda/Dockerfile312
@@ -1,7 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.12-x86_64
 
-RUN yum install -y git
-
 WORKDIR /home/user/snowflake-connector-python
 RUN chmod 777 /home/user/snowflake-connector-python
 ENV PATH="${PATH}:/opt/python/cp312-cp312/bin/"

--- a/ci/docker/connector_test_lambda/Dockerfile312
+++ b/ci/docker/connector_test_lambda/Dockerfile312
@@ -1,0 +1,12 @@
+FROM public.ecr.aws/lambda/python:3.12-x86_64
+
+RUN yum install -y git
+
+WORKDIR /home/user/snowflake-connector-python
+RUN chmod 777 /home/user/snowflake-connector-python
+ENV PATH="${PATH}:/opt/python/cp312-cp312/bin/"
+ENV PYTHONPATH="${PYTHONPATH}:/home/user/snowflake-connector-python/ci/docker/connector_test_lambda/"
+
+RUN pip3 install -U pip setuptools wheel tox tox-external_wheels
+
+CMD [ "app.handler" ]

--- a/ci/docker/connector_test_lambda/app.py
+++ b/ci/docker/connector_test_lambda/app.py
@@ -6,7 +6,7 @@ from subprocess import PIPE, Popen
 
 LOGGER = logging.getLogger(__name__)
 REPO_PATH = "/home/user/snowflake-connector-python"
-PY_SHORT_VER = f"{sys.version_info[0]}{sys.version_info[1]}"  # 38, 39, 310, 311
+PY_SHORT_VER = f"{sys.version_info[0]}{sys.version_info[1]}"  # 38, 39, 310, 311, 312
 ARCH = "x86"  # x86, aarch64
 
 

--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -5,7 +5,7 @@
 #   - Versions to be tested should be passed in as the first argument, e.g: "3.8 3.9". If omitted 3.8-3.11 will be assumed.
 #   - This script uses .. to download the newest wheel files from S3
 
-PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11}"
+PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11 3.12}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 PARAMETERS_DIR="${CONNECTOR_DIR}/.github/workflows/parameters/public"

--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -6,7 +6,7 @@
 #   - This script assumes that ../dist/repaired_wheels has the wheel(s) built for all versions to be tested
 #   - This is the script that test_docker.sh runs inside of the docker container
 
-PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11}"
+PYTHON_VERSIONS="${1:-3.8 3.9 3.10 3.11 3.12}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: SQL
     Topic :: Database
     Topic :: Scientific/Engineering :: Information Analysis

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import decimal
 import time
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from logging import getLogger
 from sys import byteorder
 from typing import TYPE_CHECKING
@@ -33,7 +33,7 @@ try:
 except ImportError:
     tzlocal = None
 
-ZERO_EPOCH = datetime.utcfromtimestamp(0)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
 logger = getLogger(__name__)
 
@@ -99,7 +99,9 @@ class ArrowConverterContext:
         return t.replace(tzinfo=tzinfo)
 
     def TIMESTAMP_NTZ_to_python(self, epoch: int, microseconds: int) -> datetime:
-        return datetime.utcfromtimestamp(epoch) + timedelta(microseconds=microseconds)
+        return datetime.fromtimestamp(epoch, timezone.utc) + timedelta(
+            microseconds=microseconds
+        )
 
     def TIMESTAMP_NTZ_to_python_windows(
         self, epoch: int, microseconds: int

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     tzlocal = None
 
-ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc).replace(tzinfo=None)
 
 logger = getLogger(__name__)
 
@@ -99,9 +99,9 @@ class ArrowConverterContext:
         return t.replace(tzinfo=tzinfo)
 
     def TIMESTAMP_NTZ_to_python(self, epoch: int, microseconds: int) -> datetime:
-        return datetime.fromtimestamp(epoch, timezone.utc) + timedelta(
-            microseconds=microseconds
-        )
+        return datetime.fromtimestamp(epoch, timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(microseconds=microseconds)
 
     def TIMESTAMP_NTZ_to_python_windows(
         self, epoch: int, microseconds: int

--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -392,7 +392,7 @@ class Auth:
                     "Token expires at: %s. "
                     "Current Time: %s",
                     str(auth_instance._jwt_token_exp),
-                    str(datetime.now(timezone.utc)),
+                    str(datetime.now(timezone.utc).replace(tzinfo=None)),
                 )
             from . import AuthByUsrPwdMfa
 

--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -11,7 +11,7 @@ import logging
 import tempfile
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from os import getenv, makedirs, mkdir, path, remove, removedirs, rmdir
 from os.path import expanduser
 from threading import Lock, Thread
@@ -392,7 +392,7 @@ class Auth:
                     "Token expires at: %s. "
                     "Current Time: %s",
                     str(auth_instance._jwt_token_exp),
-                    str(datetime.utcnow()),
+                    str(datetime.now(timezone.utc)),
                 )
             from . import AuthByUsrPwdMfa
 

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from typing import Any
 
@@ -103,7 +103,7 @@ class AuthByKeyPair(AuthByPlugin):
         account = account.upper()
         user = user.upper()
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         if isinstance(self._private_key, bytes):
             try:

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -103,7 +103,7 @@ class AuthByKeyPair(AuthByPlugin):
         account = account.upper()
         user = user.upper()
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
 
         if isinstance(self._private_key, bytes):
             try:

--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 import os
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 from random import choice
 from string import hexdigits
@@ -90,7 +90,7 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
             headers = {}
 
         def generate_authenticated_url_and_rest_args() -> tuple[bytes, dict[str, Any]]:
-            curtime = datetime.utcnow()
+            curtime = datetime.now(timezone.utc)
             timestamp = curtime.strftime("YYYY-MM-DD")
             sas_token = self.credentials.creds["AZURE_SAS_TOKEN"]
             if sas_token and sas_token.startswith("?"):

--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -90,7 +90,7 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
             headers = {}
 
         def generate_authenticated_url_and_rest_args() -> tuple[bytes, dict[str, Any]]:
-            curtime = datetime.now(timezone.utc)
+            curtime = datetime.now(timezone.utc).replace(tzinfo=None)
             timestamp = curtime.strftime("YYYY-MM-DD")
             sas_token = self.credentials.creds["AZURE_SAS_TOKEN"]
             if sas_token and sas_token.startswith("?"):

--- a/src/snowflake/connector/connection_diagnostic.py
+++ b/src/snowflake/connector/connection_diagnostic.py
@@ -211,7 +211,7 @@ class ConnectionDiagnostic:
                     conn.send(str.encode(connect))
                     conn.recv(4096).decode("utf-8")
 
-                context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                 sock = context.wrap_socket(conn, server_hostname=host)
                 certificate = ssl.DER_cert_to_PEM_cert(sock.getpeercert(True))
                 conn.close()

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -11,7 +11,7 @@ import json
 import time
 from datetime import date, datetime
 from datetime import time as dt_t
-from datetime import timedelta, tzinfo
+from datetime import timedelta, timezone, tzinfo
 from functools import partial
 from logging import getLogger
 from math import ceil
@@ -42,7 +42,7 @@ except ImportError:
 BITS_FOR_TIMEZONE = 14
 ZERO_TIMEDELTA = timedelta(seconds=0)
 ZERO_EPOCH_DATE = date(1970, 1, 1)
-ZERO_EPOCH = datetime.utcfromtimestamp(0)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
 ZERO_FILL = "000000000"
 
 logger = getLogger(__name__)
@@ -220,7 +220,7 @@ class SnowflakeConverter:
 
         def conv(value: str) -> date:
             try:
-                return datetime.utcfromtimestamp(int(value) * 86400).date()
+                return datetime.fromtimestamp(int(value) * 86400, timezone.utc).date()
             except (OSError, ValueError) as e:
                 logger.debug("Failed to convert: %s", e)
                 ts = ZERO_EPOCH + timedelta(seconds=int(value) * (24 * 60 * 60))
@@ -318,11 +318,11 @@ class SnowflakeConverter:
         scale = ctx["scale"]
 
         def conv0(value: str) -> time:
-            return datetime.utcfromtimestamp(float(value)).time()
+            return datetime.fromtimestamp(float(value), timezone.utc).time()
 
         def conv(value: str) -> dt_t:
             microseconds = float(value[0 : -scale + 6])
-            return datetime.utcfromtimestamp(microseconds).time()
+            return datetime.fromtimestamp(microseconds, timezone.utc).time()
 
         return conv if scale > 6 else conv0
 
@@ -763,5 +763,7 @@ class SnowflakeConverter:
             value=value, scale=scale
         )
         if not tz:
-            return datetime.utcfromtimestamp(seconds) + timedelta(microseconds=fraction)
+            return datetime.fromtimestamp(seconds, timezone.utc) + timedelta(
+                microseconds=fraction
+            )
         return datetime.fromtimestamp(seconds, tz=tz) + timedelta(microseconds=fraction)

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -42,7 +42,7 @@ except ImportError:
 BITS_FOR_TIMEZONE = 14
 ZERO_TIMEDELTA = timedelta(seconds=0)
 ZERO_EPOCH_DATE = date(1970, 1, 1)
-ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc).replace(tzinfo=None)
 ZERO_FILL = "000000000"
 
 logger = getLogger(__name__)
@@ -220,7 +220,11 @@ class SnowflakeConverter:
 
         def conv(value: str) -> date:
             try:
-                return datetime.fromtimestamp(int(value) * 86400, timezone.utc).date()
+                return (
+                    datetime.fromtimestamp(int(value) * 86400, timezone.utc)
+                    .replace(tzinfo=None)
+                    .date()
+                )
             except (OSError, ValueError) as e:
                 logger.debug("Failed to convert: %s", e)
                 ts = ZERO_EPOCH + timedelta(seconds=int(value) * (24 * 60 * 60))
@@ -318,11 +322,19 @@ class SnowflakeConverter:
         scale = ctx["scale"]
 
         def conv0(value: str) -> time:
-            return datetime.fromtimestamp(float(value), timezone.utc).time()
+            return (
+                datetime.fromtimestamp(float(value), timezone.utc)
+                .replace(tzinfo=None)
+                .time()
+            )
 
         def conv(value: str) -> dt_t:
             microseconds = float(value[0 : -scale + 6])
-            return datetime.fromtimestamp(microseconds, timezone.utc).time()
+            return (
+                datetime.fromtimestamp(microseconds, timezone.utc)
+                .replace(tzinfo=None)
+                .time()
+            )
 
         return conv if scale > 6 else conv0
 
@@ -763,7 +775,7 @@ class SnowflakeConverter:
             value=value, scale=scale
         )
         if not tz:
-            return datetime.fromtimestamp(seconds, timezone.utc) + timedelta(
-                microseconds=fraction
-            )
+            return datetime.fromtimestamp(seconds, timezone.utc).replace(
+                tzinfo=None
+            ) + timedelta(microseconds=fraction)
         return datetime.fromtimestamp(seconds, tz=tz) + timedelta(microseconds=fraction)

--- a/src/snowflake/connector/converter_issue23517.py
+++ b/src/snowflake/connector/converter_issue23517.py
@@ -83,9 +83,9 @@ class SnowflakeConverterIssue23517(SnowflakeConverter):
             value=value, scale=scale
         )
         if not tz:
-            return datetime.fromtimestamp(0, timezone.utc) + timedelta(
-                seconds=seconds, microseconds=fraction
-            )
+            return datetime.fromtimestamp(0, timezone.utc).replace(
+                tzinfo=None
+            ) + timedelta(seconds=seconds, microseconds=fraction)
         return datetime.fromtimestamp(0, tz=tz) + timedelta(
             seconds=seconds, microseconds=fraction
         )

--- a/src/snowflake/connector/converter_issue23517.py
+++ b/src/snowflake/connector/converter_issue23517.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta, tzinfo
+from datetime import datetime, time, timedelta, timezone, tzinfo
 from functools import partial
 from logging import getLogger
 
@@ -83,7 +83,7 @@ class SnowflakeConverterIssue23517(SnowflakeConverter):
             value=value, scale=scale
         )
         if not tz:
-            return datetime.utcfromtimestamp(0) + timedelta(
+            return datetime.fromtimestamp(0, timezone.utc) + timedelta(
                 seconds=seconds, microseconds=fraction
             )
         return datetime.fromtimestamp(0, tz=tz) + timedelta(

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -15,7 +15,7 @@ import tempfile
 import time
 import traceback
 from base64 import b64decode, b64encode
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 from os import environ, path
 from os.path import expanduser
@@ -261,7 +261,7 @@ class OCSPTelemetryData:
         return telemetry_data
         # To be updated once Python Driver has out of band telemetry.
         # telemetry_client = TelemetryClient()
-        # telemetry_client.add_log_to_batch(TelemetryData(telemetry_data, datetime.utcnow()))
+        # telemetry_client.add_log_to_batch(TelemetryData(telemetry_data, datetime.now(timezone.utc)))
 
 
 class OCSPServer:
@@ -851,7 +851,7 @@ class SnowflakeOCSP:
     MAX_CLOCK_SKEW = 900
 
     # Epoch time
-    ZERO_EPOCH = datetime.utcfromtimestamp(0)
+    ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
     # Timestamp format for logging
     OUTPUT_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%SZ"

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -261,7 +261,7 @@ class OCSPTelemetryData:
         return telemetry_data
         # To be updated once Python Driver has out of band telemetry.
         # telemetry_client = TelemetryClient()
-        # telemetry_client.add_log_to_batch(TelemetryData(telemetry_data, datetime.now(timezone.utc)))
+        # telemetry_client.add_log_to_batch(TelemetryData(telemetry_data, datetime.now(timezone.utc).replace(tzinfo=None))
 
 
 class OCSPServer:
@@ -851,7 +851,7 @@ class SnowflakeOCSP:
     MAX_CLOCK_SKEW = 900
 
     # Epoch time
-    ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
+    ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc).replace(tzinfo=None)
 
     # Timestamp format for logging
     OUTPUT_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%SZ"

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import binascii
 import re
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 from io import IOBase
 from logging import getLogger
 from operator import itemgetter
@@ -308,7 +308,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             )
 
         def generate_authenticated_url_and_args_v4() -> tuple[bytes, dict[str, bytes]]:
-            t = datetime.utcnow()
+            t = datetime.now(timezone.utc)
             amzdate = t.strftime("%Y%m%dT%H%M%SZ")
             short_amzdate = amzdate[:8]
             x_amz_headers["x-amz-date"] = amzdate

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -308,7 +308,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             )
 
         def generate_authenticated_url_and_args_v4() -> tuple[bytes, dict[str, bytes]]:
-            t = datetime.now(timezone.utc)
+            t = datetime.now(timezone.utc).replace(tzinfo=None)
             amzdate = t.strftime("%Y%m%dT%H%M%SZ")
             short_amzdate = amzdate[:8]
             x_amz_headers["x-amz-date"] = amzdate

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -97,7 +97,9 @@ class TelemetryEvent(TelemetryEventBase):
         event.update(
             {
                 "UUID": str(uuid.uuid4()),
-                "Created_On": datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                "Created_On": datetime.datetime.now(datetime.timezone.utc).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
                 "Type": self.get_type(),
                 "SchemaVersion": 1,
             }

--- a/src/snowflake/connector/telemetry_oob.py
+++ b/src/snowflake/connector/telemetry_oob.py
@@ -97,9 +97,9 @@ class TelemetryEvent(TelemetryEventBase):
         event.update(
             {
                 "UUID": str(uuid.uuid4()),
-                "Created_On": datetime.datetime.now(datetime.timezone.utc).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                ),
+                "Created_On": datetime.datetime.now(datetime.timezone.utc)
+                .replace(tzinfo=None)
+                .strftime("%Y-%m-%d %H:%M:%S"),
                 "Type": self.get_type(),
                 "SchemaVersion": 1,
             }

--- a/src/snowflake/connector/tool/dump_ocsp_response_cache.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response_cache.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 from os import path
 from time import gmtime, strftime, time
@@ -19,7 +19,7 @@ from OpenSSL.crypto import FILETYPE_ASN1, dump_certificate
 from snowflake.connector.ocsp_asn1crypto import SnowflakeOCSPAsn1Crypto as SFOCSP
 from snowflake.connector.ssl_wrap_socket import _openssl_connect
 
-ZERO_EPOCH = datetime.utcfromtimestamp(0)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
 OCSP_CACHE_SERVER_INTERVAL = 20 * 60 * 60  # seconds
 

--- a/src/snowflake/connector/tool/dump_ocsp_response_cache.py
+++ b/src/snowflake/connector/tool/dump_ocsp_response_cache.py
@@ -19,7 +19,7 @@ from OpenSSL.crypto import FILETYPE_ASN1, dump_certificate
 from snowflake.connector.ocsp_asn1crypto import SnowflakeOCSPAsn1Crypto as SFOCSP
 from snowflake.connector.ssl_wrap_socket import _openssl_connect
 
-ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc)
+ZERO_EPOCH = datetime.fromtimestamp(0, timezone.utc).replace(tzinfo=None)
 
 OCSP_CACHE_SERVER_INTERVAL = 20 * 60 * 60  # seconds
 

--- a/test/integ/test_bindings.py
+++ b/test/integ/test_bindings.py
@@ -86,7 +86,7 @@ insert into {name} values(
 """
     with conn_cnx(paramstyle="qmark") as cnx:
         cnx.cursor().execute(CREATE_TABLE.format(name=db_parameters["name"]))
-    current_utctime = datetime.now(timezone.utc)
+    current_utctime = datetime.now(timezone.utc).replace(tzinfo=None)
     current_localtime = pytz.utc.localize(current_utctime, is_dst=False).astimezone(
         pytz.timezone(PST_TZ)
     )

--- a/test/integ/test_bindings.py
+++ b/test/integ/test_bindings.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 from datetime import date, datetime
 from datetime import time as datetime_time
-from datetime import timedelta
+from datetime import timedelta, timezone
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -86,7 +86,7 @@ insert into {name} values(
 """
     with conn_cnx(paramstyle="qmark") as cnx:
         cnx.cursor().execute(CREATE_TABLE.format(name=db_parameters["name"]))
-    current_utctime = datetime.utcnow()
+    current_utctime = datetime.now(timezone.utc)
     current_localtime = pytz.utc.localize(current_utctime, is_dst=False).astimezone(
         pytz.timezone(PST_TZ)
     )

--- a/test/integ/test_converter_null.py
+++ b/test/integ/test_converter_null.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import snowflake.connector
 from snowflake.connector.converter import ZERO_EPOCH
@@ -56,7 +56,7 @@ select  current_timestamp(),
     assert NUMERIC_VALUES.match(ret[1])
     con.cursor().execute("create or replace table testtb(c1 timestamp_ntz(6))")
     try:
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         # binding value should have no impact
         con.cursor().execute("insert into testtb(c1) values(%s)", (current_time,))
         ret = con.cursor().execute("select * from testtb").fetchone()[0]

--- a/test/integ/test_converter_null.py
+++ b/test/integ/test_converter_null.py
@@ -56,7 +56,7 @@ select  current_timestamp(),
     assert NUMERIC_VALUES.match(ret[1])
     con.cursor().execute("create or replace table testtb(c1 timestamp_ntz(6))")
     try:
-        current_time = datetime.now(timezone.utc)
+        current_time = datetime.now(timezone.utc).replace(tzinfo=None)
         # binding value should have no impact
         con.cursor().execute("insert into testtb(c1) values(%s)", (current_time,))
         ret = con.cursor().execute("select * from testtb").fetchone()[0]

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -11,7 +11,7 @@ import logging
 import os
 import pickle
 import time
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, NamedTuple
 from unittest import mock
 
@@ -254,7 +254,7 @@ def test_insert_timestamp_select(conn, db_parameters):
     """
     PST_TZ = "America/Los_Angeles"
     JST_TZ = "Asia/Tokyo"
-    current_timestamp = datetime.utcnow()
+    current_timestamp = datetime.now(timezone.utc)
     current_timestamp = current_timestamp.replace(tzinfo=pytz.timezone(PST_TZ))
     current_date = current_timestamp.date()
     current_time = current_timestamp.time()

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -254,7 +254,7 @@ def test_insert_timestamp_select(conn, db_parameters):
     """
     PST_TZ = "America/Los_Angeles"
     JST_TZ = "Asia/Tokyo"
-    current_timestamp = datetime.now(timezone.utc)
+    current_timestamp = datetime.now(timezone.utc).replace(tzinfo=None)
     current_timestamp = current_timestamp.replace(tzinfo=pytz.timezone(PST_TZ))
     current_date = current_timestamp.date()
     current_time = current_timestamp.time()

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -57,10 +57,10 @@ def test_get_token_from_private_key(input_account, expected_account):
         == decoded_token.get("iss").upper()
     )
     # Token should be valid for 24 hours. Assert that the token's expiration time is between 23 and 24 hours from now.
-    assert datetime.now(timezone.utc) + timedelta(
+    assert datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
         minutes=1360
     ) < datetime.fromtimestamp(decoded_token.get("exp"))
-    assert datetime.now(timezone.utc) + timedelta(
+    assert datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
         minutes=1441
     ) > datetime.fromtimestamp(decoded_token.get("exp"))
 

--- a/test/integ/test_key_pair_authentication.py
+++ b/test/integ/test_key_pair_authentication.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os import path
 
 import jwt
@@ -57,12 +57,12 @@ def test_get_token_from_private_key(input_account, expected_account):
         == decoded_token.get("iss").upper()
     )
     # Token should be valid for 24 hours. Assert that the token's expiration time is between 23 and 24 hours from now.
-    assert datetime.utcnow() + timedelta(minutes=1360) < datetime.fromtimestamp(
-        decoded_token.get("exp")
-    )
-    assert datetime.utcnow() + timedelta(minutes=1441) > datetime.fromtimestamp(
-        decoded_token.get("exp")
-    )
+    assert datetime.now(timezone.utc) + timedelta(
+        minutes=1360
+    ) < datetime.fromtimestamp(decoded_token.get("exp"))
+    assert datetime.now(timezone.utc) + timedelta(
+        minutes=1441
+    ) > datetime.fromtimestamp(decoded_token.get("exp"))
 
 
 @pytest.mark.skipolddriver

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -359,7 +359,7 @@ field_delimiter = '|'
 error_on_column_count_mismatch=false);
 """,
         )
-        current_time = datetime.datetime.now(datetime.timezone.utc)
+        current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         current_time = current_time.replace(tzinfo=pytz.timezone("America/Los_Angeles"))
         current_date = datetime.date.today()
         other_time = current_time.replace(tzinfo=pytz.timezone("Asia/Tokyo"))

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -359,7 +359,7 @@ field_delimiter = '|'
 error_on_column_count_mismatch=false);
 """,
         )
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         current_time = current_time.replace(tzinfo=pytz.timezone("America/Los_Angeles"))
         current_date = datetime.date.today()
         other_time = current_time.replace(tzinfo=pytz.timezone("Asia/Tokyo"))

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -299,23 +299,40 @@ def test_authbyplugin_abc_api():
         # see https://github.com/python/cpython/issues/101446
         assert inspect.isfunction(bc.update_body)
         assert str(inspect.signature(bc.update_body).parameters) == (
-            """OrderedDict({'self': <Parameter "self">, 'body': <Parameter "body: 'dict[Any, Any]'">})"""
+            """OrderedDict({'self': <Parameter "self">, \
+'body': <Parameter "body: 'dict[Any, Any]'">})"""
         )
 
         # authenticate
         assert inspect.isfunction(bc.prepare)
         assert str(inspect.signature(bc.prepare).parameters) == (
-            """OrderedDict({'self': <Parameter "self">, 'conn': <Parameter "conn: 'SnowflakeConnection'">, 'authenticator': <Parameter "authenticator: 'str'">, 'service_name': <Parameter "service_name: 'str | None'">, 'account': <Parameter "account: 'str'">, 'user': <Parameter "user: 'str'">, 'password': <Parameter "password: 'str | None'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+            """OrderedDict({'self': <Parameter "self">, \
+'conn': <Parameter "conn: 'SnowflakeConnection'">, \
+'authenticator': <Parameter "authenticator: 'str'">, \
+'service_name': <Parameter "service_name: 'str | None'">, \
+'account': <Parameter "account: 'str'">, \
+'user': <Parameter "user: 'str'">, \
+'password': <Parameter "password: 'str | None'">, \
+'kwargs': <Parameter "**kwargs: 'Any'">})"""
         )
 
         # handle_failure
         assert inspect.isfunction(bc._handle_failure)
         assert str(inspect.signature(bc._handle_failure).parameters) == (
-            """OrderedDict({'self': <Parameter "self">, 'conn': <Parameter "conn: 'SnowflakeConnection'">, 'ret': <Parameter "ret: 'dict[Any, Any]'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+            """OrderedDict({'self': <Parameter "self">, \
+'conn': <Parameter "conn: 'SnowflakeConnection'">, \
+'ret': <Parameter "ret: 'dict[Any, Any]'">, \
+'kwargs': <Parameter "**kwargs: 'Any'">})"""
         )
 
         # handle_timeout
         assert inspect.isfunction(bc.handle_timeout)
         assert str(inspect.signature(bc.handle_timeout).parameters) == (
-            """OrderedDict({'self': <Parameter "self">, 'authenticator': <Parameter "authenticator: 'str'">, 'service_name': <Parameter "service_name: 'str | None'">, 'account': <Parameter "account: 'str'">, 'user': <Parameter "user: 'str'">, 'password': <Parameter "password: 'str'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+            """OrderedDict({'self': <Parameter "self">, \
+'authenticator': <Parameter "authenticator: 'str'">, \
+'service_name': <Parameter "service_name: 'str | None'">, \
+'account': <Parameter "account: 'str'">, \
+'user': <Parameter "user: 'str'">, \
+'password': <Parameter "password: 'str'">, \
+'kwargs': <Parameter "**kwargs: 'Any'">})"""
         )

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 import time
 from unittest.mock import Mock, PropertyMock
 
@@ -252,42 +253,69 @@ def test_authbyplugin_abc_api():
 
     # Verify method signatures
     # update_body
-    assert inspect.isfunction(bc.update_body)
-    assert str(inspect.signature(bc.update_body).parameters) == (
-        "OrderedDict([('self', <Parameter \"self\">), "
-        "('body', <Parameter \"body: 'dict[Any, Any]'\">)])"
-    )
+    if sys.version_info <= (3, 11):
+        assert inspect.isfunction(bc.update_body)
+        assert str(inspect.signature(bc.update_body).parameters) == (
+            "OrderedDict([('self', <Parameter \"self\">), "
+            "('body', <Parameter \"body: 'dict[Any, Any]'\">)])"
+        )
 
-    # authenticate
-    assert inspect.isfunction(bc.prepare)
-    assert str(inspect.signature(bc.prepare).parameters) == (
-        "OrderedDict([('self', <Parameter \"self\">), "
-        "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
-        "('authenticator', <Parameter \"authenticator: 'str'\">), "
-        "('service_name', <Parameter \"service_name: 'str | None'\">), "
-        "('account', <Parameter \"account: 'str'\">), "
-        "('user', <Parameter \"user: 'str'\">), "
-        "('password', <Parameter \"password: 'str | None'\">), "
-        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
-    )
+        # authenticate
+        assert inspect.isfunction(bc.prepare)
+        assert str(inspect.signature(bc.prepare).parameters) == (
+            "OrderedDict([('self', <Parameter \"self\">), "
+            "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
+            "('authenticator', <Parameter \"authenticator: 'str'\">), "
+            "('service_name', <Parameter \"service_name: 'str | None'\">), "
+            "('account', <Parameter \"account: 'str'\">), "
+            "('user', <Parameter \"user: 'str'\">), "
+            "('password', <Parameter \"password: 'str | None'\">), "
+            "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+        )
 
-    # handle_failure
-    assert inspect.isfunction(bc._handle_failure)
-    assert str(inspect.signature(bc._handle_failure).parameters) == (
-        "OrderedDict([('self', <Parameter \"self\">), "
-        "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
-        "('ret', <Parameter \"ret: 'dict[Any, Any]'\">), "
-        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
-    )
+        # handle_failure
+        assert inspect.isfunction(bc._handle_failure)
+        assert str(inspect.signature(bc._handle_failure).parameters) == (
+            "OrderedDict([('self', <Parameter \"self\">), "
+            "('conn', <Parameter \"conn: 'SnowflakeConnection'\">), "
+            "('ret', <Parameter \"ret: 'dict[Any, Any]'\">), "
+            "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+        )
 
-    # handle_timeout
-    assert inspect.isfunction(bc.handle_timeout)
-    assert str(inspect.signature(bc.handle_timeout).parameters) == (
-        "OrderedDict([('self', <Parameter \"self\">), "
-        "('authenticator', <Parameter \"authenticator: 'str'\">), "
-        "('service_name', <Parameter \"service_name: 'str | None'\">), "
-        "('account', <Parameter \"account: 'str'\">), "
-        "('user', <Parameter \"user: 'str'\">), "
-        "('password', <Parameter \"password: 'str'\">), "
-        "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
-    )
+        # handle_timeout
+        assert inspect.isfunction(bc.handle_timeout)
+        assert str(inspect.signature(bc.handle_timeout).parameters) == (
+            "OrderedDict([('self', <Parameter \"self\">), "
+            "('authenticator', <Parameter \"authenticator: 'str'\">), "
+            "('service_name', <Parameter \"service_name: 'str | None'\">), "
+            "('account', <Parameter \"account: 'str'\">), "
+            "('user', <Parameter \"user: 'str'\">), "
+            "('password', <Parameter \"password: 'str'\">), "
+            "('kwargs', <Parameter \"**kwargs: 'Any'\">)])"
+        )
+    else:
+        # starting from python 3.12 the repr of collections.OrderedDict is changed
+        # to use regular dictionary formating instead of pairs of keys and values.
+        # see https://github.com/python/cpython/issues/101446
+        assert inspect.isfunction(bc.update_body)
+        assert str(inspect.signature(bc.update_body).parameters) == (
+            """OrderedDict({'self': <Parameter "self">, 'body': <Parameter "body: 'dict[Any, Any]'">})"""
+        )
+
+        # authenticate
+        assert inspect.isfunction(bc.prepare)
+        assert str(inspect.signature(bc.prepare).parameters) == (
+            """OrderedDict({'self': <Parameter "self">, 'conn': <Parameter "conn: 'SnowflakeConnection'">, 'authenticator': <Parameter "authenticator: 'str'">, 'service_name': <Parameter "service_name: 'str | None'">, 'account': <Parameter "account: 'str'">, 'user': <Parameter "user: 'str'">, 'password': <Parameter "password: 'str | None'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+        )
+
+        # handle_failure
+        assert inspect.isfunction(bc._handle_failure)
+        assert str(inspect.signature(bc._handle_failure).parameters) == (
+            """OrderedDict({'self': <Parameter "self">, 'conn': <Parameter "conn: 'SnowflakeConnection'">, 'ret': <Parameter "ret: 'dict[Any, Any]'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+        )
+
+        # handle_timeout
+        assert inspect.isfunction(bc.handle_timeout)
+        assert str(inspect.signature(bc.handle_timeout).parameters) == (
+            """OrderedDict({'self': <Parameter "self">, 'authenticator': <Parameter "authenticator: 'str'">, 'service_name': <Parameter "service_name: 'str | None'">, 'account': <Parameter "account: 'str'">, 'user': <Parameter "user: 'str'">, 'password': <Parameter "password: 'str'">, 'kwargs': <Parameter "**kwargs: 'Any'">})"""
+        )

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -253,7 +253,7 @@ def test_authbyplugin_abc_api():
 
     # Verify method signatures
     # update_body
-    if sys.version_info <= (3, 11):
+    if sys.version_info < (3, 12):
         assert inspect.isfunction(bc.update_body)
         assert str(inspect.signature(bc.update_body).parameters) == (
             "OrderedDict([('self', <Parameter \"self\">), "

--- a/test/unit/test_connection_diagnostic.py
+++ b/test/unit/test_connection_diagnostic.py
@@ -32,7 +32,7 @@ def test_https_host_report(caplog):
         host_type="OUT_OF_BAND_TELEMETRY",
     )
 
-    assert "DNS:client-telemetry.snowflakecomputing.com" in ".".join(
+    assert "OUT_OF_BAND_TELEMETRY: client-telemetry.snowflakecomputing.com" in ".".join(
         connection_diag.test_results["OUT_OF_BAND_TELEMETRY"]
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ external_wheels =
     py39-ci: dist/*cp39*.whl
     py310-ci: dist/*cp310*.whl
     py311-ci: dist/*cp311*.whl
+    py312-ci: dist/*cp312*.whl
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_OPTS = -vvv

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ source = src/snowflake/connector
 [tox]
 minversion = 3.7
 envlist = fix_lint,
-          py{37,38,39,310,311}-{extras,unit-parallel,integ,pandas,sso},
+          py{37,38,39,310,311,312}-{extras,unit-parallel,integ,pandas,sso},
           coverage
 skip_missing_interpreters = true
 requires =
@@ -120,9 +120,9 @@ commands = coverage combine
            coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/coverage.xml
            coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov
 ;           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
-depends = py37, py38, py39, py310, py311
+depends = py37, py38, py39, py310, py311, py312
 
-[testenv:py{37,38,39,310,311}-coverage]
+[testenv:py{37,38,39,310,311,312}-coverage]
 # I hate doing this, but this env is for Jenkins, please keep it up-to-date with the one env above it if necessary
 description = [run locally after tests]: combine coverage data and create report specifically with {basepython}
 deps = {[testenv:coverage]deps}
@@ -156,7 +156,7 @@ deps =
     pip-tools
 skip_install = True
 commands = pip-compile setup.py
-depends = py37, py38, py39, py310, py311
+depends = py37, py38, py39, py310, py311, py312
 
 [pytest]
 log_level = info


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-997139: support python 3.12

changes needed for 3.12 python connector:

- ci/cd job matrix to include py 3.12
- test code change related to `OrderedDict`, starting from python 3.12 the repr of collections.OrderedDict is changed, to use regular dictionary formating instead of pairs of keys and values, see https://github.com/python/cpython/issues/101446
- `datetime.utcfromtimestamp` will be deprecated, change to use `datetime.fromtimestamp`: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp
- `datetime.utcnow` will be deprecated, change to use `datetime.now`: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
- `ssl.PROTOCOL_SSLv23` is deprecated, should use `ssl.PROTOCOL_SSL_CLIENT`, https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_SSLv23

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
