### PR TITLE
SNOW-1000284: Add support for structured types to ResultMetadataV2

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
+  - Added support for strucutured type information in ResultMetadataV2
 
 - v3.7.1(February 21, 2024)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,7 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
-  - Added support for strucutured type information in ResultMetadataV2
+  - Added support for parsing structured type information in schema queries.
 
 - v3.7.1(February 21, 2024)
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -212,7 +212,7 @@ class ResultMetadataV2:
         if fields is not None:
             if col_type in {"VECTOR", "ARRAY", "OBJECT", "MAP"}:
                 processed_fields = [
-                    ResultMetadata.from_column({"name": None, **f})
+                    ResultMetadataV2.from_column({"name": None, **f})
                     for f in col["fields"]
                 ]
             else:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -165,71 +165,8 @@ class ResultMetadata(NamedTuple):
         )
 
 
-class ResultMetadataV2Field:
-    """ResultMetadataV2Field represents the type information of one sub-type in a nested type."""
-
-    def __init__(
-        self,
-        type_code: int,
-        is_nullable: bool,
-        internal_size: int | None = None,
-        precision: int | None = None,
-        scale: int | None = None,
-        fields: list[ResultMetadataV2] | None = None,
-    ):
-        self._type_code = type_code
-        self._is_nullable = is_nullable
-        self._internal_size = internal_size
-        self._precision = precision
-        self._scale = scale
-        self._fields = fields
-
-    @classmethod
-    def from_column(cls, col: dict[str, Any]) -> ResultMetadataV2Field:
-        """Initializes a ResultMetadataV2Field object from a child of the column description in the query response."""
-        fields = None
-        if col.get("fields") is not None:
-            fields = [cls.from_column(f) for f in col["fields"]]
-        return cls(
-            FIELD_NAME_TO_ID[
-                col["extTypeName"].upper()
-                if col.get("extTypeName")
-                else col["type"].upper()
-            ],
-            col["nullable"],
-            col["length"],
-            col["precision"],
-            col["scale"],
-            fields,
-        )
-
-    @property
-    def type_code(self) -> int:
-        return self._type_code
-
-    @property
-    def is_nullable(self) -> bool:
-        return self._is_nullable
-
-    @property
-    def internal_size(self) -> int | None:
-        return self._internal_size
-
-    @property
-    def precision(self) -> int | None:
-        return self._precision
-
-    @property
-    def scale(self) -> int | None:
-        return self._scale
-
-    @property
-    def fields(self) -> list[ResultMetadataV2Field] | None:
-        return self._fields
-
-
 class ResultMetadataV2:
-    """ResultMetadataV2Field represents the type information of a single column.
+    """ResultMetadataV2 represents the type information of a single column.
 
     It is a replacement for ResultMetadata that contains additional attributes, currently
     `vector_dimension` and `fields`. This class will be unified with ResultMetadata in the
@@ -272,7 +209,9 @@ class ResultMetadataV2:
 
         fields = None
         if type_code == FIELD_NAME_TO_ID["VECTOR"] and col.get("fields") is not None:
-            fields = [ResultMetadataV2Field.from_column(f) for f in col["fields"]]
+            fields = [
+                ResultMetadata.from_column({"name": None, **f}) for f in col["fields"]
+            ]
 
         return cls(
             col["name"],
@@ -360,7 +299,7 @@ class ResultMetadataV2:
         return self._vector_dimension
 
     @property
-    def fields(self) -> list[ResultMetadataV2Field] | None:
+    def fields(self) -> list[ResultMetadataV2] | None:
         return self._fields
 
 

--- a/src/snowflake/connector/options.py
+++ b/src/snowflake/connector/options.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import warnings
 from importlib.metadata import distributions
 from logging import getLogger
@@ -78,6 +79,10 @@ def _import_or_missing_pandas_option() -> (
         from pandas import DataFrame  # NOQA
 
         pyarrow = importlib.import_module("pyarrow")
+
+        # set default memory pool to system for pyarrow to_pandas conversion
+        if "ARROW_DEFAULT_MEMORY_POOL" not in os.environ:
+            os.environ["ARROW_DEFAULT_MEMORY_POOL"] = "system"
 
         # Check whether we have the currently supported pyarrow installed
         installed_packages = {

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1276,7 +1276,6 @@ def test_to_arrow_datatypes(enable_structured_types, conn_cnx):
 
             batches = cur.get_result_batches()
             assert len(batches) == 1
-            # import pdb; pdb.set_trace()
             batch = batches[0]
             arrow_table = batch.to_arrow()
             for actual, expected in zip(arrow_table.schema, expected_types):

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1228,19 +1228,23 @@ def test_to_arrow_datatypes(enable_structured_types, conn_cnx):
             )
 
             if enable_structured_types:
-                for param in {
+                structured_params = {
                     "ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE",
                     "IGNORE_CLIENT_VESRION_IN_STRUCTURED_TYPES_RESPONSE",
                     "FORCE_ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT",
-                }:
-                    cur.execute(f"alter session set {param}=true")
-                expected_types += (
-                    pyarrow.map_(pyarrow.string(), pyarrow.int64()),
-                    pyarrow.struct(
-                        {"city": pyarrow.string(), "population": pyarrow.float64()}
-                    ),
-                    pyarrow.list_(pyarrow.float64()),
-                )
+                }
+                try:
+                    for param in structured_params:
+                        cur.execute(f"alter session set {param}=true")
+                    expected_types += (
+                        pyarrow.map_(pyarrow.string(), pyarrow.int64()),
+                        pyarrow.struct(
+                            {"city": pyarrow.string(), "population": pyarrow.float64()}
+                        ),
+                        pyarrow.list_(pyarrow.float64()),
+                    )
+                finally:
+                    cur.execute(f"alter session unset {param}")
             else:
                 expected_types += (
                     pyarrow.string(),
@@ -1265,7 +1269,7 @@ def test_to_arrow_datatypes(enable_structured_types, conn_cnx):
             '0xAAAA' :: BINARY as BINARY_type,
             '01:02:03.123456789' :: TIME as TIME_type,
             true :: BOOLEAN as BOOLEAN_type,
-            TO_GEOGRAPHY('LINESTRING(13.4814 52.5015, -121.8212 36.8252)') as GEOGRAPHY_typejk,
+            TO_GEOGRAPHY('LINESTRING(13.4814 52.5015, -121.8212 36.8252)') as GEOGRAPHY_type,
             TO_GEOMETRY('LINESTRING(13.4814 52.5015, -121.8212 36.8252)') as GEOMETRY_type,
             [1,2,3,4,5] :: vector(float, 5) as VECTOR_type,
             object_construct('k1', 1, 'k2', 2, 'k3', 3, 'k4', 4, 'k5', 5) :: map(varchar, int) as MAP_type,

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1202,6 +1202,89 @@ def test_batch_to_pandas_arrow(conn_cnx, result_format):
                 assert arrow_table.to_pydict()["FOO"] == list(range(rowcount))
 
 
+@pytest.mark.parametrize("enable_structured_types", [True, False])
+def test_to_arrow_datatypes(enable_structured_types, conn_cnx):
+    with conn_cnx() as cnx:
+        with cnx.cursor() as cur:
+            cur.execute(SQL_ENABLE_ARROW)
+
+            expected_types = (
+                pyarrow.int64(),
+                pyarrow.float64(),
+                pyarrow.string(),
+                pyarrow.date64(),
+                pyarrow.timestamp("ns"),
+                pyarrow.string(),
+                pyarrow.timestamp("ns"),
+                pyarrow.timestamp("ns"),
+                pyarrow.timestamp("ns"),
+                pyarrow.binary(),
+                pyarrow.time64("ns"),
+                pyarrow.bool_(),
+                pyarrow.string(),
+                pyarrow.string(),
+                pyarrow.list_(pyarrow.float64(), 5),
+            )
+
+            if enable_structured_types:
+                for param in {
+                    "ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE",
+                    "IGNORE_CLIENT_VESRION_IN_STRUCTURED_TYPES_RESPONSE",
+                    "FORCE_ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT",
+                }:
+                    cur.execute(f"alter session set {param}=true")
+                expected_types += (
+                    pyarrow.map_(pyarrow.string(), pyarrow.int64()),
+                    pyarrow.struct(
+                        {"city": pyarrow.string(), "population": pyarrow.float64()}
+                    ),
+                    pyarrow.list_(pyarrow.float64()),
+                )
+            else:
+                expected_types += (
+                    pyarrow.string(),
+                    pyarrow.string(),
+                    pyarrow.string(),
+                )
+
+            # Ensure an empty batch to use default typing
+            # Otherwise arrow will resize types to save space
+            cur.execute(
+                """
+            select
+            1 :: INTEGER as FIXED_type,
+            2.0 :: FLOAT as REAL_type,
+            'test' :: TEXT as TEXT_type,
+            '2024-02-28' :: DATE as DATE_type,
+            '2020-03-12 01:02:03.123456789' :: TIMESTAMP as TIMESTAMP_type,
+            '{"foo": "bar"}' :: VARIANT as VARIANT_type,
+            '2020-03-12 01:02:03.123456789' :: TIMESTAMP_LTZ as TIMESTAMP_LTZ_type,
+            '2020-03-12 01:02:03.123456789' :: TIMESTAMP_TZ as TIMESTAMP_TZ_type,
+            '2020-03-12 01:02:03.123456789' :: TIMESTAMP_NTZ as TIMESTAMP_NTZ_type,
+            '0xAAAA' :: BINARY as BINARY_type,
+            '01:02:03.123456789' :: TIME as TIME_type,
+            true :: BOOLEAN as BOOLEAN_type,
+            TO_GEOGRAPHY('LINESTRING(13.4814 52.5015, -121.8212 36.8252)') as GEOGRAPHY_typejk,
+            TO_GEOMETRY('LINESTRING(13.4814 52.5015, -121.8212 36.8252)') as GEOMETRY_type,
+            [1,2,3,4,5] :: vector(float, 5) as VECTOR_type,
+            object_construct('k1', 1, 'k2', 2, 'k3', 3, 'k4', 4, 'k5', 5) :: map(varchar, int) as MAP_type,
+            object_construct('city', 'san jose', 'population', 0.05) :: object(city varchar, population float) as OBJECT_type,
+            [1.0, 3.1, 4.5] :: array(float) as ARRAY_type
+            WHERE 1=0
+            """
+            )
+
+            batches = cur.get_result_batches()
+            assert len(batches) == 1
+            # import pdb; pdb.set_trace()
+            batch = batches[0]
+            arrow_table = batch.to_arrow()
+            for actual, expected in zip(arrow_table.schema, expected_types):
+                assert (
+                    actual.type == expected
+                ), f"Expected {actual.name} :: {actual.type} column to be of type {expected}"
+
+
 def test_simple_arrow_fetch(conn_cnx):
     rowcount = 250_000
     with conn_cnx() as cnx:

--- a/test/integ/pandas/test_arrow_pandas.py
+++ b/test/integ/pandas/test_arrow_pandas.py
@@ -1202,6 +1202,7 @@ def test_batch_to_pandas_arrow(conn_cnx, result_format):
                 assert arrow_table.to_pydict()["FOO"] == list(range(rowcount))
 
 
+@pytest.mark.internal
 @pytest.mark.parametrize("enable_structured_types", [True, False])
 def test_to_arrow_datatypes(enable_structured_types, conn_cnx):
     with conn_cnx() as cnx:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Implements: #1000284

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This change adds support for structured types to ResultMetadataV2 which should allow for accurate schemas to be created in the snowpark python repo. Notable changes:
   - Changed the from_column handler to support other structured types as well as nested structured types. 
   - Added MAP as a supported metadata type.
   - Added relevant default initializers for pyarrow in order to support casting result batches to pyarrow tables.
   - Added a test that tests that the default initializers for pyarrow work as expected. I did not see an existing one. This test also happens to hit the new code paths for the ResultMetadataV2 changes.