### PR TITLE
SNOW-0000000: Revert pyarrow 13.0.0 dependency.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,6 @@ development =
     pytzdata
 pandas =
     pandas>=1.0.0,<3.0.0
-    pyarrow>=13.0.0
+    pyarrow
 secure-local-storage =
     keyring>=23.1.0,<25.0.0

--- a/src/snowflake/connector/result_batch.py
+++ b/src/snowflake/connector/result_batch.py
@@ -703,10 +703,7 @@ class ArrowResultBatch(ResultBatch):
         """Returns this batch as a pandas DataFrame"""
         self._check_can_use_pandas()
         table = self.to_arrow(connection=connection)
-        # By default arrow returns maps as kv tuples in order to allow duplicate keys.
-        # Snowflake does not support duplicate keys in maps. In order to better match
-        # pyspark this will return maps as dictionaries which would remove duplicate keys.
-        return table.to_pandas(**{"maps_as_pydicts": "strict", **kwargs})
+        return table.to_pandas(**kwargs)
 
     def _get_pandas_iter(
         self, connection: SnowflakeConnection | None = None, **kwargs


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR removes the maps_as_pydicts parameter that would cause a dependency on pyarrow 13.0.0. This means that maps returned in pandas tables will instead be returned as lists of tuples instead. Users are still free to pass in the maps_as_pydicts parameter to fetch_all_pandas in order to get dictionary objects back instead.