### PR TITLE
SNOW-1208964: Fix source file path resolution for local storage client

### DIFF
--- a/src/snowflake/connector/local_storage_client.py
+++ b/src/snowflake/connector/local_storage_client.py
@@ -33,7 +33,7 @@ class SnowflakeLocalStorageClient(SnowflakeStorageClient):
             stage_info["location"], os.path.basename(meta.dst_file_name)
         )
         if meta.local_location:
-            src_file_name = meta.real_src_file_name
+            src_file_name = self.data_file
             if src_file_name.startswith("/"):
                 src_file_name = src_file_name[1:]
             self.stage_file_name: str = os.path.join(

--- a/src/snowflake/connector/local_storage_client.py
+++ b/src/snowflake/connector/local_storage_client.py
@@ -33,9 +33,14 @@ class SnowflakeLocalStorageClient(SnowflakeStorageClient):
             stage_info["location"], os.path.basename(meta.dst_file_name)
         )
         if meta.local_location:
-            self.stage_file_name = self.full_dst_file_name
+            src_file_name = meta.real_src_file_name
+            if src_file_name.startswith("/"):
+                src_file_name = src_file_name[1:]
+            self.stage_file_name: str = os.path.join(
+                stage_info["location"], src_file_name
+            )
             self.full_dst_file_name = os.path.join(
-                meta.local_location, meta.dst_file_name
+                meta.local_location, os.path.basename(meta.dst_file_name)
             )
 
     def get_file_header(self, filename: str) -> FileHeader | None:
@@ -64,7 +69,7 @@ class SnowflakeLocalStorageClient(SnowflakeStorageClient):
                     tfd.write(sfd.read(self.chunk_size))
 
     def finish_download(self) -> None:
-        shutil.copyfile(self.intermediate_dst_path, self.full_dst_file_name)
+        shutil.move(self.intermediate_dst_path, self.full_dst_file_name)
         self.meta.dst_file_size = os.stat(self.full_dst_file_name).st_size
         self.meta.result_status = ResultStatus.DOWNLOADED
 

--- a/test/unit/test_local_storage_client.py
+++ b/test/unit/test_local_storage_client.py
@@ -58,8 +58,7 @@ def test_multi_chunk_download(multipart_threshold):
 
         meta = SnowflakeFileMeta(
             name=file_name,
-            src_file_name=str(stage_file),
-            real_src_file_name=str(file_name),
+            src_file_name=str(file_name),
             stage_location_type=LOCAL_FS,
             dst_file_name=file_name,
             local_location=local_dir,

--- a/test/unit/test_local_storage_client.py
+++ b/test/unit/test_local_storage_client.py
@@ -59,6 +59,7 @@ def test_multi_chunk_download(multipart_threshold):
         meta = SnowflakeFileMeta(
             name=file_name,
             src_file_name=str(stage_file),
+            real_src_file_name=str(file_name),
             stage_location_type=LOCAL_FS,
             dst_file_name=file_name,
             local_location=local_dir,


### PR DESCRIPTION
Description

When running `GET` queries in a local deployment, if a prefix path is provided in the `GET` query, the connector doesn't correctly generate the source file location. See SNOW-1208964 for a detailed example.

Testing

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1208964

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

When creating a destination filepath for `PUT`, the connector uses only the basename of the file. This works even with subdirectories because in the `PUT` case, `stage_info["location"]` contains the subdirectory path. 

For `GET`, the connector is using the same logic to construct the source filepath, but the prefix is not included in `stage_info["location"]`. This PR instead constructs the source filename based on `real_src_file_name` in the `GET` case.

I also changed `shutil.copyfile` to `shutil.move` in `finish_download` - this was leaving `<filename>.part` files in the destination directory.