### PR TITLE
SNOW-1296805 Remove option tmpdir from SnowflakeEncryptionUtil.decrypt_file

### DIFF
--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -194,7 +194,7 @@ class SnowflakeEncryptionUtil:
         in_filename: str,
         chunk_size: int = 64 * kilobyte,
     ) -> str:
-        """Decrypts a file and stores the output in the same dierctory of the incoming file.
+        """Decrypts a file and stores the output in the same directory of the incoming file.
 
         Args:
             metadata: The file's metadata input.

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -193,23 +193,23 @@ class SnowflakeEncryptionUtil:
         encryption_material: SnowflakeFileEncryptionMaterial,
         in_filename: str,
         chunk_size: int = 64 * kilobyte,
-        tmp_dir: str | None = None,
     ) -> str:
-        """Decrypts a file and stores the output in the temporary directory.
+        """Decrypts a file and stores the output in the same dierctory of the incoming file.
 
         Args:
             metadata: The file's metadata input.
             encryption_material: The file's encryption material.
             in_filename: The name of the input file.
             chunk_size: The size of read chunks (Default value = block_size * 4 * 1024).
-            tmp_dir: Temporary directory to use, optional (Default value = None).
 
         Returns:
             The decrypted file's location.
         """
-        temp_output_file = f"{os.path.basename(in_filename)}#{random_string()}"
-        if tmp_dir:
-            temp_output_file = os.path.join(tmp_dir, temp_output_file)
+        # writing in same directory as in_filename
+        temp_output_file = os.path.join(
+            os.path.dirname(in_filename),
+            f"{os.path.basename(in_filename)}#{random_string()}",
+        )
 
         logger.debug("encrypted file: %s, tmp file: %s", in_filename, temp_output_file)
         with open(in_filename, "rb") as infile:

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -377,7 +377,6 @@ class SnowflakeStorageClient(ABC):
                     self.encryption_metadata,
                     meta.encryption_material,
                     str(self.intermediate_dst_path),
-                    tmp_dir=self.tmp_dir,
                 )
                 shutil.move(tmp_dst_file_name, self.full_dst_file_name)
                 self.intermediate_dst_path.unlink()

--- a/test/unit/test_encryption_util.py
+++ b/test/unit/test_encryption_util.py
@@ -46,7 +46,7 @@ def test_encrypt_decrypt_file(tmp_path):
             encryption_material, input_file, tmp_dir=str(tmp_path)
         )
         decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
-            metadata, encryption_material, encrypted_file, tmp_dir=str(tmp_path)
+            metadata, encryption_material, encrypted_file
         )
 
         contents = ""
@@ -98,10 +98,10 @@ def test_encrypt_decrypt_large_file(tmpdir):
                 )
 
             (metadata, encrypted_file) = SnowflakeEncryptionUtil.encrypt_file(
-                encryption_material, input_file, tmp_dir=str(tmpdir)
+                encryption_material, input_file
             )
             decrypted_file = SnowflakeEncryptionUtil.decrypt_file(
-                metadata, encryption_material, encrypted_file, tmp_dir=str(tmpdir)
+                metadata, encryption_material, encrypted_file
             )
 
             digest_dec, size_dec = SnowflakeFileUtil.get_digest_and_size_for_file(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1296805

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 https://github.com/snowflakedb/snowflake-connector-python/blob/972accde29792fb06fbfd068b870022bc7682f82/src/snowflake/connector/storage_client.py#L382 is problematic where self.tmp_dir are on a different device than target directory (`self.full_dst_file_name`) in a network filesystem (e.g. persistent storage mounted to a docker container). Cross device file operations could cause the program to hang (especially on windows machines). We can eliminate this by making the decrypted intermediate file is written to the same directory as target directory (`self.full_dst_file_name`), where we know is writable.
