### PR TITLE
Robust containerized externalbrowser rebased

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,19 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.7.2(TBD)
+
+  - Improved `externalbrowser` auth in containerized environments
+    - Instruct browser to not fetch `/favicon` on success page
+    - Simple retry strategy on empty socket.recv
+    - Add `SNOWFLAKE_AUTH_SOCKET_REUSE_PORT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_REUSE_PORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
+      - Useful when the randomized port used in the localhost callback url is being followed before the container engine completes port forwarding to host
+      - Statically map a port between your host and container and allow that port to be reused in rapid succession with:
+         `SF_AUTH_SOCKET_PORT=3037 SNOWFLAKE_AUTH_SOCKET_REUSE_PORT=true poetry run python somescript.py`
+    - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
+      - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
+      - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
+
 - v3.7.1(February 21, 2024)
 
   - Bumped pandas dependency from >=1.0.0,<2.2.0 to >=1.0.0,<3.0.0.

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -282,6 +282,7 @@ class AuthByWebBrowser(AuthByPlugin):
         else:
             msg = f"""
 <!DOCTYPE html><html><head><meta charset="UTF-8"/>
+<link rel="icon" href="data:,">
 <title>SAML Response for Snowflake</title></head>
 <body>
 Your identity was confirmed and propagated to Snowflake {self._application}.

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -117,10 +117,12 @@ class AuthByWebBrowser(AuthByPlugin):
         logger.debug("authenticating by Web Browser")
 
         socket_connection = self._socket(socket.AF_INET, socket.SOCK_STREAM)
-        
+
         if os.getenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "False").lower() == "true":
             if IS_WINDOWS:
-                logger.warning("Configuration SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not available in Windows. Ignoring.")
+                logger.warning(
+                    "Configuration SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not available in Windows. Ignoring."
+                )
             else:
                 socket_connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -450,3 +450,300 @@ def test_auth_webbrowser_invalid_sso(monkeypatch):
     )
     assert rest._connection.errorhandler.called  # an error
     assert auth.assertion_content is None
+
+
+def test_auth_webbrowser_socket_recv_retries_up_to_15_times_on_empty_bytearray():
+    """Authentication by WebBrowser retries on empty bytearray response from socket.recv"""
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(INVALID_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup(
+            # 14th return is empty byte array, but 15th call will return successful_web_callback
+            ([bytearray()] * 14)
+            + [successful_web_callback(ref_token)]
+        )
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ), mock.patch("time.sleep") as sleep:
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+        assert sleep.call_count == 0
+
+
+def test_auth_webbrowser_socket_recv_loop_fails_after_15_attempts():
+    """Authentication by WebBrowser stops trying after 15 consective socket.recv emty bytearray returns."""
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup(
+            # 15th return is empty byte array, so successful_web_callback will never be fetched from recv
+            ([bytearray()] * 15)
+            + [successful_web_callback(ref_token)]
+        )
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ), mock.patch("time.sleep") as sleep:
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert rest._connection.errorhandler.called  # an error
+        assert auth.assertion_content is None
+        assert sleep.call_count == 0
+
+
+def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypatch):
+    """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
+
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup_with_msg_nowait(
+            ref_token, number_of_blocking_io_errors_before_success=14
+        )
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ), mock.patch("time.sleep") as sleep:
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+        body = {"data": {}}
+        auth.update_body(body)
+        assert body["data"]["TOKEN"] == ref_token
+        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+        sleep_times = [t[0][0] for t in sleep.call_args_list]
+        assert sleep.call_count == 14
+        assert sleep_times == [0.25] * 14
+
+
+def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
+    monkeypatch,
+):
+    """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
+
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup_with_msg_nowait(
+            ref_token, number_of_blocking_io_errors_before_success=15
+        )
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ), mock.patch("time.sleep") as sleep:
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert rest._connection.errorhandler.called  # an error
+        assert auth.assertion_content is None
+        sleep_times = [t[0][0] for t in sleep.call_args_list]
+        assert sleep.call_count == 14
+        assert sleep_times == [0.25] * 14
+
+
+def test_auth_webbrowser_socket_reuseport_with_env_flag(monkeypatch):
+    """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup([successful_web_callback(ref_token)])
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ):
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert mock_socket_pkg.return_value.setsockopt.call_count == 1
+        assert mock_socket_pkg.return_value.setsockopt.call_args.args == (
+            socket.SOL_SOCKET,
+            socket.SO_REUSEPORT,
+            1,
+        )
+
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+
+
+def test_auth_webbrowser_socket_reuseport_option_not_set_with_false_flag(monkeypatch):
+    """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup([successful_web_callback(ref_token)])
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "false")
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ):
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert mock_socket_pkg.return_value.setsockopt.call_count == 0
+
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token
+
+
+def test_auth_webbrowser_socket_reuseport_option_not_set_with_no_flag(monkeypatch):
+    """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
+    ref_token = "MOCK_TOKEN"
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+
+    # mock socket
+    mock_socket_pkg = _init_socket(
+        recv_side_effect_func=recv_setup([successful_web_callback(ref_token)])
+    )
+
+    # mock webbrowser
+    mock_webbrowser = MagicMock()
+    mock_webbrowser.open_new.return_value = True
+
+    # Mock select.select to return socket client
+    with mock.patch(
+        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+    ):
+        auth = AuthByWebBrowser(
+            application=APPLICATION,
+            webbrowser_pkg=mock_webbrowser,
+            socket_pkg=mock_socket_pkg,
+        )
+        auth.prepare(
+            conn=rest._connection,
+            authenticator=AUTHENTICATOR,
+            service_name=SERVICE_NAME,
+            account=ACCOUNT,
+            user=USER,
+            password=PASSWORD,
+        )
+        assert mock_socket_pkg.return_value.setsockopt.call_count == 0
+
+        assert not rest._connection.errorhandler.called  # no error
+        assert auth.assertion_content == ref_token

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import pytest
 
 from snowflake.connector import SnowflakeConnection
-from snowflake.connector.compat import urlencode
+from snowflake.connector.compat import IS_WINDOWS, urlencode
 from snowflake.connector.constants import OCSPMode
 from snowflake.connector.description import CLIENT_NAME, CLIENT_VERSION
 from snowflake.connector.network import (
@@ -542,49 +542,53 @@ def test_auth_webbrowser_socket_recv_loop_fails_after_15_attempts():
 def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypatch):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
 
-    ref_token = "MOCK_TOKEN"
-    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
+    if not IS_WINDOWS:
+        # MSG_DONTWAIT is not supported on Windows, so this case is not applicable
+        assert True
+    else:
+        ref_token = "MOCK_TOKEN"
+        rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
 
-    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
+        monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
 
-    # mock socket
-    mock_socket_pkg = _init_socket(
-        recv_side_effect_func=recv_setup_with_msg_nowait(
-            ref_token, number_of_blocking_io_errors_before_success=14
+        # mock socket
+        mock_socket_pkg = _init_socket(
+            recv_side_effect_func=recv_setup_with_msg_nowait(
+                ref_token, number_of_blocking_io_errors_before_success=14
+            )
         )
-    )
 
-    # mock webbrowser
-    mock_webbrowser = MagicMock()
-    mock_webbrowser.open_new.return_value = True
+        # mock webbrowser
+        mock_webbrowser = MagicMock()
+        mock_webbrowser.open_new.return_value = True
 
-    # Mock select.select to return socket client
-    with mock.patch(
-        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
-    ), mock.patch("time.sleep") as sleep:
-        auth = AuthByWebBrowser(
-            application=APPLICATION,
-            webbrowser_pkg=mock_webbrowser,
-            socket_pkg=mock_socket_pkg,
-        )
-        auth.prepare(
-            conn=rest._connection,
-            authenticator=AUTHENTICATOR,
-            service_name=SERVICE_NAME,
-            account=ACCOUNT,
-            user=USER,
-            password=PASSWORD,
-        )
-        assert not rest._connection.errorhandler.called  # no error
-        assert auth.assertion_content == ref_token
-        body = {"data": {}}
-        auth.update_body(body)
-        assert body["data"]["TOKEN"] == ref_token
-        assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
-        assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
-        sleep_times = [t[0][0] for t in sleep.call_args_list]
-        assert sleep.call_count == 14
-        assert sleep_times == [0.25] * 14
+        # Mock select.select to return socket client
+        with mock.patch(
+            "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+        ), mock.patch("time.sleep") as sleep:
+            auth = AuthByWebBrowser(
+                application=APPLICATION,
+                webbrowser_pkg=mock_webbrowser,
+                socket_pkg=mock_socket_pkg,
+            )
+            auth.prepare(
+                conn=rest._connection,
+                authenticator=AUTHENTICATOR,
+                service_name=SERVICE_NAME,
+                account=ACCOUNT,
+                user=USER,
+                password=PASSWORD,
+            )
+            assert not rest._connection.errorhandler.called  # no error
+            assert auth.assertion_content == ref_token
+            body = {"data": {}}
+            auth.update_body(body)
+            assert body["data"]["TOKEN"] == ref_token
+            assert body["data"]["PROOF_KEY"] == REF_PROOF_KEY
+            assert body["data"]["AUTHENTICATOR"] == EXTERNAL_BROWSER_AUTHENTICATOR
+            sleep_times = [t[0][0] for t in sleep.call_args_list]
+            assert sleep.call_count == 14
+            assert sleep_times == [0.25] * 14
 
 
 def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
@@ -592,88 +596,96 @@ def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
 ):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
 
-    ref_token = "MOCK_TOKEN"
-    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+    if not IS_WINDOWS:
+        # MSG_DONTWAIT is not supported on Windows, so this case is not applicable
+        assert True
+    else:
+        ref_token = "MOCK_TOKEN"
+        rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
-    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
+        monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
 
-    # mock socket
-    mock_socket_pkg = _init_socket(
-        recv_side_effect_func=recv_setup_with_msg_nowait(
-            ref_token, number_of_blocking_io_errors_before_success=15
+        # mock socket
+        mock_socket_pkg = _init_socket(
+            recv_side_effect_func=recv_setup_with_msg_nowait(
+                ref_token, number_of_blocking_io_errors_before_success=15
+            )
         )
-    )
 
-    # mock webbrowser
-    mock_webbrowser = MagicMock()
-    mock_webbrowser.open_new.return_value = True
+        # mock webbrowser
+        mock_webbrowser = MagicMock()
+        mock_webbrowser.open_new.return_value = True
 
-    # Mock select.select to return socket client
-    with mock.patch(
-        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
-    ), mock.patch("time.sleep") as sleep:
-        auth = AuthByWebBrowser(
-            application=APPLICATION,
-            webbrowser_pkg=mock_webbrowser,
-            socket_pkg=mock_socket_pkg,
-        )
-        auth.prepare(
-            conn=rest._connection,
-            authenticator=AUTHENTICATOR,
-            service_name=SERVICE_NAME,
-            account=ACCOUNT,
-            user=USER,
-            password=PASSWORD,
-        )
-        assert rest._connection.errorhandler.called  # an error
-        assert auth.assertion_content is None
-        sleep_times = [t[0][0] for t in sleep.call_args_list]
-        assert sleep.call_count == 14
-        assert sleep_times == [0.25] * 14
+        # Mock select.select to return socket client
+        with mock.patch(
+            "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+        ), mock.patch("time.sleep") as sleep:
+            auth = AuthByWebBrowser(
+                application=APPLICATION,
+                webbrowser_pkg=mock_webbrowser,
+                socket_pkg=mock_socket_pkg,
+            )
+            auth.prepare(
+                conn=rest._connection,
+                authenticator=AUTHENTICATOR,
+                service_name=SERVICE_NAME,
+                account=ACCOUNT,
+                user=USER,
+                password=PASSWORD,
+            )
+            assert rest._connection.errorhandler.called  # an error
+            assert auth.assertion_content is None
+            sleep_times = [t[0][0] for t in sleep.call_args_list]
+            assert sleep.call_count == 14
+            assert sleep_times == [0.25] * 14
 
 
 def test_auth_webbrowser_socket_reuseport_with_env_flag(monkeypatch):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
-    ref_token = "MOCK_TOKEN"
-    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+    if not IS_WINDOWS:
+        # SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not supported on Windows, so this case is not applicable
+        assert True
+    else:
+        ref_token = "MOCK_TOKEN"
+        rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
 
-    # mock socket
-    mock_socket_pkg = _init_socket(
-        recv_side_effect_func=recv_setup([successful_web_callback(ref_token)])
-    )
-
-    # mock webbrowser
-    mock_webbrowser = MagicMock()
-    mock_webbrowser.open_new.return_value = True
-
-    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
-
-    # Mock select.select to return socket client
-    with mock.patch(
-        "select.select", return_value=([mock_socket_pkg.return_value], [], [])
-    ):
-        auth = AuthByWebBrowser(
-            application=APPLICATION,
-            webbrowser_pkg=mock_webbrowser,
-            socket_pkg=mock_socket_pkg,
-        )
-        auth.prepare(
-            conn=rest._connection,
-            authenticator=AUTHENTICATOR,
-            service_name=SERVICE_NAME,
-            account=ACCOUNT,
-            user=USER,
-            password=PASSWORD,
-        )
-        assert mock_socket_pkg.return_value.setsockopt.call_count == 1
-        assert mock_socket_pkg.return_value.setsockopt.call_args.args == (
-            socket.SOL_SOCKET,
-            socket.SO_REUSEPORT,
-            1,
+        # mock socket
+        mock_socket_pkg = _init_socket(
+            recv_side_effect_func=recv_setup([successful_web_callback(ref_token)])
         )
 
-        assert not rest._connection.errorhandler.called  # no error
-        assert auth.assertion_content == ref_token
+        # mock webbrowser
+        mock_webbrowser = MagicMock()
+        mock_webbrowser.open_new.return_value = True
+
+        monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+
+        # Mock select.select to return socket client
+        with mock.patch(
+            "select.select", return_value=([mock_socket_pkg.return_value], [], [])
+        ):
+            auth = AuthByWebBrowser(
+                application=APPLICATION,
+                webbrowser_pkg=mock_webbrowser,
+                socket_pkg=mock_socket_pkg,
+            )
+            auth.prepare(
+                conn=rest._connection,
+                authenticator=AUTHENTICATOR,
+                service_name=SERVICE_NAME,
+                account=ACCOUNT,
+                user=USER,
+                password=PASSWORD,
+            )
+            assert mock_socket_pkg.return_value.setsockopt.call_count == 1
+            assert mock_socket_pkg.return_value.setsockopt.call_args.args == (
+                socket.SOL_SOCKET,
+                socket.SO_REUSEPORT,
+                1,
+            )
+
+            assert not rest._connection.errorhandler.called  # no error
+            assert auth.assertion_content == ref_token
 
 
 def test_auth_webbrowser_socket_reuseport_option_not_set_with_false_flag(monkeypatch):

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -632,7 +632,9 @@ def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
         assert sleep_times == [0.25] * 14
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not supported on Windows")
+@pytest.mark.skipif(
+    IS_WINDOWS, reason="SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not supported on Windows"
+)
 def test_auth_webbrowser_socket_reuseport_with_env_flag(monkeypatch):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
     ref_token = "MOCK_TOKEN"

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -540,7 +540,7 @@ def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypatch):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
 
     ref_token = "MOCK_TOKEN"
-    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY)
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
 
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "true")
 

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -542,7 +542,7 @@ def test_auth_webbrowser_socket_recv_loop_fails_after_15_attempts():
 def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypatch):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
 
-    if not IS_WINDOWS:
+    if IS_WINDOWS:
         # MSG_DONTWAIT is not supported on Windows, so this case is not applicable
         assert True
     else:
@@ -596,7 +596,7 @@ def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attempts(
 ):
     """Authentication by WebBrowser socket.recv Does not block, but retries if BlockingIOError thrown."""
 
-    if not IS_WINDOWS:
+    if IS_WINDOWS:
         # MSG_DONTWAIT is not supported on Windows, so this case is not applicable
         assert True
     else:

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -455,7 +455,7 @@ def test_auth_webbrowser_invalid_sso(monkeypatch):
 def test_auth_webbrowser_socket_recv_retries_up_to_15_times_on_empty_bytearray():
     """Authentication by WebBrowser retries on empty bytearray response from socket.recv"""
     ref_token = "MOCK_TOKEN"
-    rest = _init_rest(INVALID_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
+    rest = _init_rest(REF_SSO_URL, REF_PROOF_KEY, disable_console_login=True)
 
     # mock socket
     mock_socket_pkg = _init_socket(

--- a/test/unit/test_auth_webbrowser.py
+++ b/test/unit/test_auth_webbrowser.py
@@ -53,6 +53,7 @@ def mock_webserver(target_instance, application, port):
     _ = port
     target_instance._webserver_status = True
 
+
 def successful_web_callback(token):
     return (
         "\r\n".join(
@@ -119,6 +120,7 @@ def recv_setup_with_msg_nowait(
             )
 
     return internally_scoped_function
+
 
 @pytest.mark.parametrize("disable_console_login", [True, False])
 @patch("secrets.token_bytes", return_value=PROOF_KEY)
@@ -345,6 +347,7 @@ def test_auth_webbrowser_fail_webserver(_, capsys, disable_console_login):
         )
         assert rest._connection.errorhandler.called  # an error
         assert auth.assertion_content is None
+
 
 def _init_rest(
     ref_sso_url, ref_proof_key, success=True, message=None, disable_console_login=False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

Note: Copy&Pasting the original message from @podung , in his original PR [here](https://github.com/snowflakedb/snowflake-connector-python/pull/1686)

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1251 

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [X] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

* Improved `externalbrowser` auth in containerized environments
    * Instruct browser to not fetch `/favicon `on success page (can cause failure to parse subsequent tokens)
    * Simple retry strategy on empty socket.recv (occurs frequently when containerized)
    * Add `SF_AUTH_SOCKET_REUSEPORT` flag (usage: `SF_AUTH_SOCKET_REUSEPORT=true`) to set the underlying socket's `SO_REUSEPORT` flag (described in the [socket man page](https://man7.org/linux/man-pages/man7/socket.7.html))
        * Use in combination with `SF_AUTH_SOCKET_PORT`
        * Consider using if running in a containerized environment and the localhost callback url is being followed before the container fully opens the port
    * Add `SF_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SF_AUTH_SOCKET_MSG_DONTWAINT=true`) to make a non-blocking socket.recv call and retry on Error
        * Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
        * NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL