### PR TITLE
[feature branch] Initial checkin for Phase 0 changes to the connector

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1279,6 +1279,7 @@ class SnowflakeConnection:
         _update_current_object: bool = True,
         _no_retry: bool = False,
         timeout: int | None = None,
+        dataframe_ast: str | None = None,
     ) -> dict[str, Any]:
         """Executes a query with a sequence counter."""
         logger.debug("_cmd_query")
@@ -1288,6 +1289,8 @@ class SnowflakeConnection:
             "sequenceId": sequence_counter,
             "querySubmissionTime": get_time_millis(),
         }
+        if dataframe_ast is not None:
+            data["dataframeAst"] = dataframe_ast
         if statement_params is not None:
             data["parameters"] = statement_params
         if is_internal:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -601,6 +601,7 @@ class SnowflakeCursor:
         _no_results: bool = False,
         _is_put_get=None,
         _no_retry: bool = False,
+        dataframe_ast: str | None = None,
     ) -> dict[str, Any]:
         del self.messages[:]
 
@@ -704,6 +705,7 @@ class SnowflakeCursor:
                 _no_results=_no_results,
                 _no_retry=_no_retry,
                 timeout=real_timeout,
+                dataframe_ast=dataframe_ast,
             )
         finally:
             try:
@@ -807,6 +809,7 @@ class SnowflakeCursor:
         _skip_upload_on_content_match: bool = False,
         file_stream: IO[bytes] | None = None,
         num_statements: int | None = None,
+        _dataframe_ast: str | None = None,
     ) -> Self | None:
         ...
 
@@ -837,6 +840,7 @@ class SnowflakeCursor:
         _skip_upload_on_content_match: bool = False,
         file_stream: IO[bytes] | None = None,
         num_statements: int | None = None,
+        _dataframe_ast: str | None = None,
     ) -> dict[str, Any] | None:
         ...
 
@@ -866,6 +870,7 @@ class SnowflakeCursor:
         _skip_upload_on_content_match: bool = False,
         file_stream: IO[bytes] | None = None,
         num_statements: int | None = None,
+        _dataframe_ast: str | None = None,
     ) -> Self | dict[str, Any] | None:
         """Executes a command/query.
 
@@ -900,6 +905,7 @@ class SnowflakeCursor:
             file_stream: File-like object to be uploaded with PUT
             num_statements: Query level parameter submitted in _statement_params constraining exact number of
             statements being submitted (or 0 if submitting an uncounted number) when using a multi-statement query.
+            _dataframe_ast: Base64-encoded dataframe request abstract syntax tree.
 
         Returns:
             The cursor itself, or None if some error happened, or the response returned
@@ -941,6 +947,7 @@ class SnowflakeCursor:
             "_no_results": _no_results,
             "_is_put_get": _is_put_get,
             "_no_retry": _no_retry,
+            "dataframe_ast": _dataframe_ast,
         }
 
         if self._connection.is_pyformat:


### PR DESCRIPTION
Allows us to pass `dataframe_ast` to `cmd_query`. This will be used by Snowpark to communicate AST-level requests.

To use this in your own development, clone this Git repo and follow instructions in `/CONTRIBUTING.md`.