### PR TITLE
SNOW-1511108 SQLAlchemy heartbeat frequency parsed as string

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,10 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.x.x(TBD)
+  - ..
+  - Fixed a bug that specifying `client_session_keep_alive_heartbeat_frequency` in snowflake-sqlalchemy could crash the connector
+
 - v3.11.0(June 17,2024)
   - Added support for `token_file_path` connection parameter to read an OAuth token from a file when connecting to Snowflake.
   - Added support for `debug_arrow_chunk` connection parameter to allow debugging raw arrow data in case of arrow data parsing failure.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,8 +8,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
-- v3.11.1(TBD)
-  - Fixed a bug that specifying `client_session_keep_alive_heartbeat_frequency` in snowflake-sqlalchemy could crash the connector
+- v3.12.0(TBD)
+  - Optimized `to_pandas()` performance by fully parallel downloading logic.
+  - Fixed a bug that specifying client_session_keep_alive_heartbeat_frequency in snowflake-sqlalchemy could crash the connector
 
 - v3.11.0(June 17,2024)
   - Added support for `token_file_path` connection parameter to read an OAuth token from a file when connecting to Snowflake.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,8 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
-- v3.x.x(TBD)
-  - ..
+- v3.11.1(TBD)
   - Fixed a bug that specifying `client_session_keep_alive_heartbeat_frequency` in snowflake-sqlalchemy could crash the connector
 
 - v3.11.0(June 17,2024)

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1673,6 +1673,12 @@ class SnowflakeConnection:
         """Validate and return heartbeat frequency in seconds."""
         real_max = int(self.rest.master_validity_in_seconds / 4)
         real_min = int(real_max / 4)
+
+        # ensure the type is integer
+        self._client_session_keep_alive_heartbeat_frequency = int(
+            self.client_session_keep_alive_heartbeat_frequency
+        )
+        
         if self.client_session_keep_alive_heartbeat_frequency is None:
             # This is an unlikely scenario but covering it just in case.
             self._client_session_keep_alive_heartbeat_frequency = real_min
@@ -1681,10 +1687,6 @@ class SnowflakeConnection:
         elif self.client_session_keep_alive_heartbeat_frequency < real_min:
             self._client_session_keep_alive_heartbeat_frequency = real_min
 
-        # ensure the type is integer
-        self._client_session_keep_alive_heartbeat_frequency = int(
-            self.client_session_keep_alive_heartbeat_frequency
-        )
         return self.client_session_keep_alive_heartbeat_frequency
 
     def _validate_client_prefetch_threads(self) -> int:

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1678,7 +1678,7 @@ class SnowflakeConnection:
         self._client_session_keep_alive_heartbeat_frequency = int(
             self.client_session_keep_alive_heartbeat_frequency
         )
-        
+
         if self.client_session_keep_alive_heartbeat_frequency is None:
             # This is an unlikely scenario but covering it just in case.
             self._client_session_keep_alive_heartbeat_frequency = real_min

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -260,6 +260,33 @@ def test_keep_alive_heartbeat_frequency_min(db_parameters):
         cnx.close()
 
 
+def test_keep_alive_heartbeat_frequency_str(db_parameters):
+    """Tests heartbeat setting with frequency specified as string.
+
+    Creates a connection with client_session_keep_alive_heartbeat_frequency
+    parameter incoming as str.
+    """
+    config = {
+        "user": db_parameters["user"],
+        "password": db_parameters["password"],
+        "host": db_parameters["host"],
+        "port": db_parameters["port"],
+        "account": db_parameters["account"],
+        "schema": db_parameters["schema"],
+        "database": db_parameters["database"],
+        "protocol": db_parameters["protocol"],
+        "timezone": "UTC",
+        "client_session_keep_alive": True,
+        "client_session_keep_alive_heartbeat_frequency": "900",
+    }
+    cnx = snowflake.connector.connect(**config)
+    try:
+        # should be automatically converted to int and not fail
+        assert cnx.client_session_keep_alive_heartbeat_frequency == 900
+    finally:
+        cnx.close()
+
+
 def test_bad_db(db_parameters):
     """Attempts to use a bad DB."""
     cnx = snowflake.connector.connect(

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -233,6 +233,7 @@ def test_keep_alive_heartbeat_frequency(db_parameters):
         cnx.close()
 
 
+@pytest.mark.skipolddriver
 def test_keep_alive_heartbeat_frequency_min(db_parameters):
     """Tests heartbeat setting with custom frequency.
 

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -237,6 +237,7 @@ def test_keep_alive_heartbeat_frequency_min(db_parameters):
     """Tests heartbeat setting with custom frequency.
 
     Creates a connection with client_session_keep_alive_heartbeat_frequency parameter and set the minimum frequency.
+    Also if a value comes as string, should be properly converted to int and not fail assertion.
     """
     config = {
         "user": db_parameters["user"],
@@ -249,39 +250,12 @@ def test_keep_alive_heartbeat_frequency_min(db_parameters):
         "protocol": db_parameters["protocol"],
         "timezone": "UTC",
         "client_session_keep_alive": True,
-        "client_session_keep_alive_heartbeat_frequency": 10,
+        "client_session_keep_alive_heartbeat_frequency": "10",
     }
     cnx = snowflake.connector.connect(**config)
     try:
         # The min value of client_session_keep_alive_heartbeat_frequency
         # is 1/16 of master token validity, so 14400 / 4 /4 => 900
-        assert cnx.client_session_keep_alive_heartbeat_frequency == 900
-    finally:
-        cnx.close()
-
-
-def test_keep_alive_heartbeat_frequency_str(db_parameters):
-    """Tests heartbeat setting with frequency specified as string.
-
-    Creates a connection with client_session_keep_alive_heartbeat_frequency
-    parameter incoming as str.
-    """
-    config = {
-        "user": db_parameters["user"],
-        "password": db_parameters["password"],
-        "host": db_parameters["host"],
-        "port": db_parameters["port"],
-        "account": db_parameters["account"],
-        "schema": db_parameters["schema"],
-        "database": db_parameters["database"],
-        "protocol": db_parameters["protocol"],
-        "timezone": "UTC",
-        "client_session_keep_alive": True,
-        "client_session_keep_alive_heartbeat_frequency": "900",
-    }
-    cnx = snowflake.connector.connect(**config)
-    try:
-        # should be automatically converted to int and not fail
         assert cnx.client_session_keep_alive_heartbeat_frequency == 900
     finally:
         cnx.close()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

* SNOW-1511108
* https://github.com/snowflakedb/snowflake-sqlalchemy/issues/509

When coming from (snowflake-)sqlalchemy's Engine, the `client_session_keep_alive_heartbeat_frequency` option seems to come as string, which then will crash the connector with
```
..
  File "/usr/local/lib/python3.11/site-packages/snowflake/connector/connection.py", line 1680, in _validate_client_session_keep_alive_heartbeat_frequency
    elif self.client_session_keep_alive_heartbeat_frequency > real_max:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'
```

2. Fill out the following pre-review checklist:

- [ ] I am adding a new automated test(s) to verify correctness of my new code
- [ ] I am adding new logging messages
- [ ] I am adding a new telemetry message
- [ ] I am modifying authorization mechanisms
- [ ] I am adding new credentials
- [ ] I am modifying OCSP code
- [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

We already seem to have a protection mechanism against such occasions by converting the input to `int`, however when we do that, it's already too late because we already tried to compare `str` to `int` and failed with `TypeError`.

Functionality isn't changed, just moved the conversion to happen _before_ the comparison to `int` happens.
