### PR TITLE
SNOW-1412405: fix ocsp validating sha384 signed certificate

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,11 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
   - Added support for `token_file_path` connection parameter to read an OAuth token from a file when connecting to Snowflake.
   - Added support for `debug_arrow_chunk` connection parameter to allow debugging raw arrow data in case of arrow data parsing failure.
+  - Fixed a bug that OCSP certificate signed using SHA384 algorithm cannot be verified.
+
+- v3.10.1(May 21, 2024)
+
+  - Removed an incorrect error log message that could occur during arrow data conversion.
 
 - v3.10.0(April 29,2024)
 

--- a/src/snowflake/connector/ocsp_asn1crypto.py
+++ b/src/snowflake/connector/ocsp_asn1crypto.py
@@ -50,8 +50,8 @@ class SnowflakeOCSPAsn1Crypto(SnowflakeOCSP):
     # map signature algorithm name to digest class
     SIGNATURE_ALGORITHM_TO_DIGEST_CLASS = {
         "sha256": hashes.SHA256,
-        "sha384": hashes.SHA3_384,
-        "sha512": hashes.SHA3_512,
+        "sha384": hashes.SHA384,
+        "sha512": hashes.SHA512,
     }
 
     def encode_cert_id_key(self, hkey):

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -14,7 +14,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from os import environ, path
 from unittest import mock
 
-from asn1crypto import pem
 from asn1crypto import x509 as asn1crypto509
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -601,10 +600,8 @@ def test_signature_verification(hash_algorithm):
         .sign(private_key, hash_algorithm, default_backend())
     )
 
-    cert_bytes = cert.public_bytes(Encoding.PEM)
-
     # in snowflake, we use lib asn1crypto to load certificate, not using lib cryptography
-    asy1_509_cert = asn1crypto509.Certificate.load(pem.unarmor(cert_bytes)[2])
+    asy1_509_cert = asn1crypto509.Certificate.load(cert.public_bytes(Encoding.DER))
 
     # sha3 family is not recognized by asn1crypto library
     if hash_algorithm.name.startswith("sha3-"):

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import platform
@@ -12,6 +13,14 @@ import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from os import environ, path
 from unittest import mock
+
+from asn1crypto import pem
+from asn1crypto import x509 as asn1crypto509
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
 
 try:
     from snowflake.connector.util_text import random_string
@@ -546,3 +555,70 @@ def test_building_new_retry():
     )
 
     del os.environ["SF_OCSP_ACTIVATE_NEW_ENDPOINT"]
+
+
+@pytest.mark.parametrize(
+    "hash_algorithm",
+    [
+        hashes.SHA256(),
+        hashes.SHA384(),
+        hashes.SHA512(),
+        hashes.SHA3_256(),
+        hashes.SHA3_384(),
+        hashes.SHA3_512(),
+    ],
+)
+def test_signature_verification(hash_algorithm):
+    # Generate a private key
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=1024, backend=default_backend()
+    )
+
+    # Generate a public key
+    public_key = private_key.public_key()
+
+    # Create a certificate
+    subject = x509.Name(
+        [
+            x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "US"),
+        ]
+    )
+
+    issuer = subject
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now())
+        .not_valid_after(datetime.datetime.now() + datetime.timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("example.com")]),
+            critical=False,
+        )
+        .sign(private_key, hash_algorithm, default_backend())
+    )
+
+    cert_bytes = cert.public_bytes(Encoding.PEM)
+
+    # in snowflake, we use lib asn1crypto to load certificate, not using lib cryptography
+    asy1_509_cert = asn1crypto509.Certificate.load(pem.unarmor(cert_bytes)[2])
+
+    # sha3 family is not recognized by asn1crypto library
+    if hash_algorithm.name.startswith("sha3-"):
+        with pytest.raises(ValueError):
+            SFOCSP().verify_signature(
+                asy1_509_cert.hash_algo,
+                cert.signature,
+                asy1_509_cert,
+                asy1_509_cert["tbs_certificate"],
+            )
+    else:
+        SFOCSP().verify_signature(
+            asy1_509_cert.hash_algo,
+            cert.signature,
+            asy1_509_cert,
+            asy1_509_cert["tbs_certificate"],
+        )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

SHA3-384 is a different algorithm from SHA384, and it's not supported by the asn1crypto library.
this PR fixes the sha algorithm mapping info
