### PR TITLE
SNOW-1518775: fix connector fips docker image

### DIFF
--- a/ci/docker/connector_test_fips/Dockerfile
+++ b/ci/docker/connector_test_fips/Dockerfile
@@ -12,6 +12,9 @@ RUN chmod 777 /home/user
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 RUN yum install -y redhat-rpm-config gcc libffi-devel openssl openssl-devel centos-release-scl && \
     yum install -y rh-python38 rh-python38-python-devel && \
     yum clean all && \

--- a/ci/docker/connector_test_fips/Dockerfile
+++ b/ci/docker/connector_test_fips/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 
 # This is to solve permission issue, read https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64"
@@ -15,8 +15,10 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-RUN yum install -y redhat-rpm-config gcc libffi-devel openssl openssl-devel centos-release-scl && \
-    yum install -y rh-python38 rh-python38-python-devel && \
+
+RUN yum clean all && \
+    yum install -y redhat-rpm-config gcc libffi-devel openssl openssl-devel && \
+    yum install -y python38 python38-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
-RUN scl enable rh-python38 "python3.8 -m pip install --user --upgrade pip setuptools wheel"
+RUN python3 -m pip install --user --upgrade pip setuptools wheel


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1518775
centos7 reaches end of life and https://mirrorlist.centos.org/ is gone. leading to docker image could not be built.
solution provided by
https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
