### PR TITLE
Update keyring upper bound to 26

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,4 +96,4 @@ pandas =
     pandas>=1.0.0,<3.0.0
     pyarrow
 secure-local-storage =
-    keyring>=23.1.0,<25.0.0
+    keyring>=23.1.0,<26.0.0


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2001

2. Fill out the following pre-review checklist:

   - (n/a) [x] I am adding a new automated test(s) to verify correctness of my new code
   - (n/a) [x] I am adding new logging messages
   - (n/a) [x] I am adding a new telemetry message
   - (n/a) [x] I am modifying authorization mechanisms
   - (n/a) [x] I am adding new credentials
   - (n/a) [x] I am modifying OCSP code
   - [x] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR bumps the upper bound for the `keyring` dependency. The major version bump corresponding with `24 -> 25` resulted in two breaking changes that are not relevant to the use cases in `snowflake-connector-python` ([changelog here](https://keyring.readthedocs.io/en/latest/history.html)):
   
      > - Removed check for config in XDG_DATA_HOME on Linux systems. ([#99](https://github.com/jaraco/keyring/issues/99))
      > - In platform config support, remove support for Windows XP, now 10 years sunset.
   
   Essentially, `keyring` is deprecation OS related support. So this is breaking for users of, say, Windows XP, but this does **_not_** constitute a breaking API change, meaning that `snowflake-connector-python` is safe to support a higher version of this library without breaking any of the code used directly within `snowflake-connector-python`.
   
   **I actually would not mind if Snowflake simply removed the upper bound for this dependency altogether. :smiley:** However, this is not a can of worms I necessarily need to open right now. I just need to support `keyring==25.x`.

4. (Optional) PR for stored-proc connector:
