### PR TITLE
Convert print statements to logging statements

### DIFF
--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -166,7 +166,7 @@ class AuthByWebBrowser(AuthByPlugin):
                 )
                 return
 
-            print(
+            logger.info(
                 "Initiating login request with your identity provider. A "
                 "browser window should have opened for you to complete the "
                 "login. If you can't see it, check existing browser windows, "
@@ -174,9 +174,9 @@ class AuthByWebBrowser(AuthByPlugin):
             )
 
             logger.debug("step 2: open a browser")
-            print(f"Going to open: {sso_url} to authenticate...")
+            logger.info(f"Going to open: {sso_url} to authenticate...")
             if not self._webbrowser.open_new(sso_url):
-                print(
+                logger.warning(
                     "We were unable to open a browser window for you, "
                     "please open the url above manually then paste the "
                     "URL you are redirected to into the terminal."


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1892 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The use of `print` breaks piping outputs, as the output is contaminated with the message when using `exteranlbrowswer` authentication. Moving these messages into logging allows for pipelining, and also elevating the the failure mode to a more suitable level of urgency.
