### PR TITLE
MINOR: Bumped up PythonConnector MINOR version from 3.9.1 to 3.10.0

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,11 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 
 - v3.10.0 (TBD)
+
+- v3.10.0(April 29,2024)
+
+   -N/A
+
   - Added support for structured types to fetch_pandas_all.
   - Fixed an issue that endpoint for China s3 is not formed correctly.
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,7 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.10.0(April 29,2024)
 
   - Added support for structured types to fetch_pandas_all.
-  - Fixed an issue that endpoint for China s3 is not formed correctly.
+  - Fixed an issue relating to incorrectly formed China S3 endpoints.
 
 - v3.9.1(April 22,2024)
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,11 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
-- v3.10.0 (TBD)
-
 - v3.10.0(April 29,2024)
-
-   -N/A
 
   - Added support for structured types to fetch_pandas_all.
   - Fixed an issue that endpoint for China s3 is not formed correctly.

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
 # Don't change the forth version number from None
-VERSION = (3, 9, 1, None)
+VERSION = (3, 10, 0, None)

--- a/tested_requirements/requirements_310.reqs
+++ b/tested_requirements/requirements_310.reqs
@@ -7,7 +7,7 @@ cryptography==42.0.5
 filelock==3.13.4
 idna==3.7
 packaging==24.0
-platformdirs==4.2.0
+platformdirs==4.2.1
 pycparser==2.22
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
@@ -17,4 +17,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.4
 typing_extensions==4.11.0
 urllib3==2.2.1
-snowflake-connector-python==3.9.0
+snowflake-connector-python==3.10.0

--- a/tested_requirements/requirements_311.reqs
+++ b/tested_requirements/requirements_311.reqs
@@ -7,7 +7,7 @@ cryptography==42.0.5
 filelock==3.13.4
 idna==3.7
 packaging==24.0
-platformdirs==4.2.0
+platformdirs==4.2.1
 pycparser==2.22
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
@@ -17,4 +17,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.4
 typing_extensions==4.11.0
 urllib3==2.2.1
-snowflake-connector-python==3.9.0
+snowflake-connector-python==3.10.0

--- a/tested_requirements/requirements_312.reqs
+++ b/tested_requirements/requirements_312.reqs
@@ -7,7 +7,7 @@ cryptography==42.0.5
 filelock==3.13.4
 idna==3.7
 packaging==24.0
-platformdirs==4.2.0
+platformdirs==4.2.1
 pycparser==2.22
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
@@ -19,4 +19,4 @@ tomlkit==0.12.4
 typing_extensions==4.11.0
 urllib3==2.2.1
 wheel==0.43.0
-snowflake-connector-python==3.9.0
+snowflake-connector-python==3.10.0

--- a/tested_requirements/requirements_38.reqs
+++ b/tested_requirements/requirements_38.reqs
@@ -7,7 +7,7 @@ cryptography==42.0.5
 filelock==3.13.4
 idna==3.7
 packaging==24.0
-platformdirs==4.2.0
+platformdirs==4.2.1
 pycparser==2.22
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
@@ -17,4 +17,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.4
 typing_extensions==4.11.0
 urllib3==1.26.18
-snowflake-connector-python==3.9.0
+snowflake-connector-python==3.10.0

--- a/tested_requirements/requirements_39.reqs
+++ b/tested_requirements/requirements_39.reqs
@@ -7,7 +7,7 @@ cryptography==42.0.5
 filelock==3.13.4
 idna==3.7
 packaging==24.0
-platformdirs==4.2.0
+platformdirs==4.2.1
 pycparser==2.22
 PyJWT==2.8.0
 pyOpenSSL==24.1.0
@@ -17,4 +17,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.4
 typing_extensions==4.11.0
 urllib3==1.26.18
-snowflake-connector-python==3.9.0
+snowflake-connector-python==3.10.0


### PR DESCRIPTION
@noreview - This is an automated process. No review is required

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This release should be fairly light. There are two main things we're pushing as part of it:

    1. Added support for structured types to fetch_pandas_all.
        As part of the structured types initiative this PR adds support for fetching structured data as pandas dataframes. This is a new functionality and shouldn't have any effect on current queries.

    2. Fixed an issue that endpoint for China s3 is not formed correctly.
        @sfc-gh-yuwang can provide more details if needed.