### PR TITLE
SNOW-1468259 Add connection timeout and read timeout to storage client request

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.12.0(TBD)
+  - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.
+
 - v3.11.0(June 17,2024)
   - Added support for `token_file_path` connection parameter to read an OAuth token from a file when connecting to Snowflake.
   - Added support for `debug_arrow_chunk` connection parameter to allow debugging raw arrow data in case of arrow data parsing failure.

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -399,6 +399,7 @@ class IterUnit(Enum):
     TABLE_UNIT = "table"
 
 
+# File Transfer
 # Amazon S3 multipart upload limits
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 S3_DEFAULT_CHUNK_SIZE = 8 * 1024**2
@@ -409,6 +410,10 @@ S3_MAX_PARTS = 10000
 
 S3_CHUNK_SIZE = 8388608  # boto3 default
 AZURE_CHUNK_SIZE = 4 * megabyte
+
+# https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+REQUEST_CONNECTION_TIMEOUT = 10
+REQUEST_READ_TIMEOUT = 600
 
 DAY_IN_SECONDS = 60 * 60 * 24
 

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -19,7 +19,13 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple
 
 import OpenSSL
 
-from .constants import HTTP_HEADER_CONTENT_ENCODING, FileHeader, ResultStatus
+from .constants import (
+    HTTP_HEADER_CONTENT_ENCODING,
+    REQUEST_CONNECTION_TIMEOUT,
+    REQUEST_READ_TIMEOUT,
+    FileHeader,
+    ResultStatus,
+)
 from .encryption_util import EncryptionMetadata, SnowflakeEncryptionUtil
 from .errors import RequestExceedMaxRetryError
 from .file_util import SnowflakeFileUtil
@@ -280,6 +286,7 @@ class SnowflakeStorageClient(ABC):
         while self.retry_count[retry_id] < self.max_retry:
             cur_timestamp = self.credentials.timestamp
             url, rest_kwargs = get_request_args()
+            rest_kwargs["timeout"] = (REQUEST_CONNECTION_TIMEOUT, REQUEST_READ_TIMEOUT)
             try:
                 if conn:
                     with conn._rest._use_requests_session(url) as session:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-1468259](https://snowflakecomputing.atlassian.net/browse/SNOW-1468259)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   By default, `request` do not time out unless a timeout value is set explicitly. A user recently reported that their file transfer would sometimes hang indefinitely at reading from a request call. This PR aims to mitigate this issue by specifying a default connection timeout of 10 seconds and socket read timeout of 10 minutes. Please see 
 https://requests.readthedocs.io/en/latest/user/advanced/#timeouts


[SNOW-1468259]: https://snowflakecomputing.atlassian.net/browse/SNOW-1468259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ