### PR TITLE
SNOW-1049425 Bump keyring dependency lower bound to address security vulnerability

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Bumped pyOpenSSL dependency from >=16.2.0,<24.0.0 to >=16.2.0,<25.0.0.
   - Fixed a memory leak in decimal data conversion.
   - Fixed a bug where `write_pandas` wasn't truncating the target table.
+  - Bumped keyring dependency lower bound to 23.1.0 to address security vulnerability.
 
 - v3.7.0(January 25,2024)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,4 +96,4 @@ pandas =
     pandas>=1.0.0,<3.0.0
     pyarrow
 secure-local-storage =
-    keyring!=16.1.0,<25.0.0
+    keyring>=23.1.0,<25.0.0


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1049425

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   keyring < 23.1.0 has a [security loophole](https://github.com/jaraco/keyring/issues/274) where malicious user could place ddl at a harcoded path that non-admin users could write to on Windows. The problematic code is removed in 23.1.0. Hence we could address this vulnerability by capping the dependency on `keyring` to >= 23.1.0.
   
