### PR TITLE
Fix gcp test so that gcs downscoped is always enabled

### DIFF
--- a/test/integ/test_put_get_with_gcp_account.py
+++ b/test/integ/test_put_get_with_gcp_account.py
@@ -57,7 +57,7 @@ logger = getLogger(__name__)
 pytestmark = pytest.mark.gcp
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", True)
+@pytest.mark.parametrize("enable_gcs_downscoped", [True])
 @pytest.mark.parametrize(
     "from_path", [True, pytest.param(False, marks=pytest.mark.skipolddriver)]
 )
@@ -127,7 +127,7 @@ def test_put_get_with_gcp(
     assert original_contents == contents, "Output is different from the original file"
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", True)
+@pytest.mark.parametrize("enable_gcs_downscoped", [True])
 def test_put_copy_many_files_gcp(
     tmpdir,
     conn_cnx,
@@ -192,7 +192,7 @@ def test_put_copy_many_files_gcp(
                 run(csr, "drop table if exists {name}")
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", True)
+@pytest.mark.parametrize("enable_gcs_downscoped", [True])
 def test_put_copy_duplicated_files_gcp(
     tmpdir,
     conn_cnx,
@@ -288,7 +288,7 @@ def test_put_copy_duplicated_files_gcp(
                 run(csr, "drop table if exists {name}")
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", True)
+@pytest.mark.parametrize("enable_gcs_downscoped", [True])
 def test_put_get_large_files_gcp(
     tmpdir,
     conn_cnx,
@@ -476,7 +476,7 @@ def test_get_gcp_file_object_http_400_error(tmpdir, conn_cnx):
     assert original_contents == contents, "Output is different from the original file"
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", True)
+@pytest.mark.parametrize("enable_gcs_downscoped", [True])
 def test_auto_compress_off_gcp(
     tmpdir,
     conn_cnx,

--- a/test/integ/test_put_get_with_gcp_account.py
+++ b/test/integ/test_put_get_with_gcp_account.py
@@ -57,7 +57,7 @@ logger = getLogger(__name__)
 pytestmark = pytest.mark.gcp
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", [True, False])
+@pytest.mark.parametrize("enable_gcs_downscoped", True)
 @pytest.mark.parametrize(
     "from_path", [True, pytest.param(False, marks=pytest.mark.skipolddriver)]
 )
@@ -127,7 +127,7 @@ def test_put_get_with_gcp(
     assert original_contents == contents, "Output is different from the original file"
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", [True, False])
+@pytest.mark.parametrize("enable_gcs_downscoped", True)
 def test_put_copy_many_files_gcp(
     tmpdir,
     conn_cnx,
@@ -192,7 +192,7 @@ def test_put_copy_many_files_gcp(
                 run(csr, "drop table if exists {name}")
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", [True, False])
+@pytest.mark.parametrize("enable_gcs_downscoped", True)
 def test_put_copy_duplicated_files_gcp(
     tmpdir,
     conn_cnx,
@@ -288,7 +288,7 @@ def test_put_copy_duplicated_files_gcp(
                 run(csr, "drop table if exists {name}")
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", [True, False])
+@pytest.mark.parametrize("enable_gcs_downscoped", True)
 def test_put_get_large_files_gcp(
     tmpdir,
     conn_cnx,
@@ -476,7 +476,7 @@ def test_get_gcp_file_object_http_400_error(tmpdir, conn_cnx):
     assert original_contents == contents, "Output is different from the original file"
 
 
-@pytest.mark.parametrize("enable_gcs_downscoped", [True, False])
+@pytest.mark.parametrize("enable_gcs_downscoped", True)
 def test_auto_compress_off_gcp(
     tmpdir,
     conn_cnx,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
