### PR TITLE
SNOW-1000284: Refactor MetadataV2 ahead of structured types.

### DIFF
--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -165,71 +165,8 @@ class ResultMetadata(NamedTuple):
         )
 
 
-class ResultMetadataV2Field:
-    """ResultMetadataV2Field represents the type information of one sub-type in a nested type."""
-
-    def __init__(
-        self,
-        type_code: int,
-        is_nullable: bool,
-        internal_size: int | None = None,
-        precision: int | None = None,
-        scale: int | None = None,
-        fields: list[ResultMetadataV2] | None = None,
-    ):
-        self._type_code = type_code
-        self._is_nullable = is_nullable
-        self._internal_size = internal_size
-        self._precision = precision
-        self._scale = scale
-        self._fields = fields
-
-    @classmethod
-    def from_column(cls, col: dict[str, Any]) -> ResultMetadataV2Field:
-        """Initializes a ResultMetadataV2Field object from a child of the column description in the query response."""
-        fields = None
-        if col.get("fields") is not None:
-            fields = [cls.from_column(f) for f in col["fields"]]
-        return cls(
-            FIELD_NAME_TO_ID[
-                col["extTypeName"].upper()
-                if col.get("extTypeName")
-                else col["type"].upper()
-            ],
-            col["nullable"],
-            col["length"],
-            col["precision"],
-            col["scale"],
-            fields,
-        )
-
-    @property
-    def type_code(self) -> int:
-        return self._type_code
-
-    @property
-    def is_nullable(self) -> bool:
-        return self._is_nullable
-
-    @property
-    def internal_size(self) -> int | None:
-        return self._internal_size
-
-    @property
-    def precision(self) -> int | None:
-        return self._precision
-
-    @property
-    def scale(self) -> int | None:
-        return self._scale
-
-    @property
-    def fields(self) -> list[ResultMetadataV2Field] | None:
-        return self._fields
-
-
 class ResultMetadataV2:
-    """ResultMetadataV2Field represents the type information of a single column.
+    """ResultMetadataV2 represents the type information of a single column.
 
     It is a replacement for ResultMetadata that contains additional attributes, currently
     `vector_dimension` and `fields`. This class will be unified with ResultMetadata in the
@@ -272,7 +209,9 @@ class ResultMetadataV2:
 
         fields = None
         if type_code == FIELD_NAME_TO_ID["VECTOR"] and col.get("fields") is not None:
-            fields = [ResultMetadataV2Field.from_column(f) for f in col["fields"]]
+            fields = [
+                ResultMetadata.from_column({"name": None, **f}) for f in col["fields"]
+            ]
 
         return cls(
             col["name"],
@@ -360,7 +299,7 @@ class ResultMetadataV2:
         return self._vector_dimension
 
     @property
-    def fields(self) -> list[ResultMetadataV2Field] | None:
+    def fields(self) -> list[ResultMetadataV2] | None:
         return self._fields
 
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -210,7 +210,7 @@ class ResultMetadataV2:
         fields = None
         if type_code == FIELD_NAME_TO_ID["VECTOR"] and col.get("fields") is not None:
             fields = [
-                ResultMetadata.from_column({"name": None, **f}) for f in col["fields"]
+                ResultMetadataV2.from_column({"name": None, **f}) for f in col["fields"]
             ]
 
         return cls(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes part of #1000284

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR removes the ResultMetadataV2Field class. This class is functionally the same as the ResultMetadataV2 class with the one difference being it can be created without a name. With structured types incoming the metadata can be arbitrarily nested so I don't think it makes sense to have separate classes for the top level metadata and the child metadatas. 

  The only place this class is referenced is the ResultMetadataV2.from_column and I've replaced that with an equivalent initializer for a ResultMetadataV2 object instead. This class was not referenced by any tests or any other repo so I think it should be safe to remove without a breaking-change api version bump.