### PR TITLE
SNOW-996732: improve clean up logic of connection

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
+  - Improved cleanup logic for connection to rely on interpreter shutdown instead of the `__del__` method.
 
 - v3.7.1(February 21, 2024)
 

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import atexit
+from contextlib import suppress
 import logging
 import os
 import pathlib
@@ -1748,10 +1749,8 @@ class SnowflakeConnection:
             self._done_async_sfqids[sf_qid] = None
 
     def _close_at_exit(self):
-        try:
+        with suppress(Exception):
             self.close(retry=False)
-        except Exception:
-            pass
 
     def get_query_status(self, sf_qid: str) -> QueryStatus:
         """Retrieves the status of query with sf_qid.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -441,6 +441,7 @@ class SnowflakeConnection:
 
         # get the imported modules from sys.modules
         self._log_telemetry_imported_packages()
+        # check SNOW-1218851 for long term improvement plan to refactor ocsp code
         atexit.register(self._close_at_exit)
 
     @property

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import atexit
-from contextlib import suppress
 import logging
 import os
 import pathlib
@@ -18,6 +17,7 @@ import warnings
 import weakref
 from concurrent.futures import as_completed
 from concurrent.futures.thread import ThreadPoolExecutor
+from contextlib import suppress
 from difflib import get_close_matches
 from functools import partial
 from io import StringIO

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -718,6 +718,8 @@ class SnowflakeConnection:
 
     def close(self, retry: bool = True) -> None:
         """Closes the connection."""
+        # unregister to dereference connection object as it's already closed after the execution
+        atexit.unregister(self._close_at_exit)
         try:
             if not self.rest:
                 logger.debug("Rest object has been destroyed, cannot close session")

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1342,3 +1342,20 @@ def test_ocsp_mode_insecure(conn_cnx, is_public_test, caplog):
             assert "snowflake.connector.ocsp_snowflake" in caplog.text
         else:
             assert "snowflake.connector.ocsp_snowflake" not in caplog.text
+
+
+@pytest.mark.skipolddriver
+def test_connection_atexit_close(db_parameters, capsys):
+    """Basic Connection test without schema."""
+    cnx = snowflake.connector.connect(
+        user=db_parameters["user"],
+        password=db_parameters["password"],
+        host=db_parameters["host"],
+        port=db_parameters["port"],
+        account=db_parameters["account"],
+        database=db_parameters["database"],
+        protocol=db_parameters["protocol"],
+        timezone="UTC",
+    )
+    cnx._close_at_exit()
+    assert cnx.is_closed()

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1345,17 +1345,8 @@ def test_ocsp_mode_insecure(conn_cnx, is_public_test, caplog):
 
 
 @pytest.mark.skipolddriver
-def test_connection_atexit_close(db_parameters, capsys):
+def test_connection_atexit_close(conn_cnx):
     """Basic Connection test without schema."""
-    cnx = snowflake.connector.connect(
-        user=db_parameters["user"],
-        password=db_parameters["password"],
-        host=db_parameters["host"],
-        port=db_parameters["port"],
-        account=db_parameters["account"],
-        database=db_parameters["database"],
-        protocol=db_parameters["protocol"],
-        timezone="UTC",
-    )
-    cnx._close_at_exit()
-    assert cnx.is_closed()
+    with conn_cnx() as conn:
+        conn._close_at_exit()
+        assert conn.is_closed()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

  the `__del__` method is unstable and gets called at random timing.
in one of the recent report, we found the `__del__` is causing circular import issue.

as a short term fix, we fix by moving away from `__del__` method to using `atexit` to clean up connection at intepreter shutdown time.

long term fix plan here: SNOW-1218851

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
