### PR TITLE
 Fix write_pandas() truncate-only flow to prevent CREATE TABLE IF NOT EXISTS

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,7 +20,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
-    - Update `write_pandas` to skip TABLE IF NOT EXISTS in truncate mode
+  - Updated diagnostics to use system$allowlist instead of system$whitelist.
+  - Update `write_pandas` to skip TABLE IF NOT EXISTS in truncate mode
 
 - v3.7.1(February 21, 2024)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
     - Add `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT` flag (usage: `SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT=true`) to make a non-blocking socket.recv call and retry on Error
       - Consider using this if running in a containerized environment and externalbrowser auth frequently hangs while waiting for callback
       - NOTE: this has not been tested extensively, but has been shown to improve the experience when using WSL
+    - Update `write_pandas` to skip TABLE IF NOT EXISTS in truncate mode
 
 - v3.7.1(February 21, 2024)
 

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -393,13 +393,14 @@ def write_pandas(
             quote_identifiers,
         )
 
-        create_table_sql = (
-            f"CREATE {table_type.upper()} TABLE IF NOT EXISTS {target_table_location} "
-            f"({create_table_columns})"
-            f" /* Python:snowflake.connector.pandas_tools.write_pandas() */ "
-        )
-        logger.debug(f"auto creating table with '{create_table_sql}'")
-        cursor.execute(create_table_sql, _is_internal=True)
+        if auto_create_table:
+            create_table_sql = (
+                f"CREATE {table_type.upper()} TABLE IF NOT EXISTS {target_table_location} "
+                f"({create_table_columns})"
+                f" /* Python:snowflake.connector.pandas_tools.write_pandas() */ "
+            )
+            logger.debug(f"auto creating table with '{create_table_sql}'")
+            cursor.execute(create_table_sql, _is_internal=True)
         # need explicit casting when the underlying table schema is inferred
         parquet_columns = "$1:" + ",$1:".join(
             f"{quote}{snowflake_col}{quote}::{column_type_mapping[col]}"

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -115,6 +115,7 @@ def test_write_pandas_with_overwrite(
         f"({col_name} STRING, {col_points} INT, {col_id} INT AUTOINCREMENT)"
     )
 
+    show_sql = f"SHOW TABLES LIKE '{random_table_name}'"  # SHOW command like is case-insensitive
     select_sql = f"SELECT * FROM {table_name}"
     select_count_sql = f"SELECT count(*) FROM {table_name}"
     drop_sql = f"DROP TABLE IF EXISTS {table_name}"
@@ -147,6 +148,35 @@ def test_write_pandas_with_overwrite(
             result = cnx.cursor(DictCursor).execute(select_count_sql).fetchone()
             # Check number of rows
             assert result["COUNT(*)"] == 1
+
+            # Truncate-only mode
+            if not auto_create_table:
+                # Capture the created_on timestamp of the target table before truncation
+                result = cnx.cursor(DictCursor).execute(show_sql).fetchone()
+                create_ts_before_trunc = result["created_on"]
+
+                # This operation should only truncate the table
+                success, nchunks, nrows, _ = write_pandas(
+                    cnx,
+                    df2,
+                    random_table_name,
+                    quote_identifiers=quote_identifiers,
+                    auto_create_table=auto_create_table,
+                    overwrite=True,
+                    index=index,
+                )
+
+                # Capture the created_on timestamp of the target table after truncation
+                result = cnx.cursor(DictCursor).execute(show_sql).fetchone()
+                create_ts_after_trunc = result["created_on"]
+                assert create_ts_before_trunc == create_ts_after_trunc
+
+                # Check write_pandas output
+                assert success
+                assert nchunks == 1
+                result = cnx.cursor(DictCursor).execute(select_count_sql).fetchone()
+                # Check number of rows
+                assert result["COUNT(*)"] == 1
 
             # Write dataframe with a different schema
             if auto_create_table:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

Addresses [SNOW-1184290](https://snowflakecomputing.atlassian.net/browse/SNOW-1184290)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Builds on the changes committed in SNOW-733213 to enforce truncate-only behavior by excluding CREATE TABLE IF NOT EXISTS when auto_create_table = False and overwrite = True.

[SNOW-1184290]: https://snowflakecomputing.atlassian.net/browse/SNOW-1184290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ