### PR TITLE
SNOW-1000283: Add support for Structured Types.

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -17,6 +17,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed PyArrow Table type hinting
   - Added support for connecting using an existing connection via the session and master token.
   - Added support for connecting to Snowflake by authenticating with multiple SAML IDP using external browser.
+  - Added support for structured types (OBJECT, MAP, ARRAY) to nanoarrow converters.
 
 - v3.6.0(December 09,2023)
 

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ if _ABLE_TO_COMPILE_EXTENSIONS and not SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSION
                         *((file,) if isinstance(file, str) else file)
                     )
                     for file in {
+                        "ArrayConverter.cpp",
                         "BinaryConverter.cpp",
                         "BooleanConverter.cpp",
                         "CArrowChunkIterator.cpp",
@@ -104,6 +105,8 @@ if _ABLE_TO_COMPILE_EXTENSIONS and not SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSION
                         "FixedSizeListConverter.cpp",
                         "FloatConverter.cpp",
                         "IntConverter.cpp",
+                        "MapConverter.cpp",
+                        "ObjectConverter.cpp",
                         "SnowflakeType.cpp",
                         "StringConverter.cpp",
                         "TimeConverter.cpp",

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.cpp
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "ArrayConverter.hpp"
+
+#include <memory>
+
+#include "CArrowChunkIterator.hpp"
+#include "CArrowIterator.hpp"
+#include "SnowflakeType.hpp"
+
+namespace sf {
+Logger* ArrayConverter::logger =
+    new Logger("snowflake.connector.ArrayConverter");
+
+void ArrayConverter::generateError(const std::string& msg) const {
+  logger->error(__FILE__, __func__, __LINE__, msg.c_str());
+  PyErr_SetString(PyExc_Exception, msg.c_str());
+}
+
+ArrayConverter::ArrayConverter(ArrowSchemaView* schemaView,
+                               ArrowArrayView* array, PyObject* context,
+                               bool useNumpy) {
+  m_array = array;
+
+  if (schemaView->schema->n_children != 1) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] invalid arrow schema for array items expected 1 "
+        "schema child, but got %d",
+        schemaView->schema->n_children);
+    this->generateError(errorInfo);
+    return;
+  }
+
+  ArrowSchema* itemSchema = schemaView->schema->children[0];
+  ArrowArrayView* item_array = array->children[0];
+  item_converter =
+      getConverterFromSchema(itemSchema, item_array, context, useNumpy, logger);
+}
+
+PyObject* ArrayConverter::toPyObject(int64_t rowIndex) const {
+  if (ArrowArrayViewIsNull(m_array, rowIndex)) {
+    Py_RETURN_NONE;
+  }
+
+  // Array item offsets are stored in the second array buffers
+  // Infer start an end of this rows slice by looking at the
+  // current and next offset. If there isn't another offset use
+  // the end of the array instead.
+  int start = m_array->buffer_views[1].data.as_int32[rowIndex];
+  int end = m_array->children[0]->length;
+  if (rowIndex + 1 < m_array->length) {
+    end = m_array->buffer_views[1].data.as_int32[rowIndex + 1];
+  }
+
+  PyObject* list = PyList_New(end - start);
+  for (int i = start; i < end; i++) {
+    PyList_SetItem(list, i - start, item_converter->toPyObject(i));
+  }
+  return list;
+}
+
+}  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.cpp
@@ -33,10 +33,10 @@ ArrayConverter::ArrayConverter(ArrowSchemaView* schemaView,
     return;
   }
 
-  ArrowSchema* itemSchema = schemaView->schema->children[0];
+  ArrowSchema* item_schema = schemaView->schema->children[0];
   ArrowArrayView* item_array = array->children[0];
-  item_converter =
-      getConverterFromSchema(itemSchema, item_array, context, useNumpy, logger);
+  m_item_converter = getConverterFromSchema(item_schema, item_array, context,
+                                            useNumpy, logger);
 }
 
 PyObject* ArrayConverter::toPyObject(int64_t rowIndex) const {
@@ -56,7 +56,7 @@ PyObject* ArrayConverter::toPyObject(int64_t rowIndex) const {
 
   PyObject* list = PyList_New(end - start);
   for (int i = start; i < end; i++) {
-    PyList_SetItem(list, i - start, item_converter->toPyObject(i));
+    PyList_SetItem(list, i - start, m_item_converter->toPyObject(i));
   }
   return list;
 }

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.hpp
@@ -25,7 +25,7 @@ class ArrayConverter : public IColumnConverter {
   void generateError(const std::string& msg) const;
 
   ArrowArrayView* m_array;
-  std::shared_ptr<sf::IColumnConverter> item_converter;
+  std::shared_ptr<sf::IColumnConverter> m_item_converter;
   static Logger* logger;
 };
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ArrayConverter.hpp
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#ifndef PC_ARRAYCONVERTER_HPP
+#define PC_ARRAYCONVERTER_HPP
+
+#include <memory>
+
+#include "IColumnConverter.hpp"
+#include "logging.hpp"
+#include "nanoarrow.h"
+#include "nanoarrow.hpp"
+
+namespace sf {
+
+class ArrayConverter : public IColumnConverter {
+ public:
+  explicit ArrayConverter(ArrowSchemaView* schemaView, ArrowArrayView* array,
+                          PyObject* context, bool useNumpy);
+
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+ private:
+  void generateError(const std::string& msg) const;
+
+  ArrowArrayView* m_array;
+  std::shared_ptr<sf::IColumnConverter> item_converter;
+  static Logger* logger;
+};
+
+}  // namespace sf
+#endif  // PC_ARRAYCONVERTER_HPP

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -378,8 +378,13 @@ std::shared_ptr<sf::IColumnConverter> getConverterFromSchema(
             returnCode);
         scale =
             std::stoi(std::string(scaleString.data, scaleString.size_bytes));
-        byteLength = std::stoi(
-            std::string(byteLengthString.data, byteLengthString.size_bytes));
+
+        // Byte Length may be unset if TIMESTAMP_TZ is the child of a structured type
+        // In this case rely on the default value.
+        if (byteLengthString.data != nullptr) {
+          byteLength = std::stoi(
+              std::string(byteLengthString.data, byteLengthString.size_bytes));
+        }
       }
       switch (byteLength) {
         case 8: {

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "ArrayConverter.hpp"
 #include "BinaryConverter.hpp"
 #include "BooleanConverter.hpp"
 #include "DateConverter.hpp"
@@ -15,6 +16,8 @@
 #include "FixedSizeListConverter.hpp"
 #include "FloatConverter.hpp"
 #include "IntConverter.hpp"
+#include "MapConverter.hpp"
+#include "ObjectConverter.hpp"
 #include "StringConverter.hpp"
 #include "TimeConverter.hpp"
 #include "TimeStampConverter.hpp"
@@ -193,9 +196,7 @@ std::shared_ptr<sf::IColumnConverter> getConverterFromSchema(
     }
 
     case SnowflakeType::Type::ANY:
-    case SnowflakeType::Type::ARRAY:
     case SnowflakeType::Type::CHAR:
-    case SnowflakeType::Type::OBJECT:
     case SnowflakeType::Type::TEXT:
     case SnowflakeType::Type::VARIANT: {
       converter = std::make_shared<sf::StringConverter>(array);
@@ -379,8 +380,8 @@ std::shared_ptr<sf::IColumnConverter> getConverterFromSchema(
         scale =
             std::stoi(std::string(scaleString.data, scaleString.size_bytes));
 
-        // Byte Length may be unset if TIMESTAMP_TZ is the child of a structured type
-        // In this case rely on the default value.
+        // Byte Length may be unset if TIMESTAMP_TZ is the child of a structured
+        // type In this case rely on the default value.
         if (byteLengthString.data != nullptr) {
           byteLength = std::stoi(
               std::string(byteLengthString.data, byteLengthString.size_bytes));
@@ -410,6 +411,58 @@ std::shared_ptr<sf::IColumnConverter> getConverterFromSchema(
         }
       }
 
+      break;
+    }
+
+    case SnowflakeType::Type::ARRAY: {
+      switch (schemaView.type) {
+        case NANOARROW_TYPE_STRING:
+          converter = std::make_shared<sf::StringConverter>(array);
+          break;
+        case NANOARROW_TYPE_LIST:
+          converter = std::make_shared<sf::ArrayConverter>(&schemaView, array,
+                                                           context, useNumpy);
+          break;
+        default: {
+          std::string errorInfo = Logger::formatString(
+              "[Snowflake Exception] unknown arrow internal data type(%d) "
+              "for ARRAY data in %s",
+              NANOARROW_TYPE_ENUM_STRING[schemaView.type],
+              schemaView.schema->name);
+          logger->error(__FILE__, __func__, __LINE__, errorInfo.c_str());
+          PyErr_SetString(PyExc_Exception, errorInfo.c_str());
+          break;
+        }
+      }
+      break;
+    }
+
+    case SnowflakeType::Type::MAP: {
+      converter = std::make_shared<sf::MapConverter>(&schemaView, array,
+                                                     context, useNumpy);
+      break;
+    }
+
+    case SnowflakeType::Type::OBJECT: {
+      switch (schemaView.type) {
+        case NANOARROW_TYPE_STRING:
+          converter = std::make_shared<sf::StringConverter>(array);
+          break;
+        case NANOARROW_TYPE_STRUCT:
+          converter = std::make_shared<sf::ObjectConverter>(&schemaView, array,
+                                                            context, useNumpy);
+          break;
+        default: {
+          std::string errorInfo = Logger::formatString(
+              "[Snowflake Exception] unknown arrow internal data type(%d) "
+              "for OBJECT data in %s",
+              NANOARROW_TYPE_ENUM_STRING[schemaView.type],
+              schemaView.schema->name);
+          logger->error(__FILE__, __func__, __LINE__, errorInfo.c_str());
+          PyErr_SetString(PyExc_Exception, errorInfo.c_str());
+          break;
+        }
+      }
       break;
     }
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -79,6 +79,10 @@ class CArrowChunkIterator : public CArrowIterator {
   bool m_useNumpy;
 
   void initColumnConverters();
+
+  void log_schema(ArrowSchema* schema, int ident);
+  void log_metadata(const char* metadata, int ident);
+  void log_array(ArrowArrayView* array, int ident);
 };
 
 class DictCArrowChunkIterator : public CArrowChunkIterator {

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -79,7 +79,6 @@ class CArrowChunkIterator : public CArrowIterator {
   bool m_useNumpy;
 
   void initColumnConverters();
-
 };
 
 class DictCArrowChunkIterator : public CArrowChunkIterator {

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.hpp
@@ -80,9 +80,6 @@ class CArrowChunkIterator : public CArrowIterator {
 
   void initColumnConverters();
 
-  void log_schema(ArrowSchema* schema, int ident);
-  void log_metadata(const char* metadata, int ident);
-  void log_array(ArrowArrayView* array, int ident);
 };
 
 class DictCArrowChunkIterator : public CArrowChunkIterator {

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowTableIterator.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowTableIterator.cpp
@@ -112,6 +112,7 @@ void CArrowTableIterator::reconstructRecordBatches_nanoarrow() {
         case SnowflakeType::Type::BOOLEAN:
         case SnowflakeType::Type::CHAR:
         case SnowflakeType::Type::DATE:
+        case SnowflakeType::Type::MAP:
         case SnowflakeType::Type::OBJECT:
         case SnowflakeType::Type::REAL:
         case SnowflakeType::Type::TEXT:

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.cpp
@@ -42,15 +42,15 @@ MapConverter::MapConverter(ArrowSchemaView* schemaView, ArrowArrayView* array,
     return;
   }
 
-  ArrowSchema* keySchema = entries->children[0];
-  ArrowArrayView* keyArray = array->children[0]->children[0];
-  key_converter =
-      getConverterFromSchema(keySchema, keyArray, context, useNumpy, logger);
+  ArrowSchema* key_schema = entries->children[0];
+  ArrowArrayView* key_array = array->children[0]->children[0];
+  m_key_converter =
+      getConverterFromSchema(key_schema, key_array, context, useNumpy, logger);
 
-  ArrowSchema* valueSchema = entries->children[1];
-  ArrowArrayView* valueArray = array->children[0]->children[1];
-  value_converter = getConverterFromSchema(valueSchema, valueArray, context,
-                                           useNumpy, logger);
+  ArrowSchema* value_schema = entries->children[1];
+  ArrowArrayView* value_array = array->children[0]->children[1];
+  m_value_converter = getConverterFromSchema(value_schema, value_array, context,
+                                             useNumpy, logger);
 }
 
 PyObject* MapConverter::toPyObject(int64_t rowIndex) const {
@@ -70,8 +70,8 @@ PyObject* MapConverter::toPyObject(int64_t rowIndex) const {
 
   PyObject* dict = PyDict_New();
   for (int i = start; i < end; i++) {
-    PyDict_SetItem(dict, key_converter->toPyObject(i),
-                   value_converter->toPyObject(i));
+    PyDict_SetItem(dict, m_key_converter->toPyObject(i),
+                   m_value_converter->toPyObject(i));
   }
   return dict;
 }

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.cpp
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "MapConverter.hpp"
+
+#include <memory>
+
+#include "CArrowChunkIterator.hpp"
+#include "CArrowIterator.hpp"
+#include "SnowflakeType.hpp"
+
+namespace sf {
+Logger* MapConverter::logger = new Logger("snowflake.connector.MapConverter");
+
+void MapConverter::generateError(const std::string& msg) const {
+  logger->error(__FILE__, __func__, __LINE__, msg.c_str());
+  PyErr_SetString(PyExc_Exception, msg.c_str());
+}
+
+MapConverter::MapConverter(ArrowSchemaView* schemaView, ArrowArrayView* array,
+                           PyObject* context, bool useNumpy) {
+  m_array = array;
+
+  if (schemaView->schema->n_children != 1) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] invalid arrow schema for map entries expected 1 "
+        "schema child, but got %d",
+        schemaView->schema->n_children);
+    this->generateError(errorInfo);
+    return;
+  }
+
+  ArrowSchema* entries = schemaView->schema->children[0];
+
+  if (entries->n_children != 2) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] invalid arrow schema for map key/value pair "
+        "expected 2 entries, but got %d",
+        entries->n_children);
+    this->generateError(errorInfo);
+    return;
+  }
+
+  ArrowSchema* keySchema = entries->children[0];
+  ArrowArrayView* keyArray = array->children[0]->children[0];
+  key_converter =
+      getConverterFromSchema(keySchema, keyArray, context, useNumpy, logger);
+
+  ArrowSchema* valueSchema = entries->children[1];
+  ArrowArrayView* valueArray = array->children[0]->children[1];
+  value_converter = getConverterFromSchema(valueSchema, valueArray, context,
+                                           useNumpy, logger);
+}
+
+PyObject* MapConverter::toPyObject(int64_t rowIndex) const {
+  if (ArrowArrayViewIsNull(m_array, rowIndex)) {
+    Py_RETURN_NONE;
+  }
+
+  // Map ArrowArrays have two child Arrays that contain the the keys and values.
+  // The offsets for how many items belong to each row are stored in the parent
+  // array offset buffer. The start and end of a row slice has to be infered
+  // from the offsets for each row.
+  int start = m_array->buffer_views[1].data.as_int32[rowIndex];
+  int end = m_array->children[0]->length;
+  if (rowIndex + 1 < m_array->length) {
+    end = m_array->buffer_views[1].data.as_int32[rowIndex + 1];
+  }
+
+  PyObject* dict = PyDict_New();
+  for (int i = start; i < end; i++) {
+    PyDict_SetItem(dict, key_converter->toPyObject(i),
+                   value_converter->toPyObject(i));
+  }
+  return dict;
+}
+
+}  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.hpp
@@ -25,8 +25,8 @@ class MapConverter : public IColumnConverter {
   void generateError(const std::string& msg) const;
 
   ArrowArrayView* m_array;
-  std::shared_ptr<sf::IColumnConverter> key_converter;
-  std::shared_ptr<sf::IColumnConverter> value_converter;
+  std::shared_ptr<sf::IColumnConverter> m_key_converter;
+  std::shared_ptr<sf::IColumnConverter> m_value_converter;
   static Logger* logger;
 };
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/MapConverter.hpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#ifndef PC_MAPCONVERTER_HPP
+#define PC_MAPCONVERTER_HPP
+
+#include <memory>
+
+#include "IColumnConverter.hpp"
+#include "logging.hpp"
+#include "nanoarrow.h"
+#include "nanoarrow.hpp"
+
+namespace sf {
+
+class MapConverter : public IColumnConverter {
+ public:
+  explicit MapConverter(ArrowSchemaView* schemaView, ArrowArrayView* array,
+                        PyObject* context, bool useNumpy);
+
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+ private:
+  void generateError(const std::string& msg) const;
+
+  ArrowArrayView* m_array;
+  std::shared_ptr<sf::IColumnConverter> key_converter;
+  std::shared_ptr<sf::IColumnConverter> value_converter;
+  static Logger* logger;
+};
+
+}  // namespace sf
+#endif  // PC_MAPCONVERTER_HPP

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.cpp
@@ -19,17 +19,17 @@ ObjectConverter::ObjectConverter(ArrowSchemaView* schemaView,
                                  bool useNumpy) {
   m_array = array;
   m_converters.clear();
-  m_propertyNames.clear();
+  m_property_names.clear();
   m_propertyCount = schemaView->schema->n_children;
 
   for (int i = 0; i < schemaView->schema->n_children; i++) {
-    ArrowSchema* propertySchema = schemaView->schema->children[i];
+    ArrowSchema* property_schema = schemaView->schema->children[i];
 
-    m_propertyNames.push_back(propertySchema->name);
+    m_property_names.push_back(property_schema->name);
 
     ArrowArrayView* child_array = array->children[i];
 
-    m_converters.push_back(getConverterFromSchema(propertySchema, child_array,
+    m_converters.push_back(getConverterFromSchema(property_schema, child_array,
                                                   context, useNumpy, logger));
   }
 }
@@ -41,7 +41,7 @@ PyObject* ObjectConverter::toPyObject(int64_t rowIndex) const {
 
   PyObject* dict = PyDict_New();
   for (int i = 0; i < m_propertyCount; i++) {
-    PyDict_SetItemString(dict, m_propertyNames[i],
+    PyDict_SetItemString(dict, m_property_names[i],
                          m_converters[i]->toPyObject(rowIndex));
   }
   return dict;

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "ObjectConverter.hpp"
+
+#include <memory>
+
+#include "CArrowChunkIterator.hpp"
+#include "CArrowIterator.hpp"
+#include "SnowflakeType.hpp"
+
+namespace sf {
+Logger* ObjectConverter::logger =
+    new Logger("snowflake.connector.BinaryConverter");
+
+ObjectConverter::ObjectConverter(ArrowSchemaView* schemaView,
+                                 ArrowArrayView* array, PyObject* context,
+                                 bool useNumpy) {
+  m_array = array;
+  m_converters.clear();
+  m_propertyNames.clear();
+  m_propertyCount = schemaView->schema->n_children;
+
+  for (int i = 0; i < schemaView->schema->n_children; i++) {
+    ArrowSchema* propertySchema = schemaView->schema->children[i];
+
+    m_propertyNames.push_back(propertySchema->name);
+
+    ArrowArrayView* child_array = array->children[i];
+
+    m_converters.push_back(getConverterFromSchema(propertySchema, child_array,
+                                                  context, useNumpy, logger));
+  }
+}
+
+PyObject* ObjectConverter::toPyObject(int64_t rowIndex) const {
+  if (ArrowArrayViewIsNull(m_array, rowIndex)) {
+    Py_RETURN_NONE;
+  }
+
+  PyObject* dict = PyDict_New();
+  for (int i = 0; i < m_propertyCount; i++) {
+    PyDict_SetItemString(dict, m_propertyNames[i],
+                         m_converters[i]->toPyObject(rowIndex));
+  }
+  return dict;
+}
+
+}  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.hpp
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+#ifndef PC_OBJECTCONVERTER_HPP
+#define PC_OBJECTCONVERTER_HPP
+
+#include <memory>
+
+#include "IColumnConverter.hpp"
+#include "logging.hpp"
+#include "nanoarrow.h"
+#include "nanoarrow.hpp"
+
+namespace sf {
+
+class ObjectConverter : public IColumnConverter {
+ public:
+  explicit ObjectConverter(ArrowSchemaView* schemaView, ArrowArrayView* array,
+                           PyObject* context, bool useNumpy);
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+ private:
+  static Logger* logger;
+  ArrowArrayView* m_array;
+  int m_propertyCount;
+  std::vector<const char*> m_propertyNames;
+  std::vector<std::shared_ptr<sf::IColumnConverter>> m_converters;
+};
+
+}  // namespace sf
+
+#endif  // PC_OBJECTCONVERTER_HPP

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/ObjectConverter.hpp
@@ -23,7 +23,7 @@ class ObjectConverter : public IColumnConverter {
   static Logger* logger;
   ArrowArrayView* m_array;
   int m_propertyCount;
-  std::vector<const char*> m_propertyNames;
+  std::vector<const char*> m_property_names;
   std::vector<std::shared_ptr<sf::IColumnConverter>> m_converters;
 };
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
@@ -18,6 +18,7 @@ std::unordered_map<std::string, SnowflakeType::Type>
         {"DOUBLE", SnowflakeType::Type::REAL},
         {"FIXED", SnowflakeType::Type::FIXED},
         {"FLOAT", SnowflakeType::Type::REAL},
+        {"MAP", SnowflakeType::Type::MAP},
         {"OBJECT", SnowflakeType::Type::OBJECT},
         {"REAL", SnowflakeType::Type::REAL},
         {"STRING", SnowflakeType::Type::TEXT},

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
@@ -30,7 +30,8 @@ class SnowflakeType {
     TIMESTAMP_NTZ = 13,
     TIMESTAMP_TZ = 14,
     VARIANT = 15,
-    VECTOR = 16
+    VECTOR = 16,
+    MAP = 17,
   };
 
   static SnowflakeType::Type snowflakeTypeFromString(std::string str) {

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -88,8 +88,7 @@ def serialize(value):
         return value.hex()
     elif isinstance(value, (date, time)):
         return str(value)
-    else:
-        return value
+    return value
 
 
 @pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -125,6 +125,7 @@ def structured_type_verify(conn_cnx, query, data):
         assert rows[0][0] == data, "Result values should match input examples."
 
 
+@pytest.mark.internal
 @pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
 def test_array(datatype, examples, conn_cnx):
     json_values = re.escape(json.dumps(examples, default=serialize))
@@ -135,6 +136,7 @@ def test_array(datatype, examples, conn_cnx):
     structured_type_verify(conn_cnx, query, examples)
 
 
+@pytest.mark.internal
 @pytest.mark.parametrize("key_type", ["varchar", "number"])
 @pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
 def test_map(key_type, datatype, examples, conn_cnx):
@@ -147,6 +149,7 @@ def test_map(key_type, datatype, examples, conn_cnx):
     structured_type_verify(conn_cnx, query, data)
 
 
+@pytest.mark.internal
 @pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
 def test_object(datatype, examples, conn_cnx):
     fields = [f"{datatype}_{i}" for i in range(len(examples))]
@@ -160,6 +163,7 @@ def test_object(datatype, examples, conn_cnx):
     structured_type_verify(conn_cnx, query, data)
 
 
+@pytest.mark.internal
 def test_nested_types(conn_cnx):
     data = {"child": [{"key1": {"struct_field": 1}}]}
     json_string = re.escape(json.dumps(data, default=serialize))

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import json
 import random
-from datetime import datetime, timedelta
+import re
+from datetime import date, datetime, time, timedelta, timezone
 
 import numpy
 import pytest
@@ -21,6 +23,151 @@ try:
     no_arrow_iterator_ext = False
 except ImportError:
     no_arrow_iterator_ext = True
+
+
+TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
+
+# Basic set of primitive types with synonymous types excluded
+PRIMITIVE_DATATYPE_EXAMPLES = {
+    "BINARY": [
+        None,
+        bytearray(b"\xAB"),
+        bytearray(b"\xFA\x42\x00"),
+    ],
+    "BOOLEAN": [None, True, False],
+    "CHAR": [None, "a", "b"],
+    "DATE": [
+        None,
+        date(2016, 7, 23),
+        date(1970, 1, 1),
+        date(1969, 12, 31),
+        date(1, 1, 1),
+        date(9999, 12, 31),
+    ],
+    "DOUBLE": [
+        -86.6426540296895,
+        3.14159265359,
+        1.7976931348623157e308,
+    ],
+    "NUMBER": [None, 1, 2, 3],
+    "INTEGER": [
+        None,
+        0,
+        99999999999999999999999999999999999999,
+        -99999999999999999999999999999999999999,
+    ],
+    "TIME": [
+        None,
+        time(0, 0, 0),
+        time(8, 59, 59),
+        time(12, 0, 0),
+        time(23, 0, 31),
+    ],
+    "TIMESTAMP_LTZ": [
+        None,
+        datetime.strptime("2024-01-01 12:00:00", TIMESTAMP_FMT).replace(
+            tzinfo=timezone.utc
+        ),
+    ],
+    "TIMESTAMP_NTZ": [
+        None,
+        datetime.strptime("2024-01-01 12:00:00", TIMESTAMP_FMT),
+    ],
+    "TIMESTAMP_TZ": [
+        None,
+        datetime.strptime("2024-01-01 12:00:00", TIMESTAMP_FMT).replace(
+            tzinfo=timezone.utc
+        ),
+    ],
+    "VARCHAR": [None, "ascii_test", b"\xf0\x9f\x98\x80".decode("utf-8")],
+}
+
+
+def serialize(value):
+    if isinstance(value, bytearray):
+        return value.hex()
+    elif isinstance(value, (date, time)):
+        return str(value)
+    else:
+        return value
+
+
+@pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
+def test_datatypes(datatype, examples, conn_cnx):
+    json_values = re.escape(json.dumps(examples, default=serialize))
+    query = f"""
+    SELECT
+      value :: {datatype} as col
+    FROM
+      TABLE(FLATTEN(input => parse_json('{json_values}')));
+    """
+    with conn_cnx() as conn:
+        rows = conn.cursor().execute(query).fetchall()
+        if datatype == "DOUBLE":
+            for x, y in zip(sorted(r[0] for r in rows), sorted(examples)):
+                assert x == pytest.approx(y)
+        else:
+            assert [r[0] for r in rows] == examples
+
+
+def structured_type_verify(conn_cnx, query, data):
+    with conn_cnx() as conn:
+        conn.cursor().execute("alter session set use_cached_result=false")
+        conn.cursor().execute(
+            "alter session set enable_structured_types_in_client_response=true"
+        )
+        conn.cursor().execute(
+            "alter session set force_enable_structured_types_native_arrow_format=true"
+        )
+        rows = conn.cursor().execute(query).fetchall()
+        assert len(rows) == 1, "Result should only have one row."
+        assert len(rows[0]) == 1, "Result should only have one column."
+        assert rows[0][0] == data, "Result values should match input examples."
+
+
+@pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
+def test_array(datatype, examples, conn_cnx):
+    json_values = re.escape(json.dumps(examples, default=serialize))
+    query = f"""
+    SELECT
+      parse_json('{json_values}') :: array({datatype}) as col
+    """
+    structured_type_verify(conn_cnx, query, examples)
+
+
+@pytest.mark.parametrize("key_type", ["varchar", "number"])
+@pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
+def test_map(key_type, datatype, examples, conn_cnx):
+    data = {i if key_type == "number" else str(i): ex for i, ex in enumerate(examples)}
+    json_string = re.escape(json.dumps(data, default=serialize))
+    query = f"""
+    SELECT
+      parse_json('{json_string}') :: map({key_type}, {datatype}) as col
+    """
+    structured_type_verify(conn_cnx, query, data)
+
+
+@pytest.mark.parametrize("datatype,examples", list(PRIMITIVE_DATATYPE_EXAMPLES.items()))
+def test_object(datatype, examples, conn_cnx):
+    fields = [f"{datatype}_{i}" for i in range(len(examples))]
+    schema = ", ".join(f"{field} {datatype}" for field in fields)
+    data = {k: v for k, v in zip(fields, examples)}
+    json_string = re.escape(json.dumps(data, default=serialize))
+    query = f"""
+    SELECT
+      parse_json('{json_string}') :: object({schema}) as col
+    """
+    structured_type_verify(conn_cnx, query, data)
+
+
+def test_nested_types(conn_cnx):
+    data = {"child": [{"key1": {"struct_field": 1}}]}
+    json_string = re.escape(json.dumps(data, default=serialize))
+    query = f"""
+    SELECT
+      parse_json('{json_string}') :: object(child array(map (varchar, object(struct_field number)))) as col
+    """
+    structured_type_verify(conn_cnx, query, data)
 
 
 def test_select_tinyint(conn_cnx):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Implements SNOW-1000283

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This change adds support for structured types. Specifically types defined on Snowflake with these definition types:

```
OBJECT(field_1, value_type_1, ...)
ARRAY(element_type)
MAP(key_type, value_type)
```
These types are currently returned as json encoded strings and will continue to be unless the `ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE` session parameter is true.
Review Notes:
MAP previously was not a supported type in the connector, but was on the DB side. This change adds the type to relevant type enums.