### PR TITLE
SNOW-999576: Fix several local test problems

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Added a new boolean parameter `force_return_table` to `SnowflakeCursor.fetch_arrow_all` to force returning `pyarrow.Table` in case of zero rows.
   - Cleanup some C++ code warnings and performance issues.
+  - Make local testing more robust against implicit assumptions.
 
 - v3.6.0(December 09,2023)
 

--- a/test/README.md
+++ b/test/README.md
@@ -14,19 +14,23 @@ CONNECTION_PARAMETERS = {
 }
 ```
 
-### Running a single test
-
-Assuming that all dependencies are installed, running a single test is as simple as:
-`python -m pytest test/integ/test_connection.py::test_basic`.
-
 ### Running a suite of tests
 
-We use `tox` to run test suites and other utilities.
+We use `tox` version 4 to run test suites and other utilities.
 
 To run the most important tests, execute:
 
 ```shell
 tox -e "fix_lint,py37{,-pandas,-sso}"
+```
+
+### Running a single test
+
+Enter the tox environment you want (e.g. `py38`) and run `pytest` from there:
+
+```shell
+source .tox/py38/bin/activate
+pytest -v test/integ/test_connection.py::test_basic
 ```
 
 ## Test types

--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,16 @@ To run the most important tests, execute:
 tox -e "fix_lint,py37{,-pandas,-sso}"
 ```
 
+**NOTE** Some integration tests may be sensitive to the cloud provider of the
+account that the test suite connects to.  By default, when testing locally,
+the "provider" is called `dev`, but you may see some test failures with this
+provider (which isn't really a provider).  To eliminate this false failure,
+set the environment variable `cloud_provider` to one of `aws`, `gcp`, or
+`azure` as appropriate for the account you're running integration tests
+against.  This is handled correctly in CI so should only affect local
+developers.  In the future, we'll try to make this automatic by querying the
+account after the connection is made.
+
 ### Running a single test
 
 Enter the tox environment you want (e.g. `py38`) and run `pytest` from there:

--- a/test/integ/test_autocommit.py
+++ b/test/integ/test_autocommit.py
@@ -167,6 +167,7 @@ def test_autocommit_parameters(db_parameters):
         protocol=db_parameters["protocol"],
         schema=db_parameters["schema"],
         database=db_parameters["database"],
+        warehouse=db_parameters["warehouse"],
         autocommit=False,
     ) as cnx:
         exe(
@@ -186,6 +187,7 @@ CREATE TABLE {name} (c1 boolean)
         protocol=db_parameters["protocol"],
         schema=db_parameters["schema"],
         database=db_parameters["database"],
+        warehouse=db_parameters["warehouse"],
         autocommit=True,
     ) as cnx:
         _run_autocommit_on(cnx, db_parameters)

--- a/test/integ/test_converter_null.py
+++ b/test/integ/test_converter_null.py
@@ -27,6 +27,7 @@ def test_converter_no_converter_to_python(db_parameters):
         port=db_parameters["port"],
         account=db_parameters["account"],
         database=db_parameters["database"],
+        warehouse=db_parameters["warehouse"],
         schema=db_parameters["schema"],
         protocol=db_parameters["protocol"],
         timezone="UTC",

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -297,6 +297,7 @@ def test_insert_timestamp_select(conn, db_parameters):
         account=db_parameters["account"],
         database=db_parameters["database"],
         schema=db_parameters["schema"],
+        warehouse=db_parameters["warehouse"],
         protocol=db_parameters["protocol"],
         timezone="UTC",
     )

--- a/test/integ/test_transaction.py
+++ b/test/integ/test_transaction.py
@@ -78,6 +78,7 @@ def test_connection_context_manager(request, db_parameters):
         "host": db_parameters["host"],
         "port": db_parameters["port"],
         "database": db_parameters["database"],
+        "warehouse": db_parameters["warehouse"],
         "schema": db_parameters["schema"],
         "timezone": "UTC",
     }

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -530,9 +530,14 @@ def test_config_file_resolution_sfdirs_nondefault(tmp_path, monkeypatch):
         assert isinstance(_resolve_platform_dirs(), SFPlatformDirs)
 
 
-def test_config_file_resolution_non_sfdirs(monkeypatch):
+def test_config_file_resolution_non_sfdirs(tmp_path, monkeypatch):
     with monkeypatch.context() as m:
-        m.delenv("SNOWFLAKE_HOME", raising=False)
+        # 2024-01-03(bwarsaw): It's not enough to remove SNOWFLAKE_HOME from the environment, because
+        # _resolve_platform_dirs() defaults to ~/.snowflake, so if the user running the tests has this
+        # directory, the test will fail.  Instead, ensure that this environment variable points to a
+        # non-existent directory.
+        fake_home = tmp_path / ".snowflake"
+        m.setenv("SNOWFLAKE_HOME", str(fake_home))
         assert not isinstance(_resolve_platform_dirs(), SFPlatformDirs)
 
 

--- a/test/unit/test_encryption_util.py
+++ b/test/unit/test_encryption_util.py
@@ -43,10 +43,10 @@ def test_encrypt_decrypt_file(tmp_path):
             fd.write(data)
 
         (metadata, encrypted_file) = SnowflakeEncryptionUtil.encrypt_file(
-            encryption_material, input_file
+            encryption_material, input_file, tmp_dir=str(tmp_path)
         )
         decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
-            metadata, encryption_material, encrypted_file
+            metadata, encryption_material, encrypted_file, tmp_dir=str(tmp_path)
         )
 
         contents = ""
@@ -98,10 +98,10 @@ def test_encrypt_decrypt_large_file(tmpdir):
                 )
 
             (metadata, encrypted_file) = SnowflakeEncryptionUtil.encrypt_file(
-                encryption_material, input_file
+                encryption_material, input_file, tmp_dir=str(tmpdir)
             )
             decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
-                metadata, encryption_material, encrypted_file
+                metadata, encryption_material, encrypted_file, tmp_dir=str(tmpdir)
             )
 
             digest_dec, size_dec = SnowflakeFileUtil.get_digest_and_size_for_file(

--- a/tox.ini
+++ b/tox.ini
@@ -49,11 +49,11 @@ passenv =
     SF_PROJECT_ROOT
     cloud_provider
     SF_REGRESS_LOGS
-    ; Github Actions provided environmental variables
+    # Github Actions provided environmental variables
     GITHUB_ACTIONS
     JENKINS_HOME
-    ; This is required on windows. Otherwise pwd module won't be imported successfully,
-    ; see https://github.com/tox-dev/tox/issues/1455
+    # This is required on windows. Otherwise pwd module won't be imported successfully,
+    # see https://github.com/tox-dev/tox/issues/1455
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
     PYTEST_ADDOPTS

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ envlist = fix_lint,
           coverage
 skip_missing_interpreters = true
 requires =
+    setuptools>=40.6.0
     tox-external-wheels>=0.1.6
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ extras =
     development
     pandas: pandas
     sso: secure-local-storage
-install_command = python -m pip install -U {opts} {packages}
+package = wheel
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_OPTS = -vvv

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,6 @@ envlist = fix_lint,
           py{37,38,39,310,311,312}-{extras,unit-parallel,integ,pandas,sso},
           coverage
 skip_missing_interpreters = true
-requires =
-    setuptools>=40.6.0
-    tox-external-wheels>=0.1.6
 
 [testenv]
 description = run the tests with pytest under {basepython}
@@ -32,13 +29,6 @@ extras =
     pandas: pandas
     sso: secure-local-storage
 install_command = python -m pip install -U {opts} {packages}
-external_wheels =
-    py37-ci: dist/*cp37*.whl
-    py38-ci: dist/*cp38*.whl
-    py39-ci: dist/*cp39*.whl
-    py310-ci: dist/*cp310*.whl
-    py311-ci: dist/*cp311*.whl
-    py312-ci: dist/*cp312*.whl
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_OPTS = -vvv


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   * In several cases, we need to dig the `warehouse` parameter out of the connection dictionary, and use that explicitly rather than rely on an implicit user default warehouse.
   * Add `setuptools` as an explicit tox provisioning requirement.
   * Don't assume that unsetting the `SNOWFLAKE_HOME` environment variable is enough to pass the fallback test, since the local user may have `~/.snowflake`, and if they do, this is used as the implicit fallback.  Use a fake home in a temporary directory instead, which is guaranteed not to exist.
