### PR TITLE
SNOW-1460707: Fix permission error when there is no permission on the parent directory of config file path 

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -14,6 +14,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for `debug_arrow_chunk` connection parameter to allow debugging raw arrow data in case of arrow data parsing failure.
   - Fixed a bug that OCSP certificate signed using SHA384 algorithm cannot be verified.
   - Fixed a bug that status code shown as uploaded when PUT command failed with 400 error.
+  - Fixed a bug that a PermissionError was raised when the current user does not have the right permission on parent directory of config file path.
 
 - v3.10.1(May 21, 2024)
 

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -320,8 +320,15 @@ class ConfigManager:
         ):
             if sliceoptions.only_in_slice:
                 del read_config_file[section]
-            if not filep.exists():
+            try:
+                if not filep.exists():
+                    continue
+            except PermissionError:
+                LOGGER.debug(
+                    f"Fail to read configuration file from {str(filep)} due to no permission on its parent directory"
+                )
                 continue
+
             if (
                 sliceoptions.check_permissions  # Skip checking if this file couldn't hold sensitive information
                 # Same check as openssh does for permissions

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -592,6 +592,7 @@ def test_warn_config_file_permissions(tmp_path):
     )
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="chmod doesn't work on Windows")
 def test_log_debug_config_file_parent_dir_permissions(tmp_path, caplog):
     tmp_dir = tmp_path / "tmp_dir"
     tmp_dir.mkdir()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1959

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `path.exists` will raise a PermissionError if there is no permission on the parent directory of config file path 
