### PR TITLE
SNOW-1570328: fix disabling client telemetry

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.12.1(TBD)
   - Fixed a bug that session token is logged when renewing session.
+  - Fixed a bug that disabling client telemetry does not work.
 
 - v3.12.0(July 24,2024)
   - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -409,7 +409,8 @@ class SnowflakeConnection:
         self.messages = []
         self._async_sfqids: dict[str, None] = {}
         self._done_async_sfqids: dict[str, None] = {}
-        self.telemetry_enabled = False
+        self._client_param_telemetry_enabled = True
+        self._server_param_telemetry_enabled = False
         self._session_parameters: dict[str, str | int | bool] = {}
         logger.info(
             "Snowflake Connector for Python Version: %s, "
@@ -626,11 +627,22 @@ class SnowflakeConnection:
 
     @property
     def telemetry_enabled(self) -> bool:
-        return self._telemetry_enabled
+        return bool(
+            self._client_param_telemetry_enabled
+            and self._server_param_telemetry_enabled
+        )
 
     @telemetry_enabled.setter
     def telemetry_enabled(self, value) -> None:
-        self._telemetry_enabled = True if value else False
+        self._client_param_telemetry_enabled = True if value else False
+        if (
+            self._client_param_telemetry_enabled
+            and not self._server_param_telemetry_enabled
+        ):
+            logger.info(
+                "Telemetry has been disabled by the session parameter CLIENT_TELEMETRY_ENABLED."
+                " Set parameter to true to enable telemetry."
+            )
 
     @property
     def service_name(self) -> str | None:
@@ -777,7 +789,7 @@ class SnowflakeConnection:
 
             # close telemetry first, since it needs rest to send remaining data
             logger.info("closed")
-            self._telemetry.close(send_on_close=retry)
+            self._telemetry.close(send_on_close=bool(retry and self.telemetry_enabled))
             if (
                 self._all_async_queries_finished()
                 and not self._server_session_keep_alive
@@ -1717,7 +1729,7 @@ class SnowflakeConnection:
         for name, value in parameters.items():
             self._session_parameters[name] = value
             if PARAMETER_CLIENT_TELEMETRY_ENABLED == name:
-                self.telemetry_enabled = value
+                self._server_param_telemetry_enabled = value
             elif PARAMETER_CLIENT_TELEMETRY_OOB_ENABLED == name:
                 if value:
                     TelemetryService.get_instance().enable()

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -641,7 +641,7 @@ class SnowflakeConnection:
         ):
             logger.info(
                 "Telemetry has been disabled by the session parameter CLIENT_TELEMETRY_ENABLED."
-                " Set parameter to true to enable telemetry."
+                " Set session parameter CLIENT_TELEMETRY_ENABLED to true to enable telemetry."
             )
 
     @property


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1570328

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

there are two issues:

- disabling telemetry by property `connection.telemetry_enabled=False` doesn't work on client because every time cursor finishes executing sql, it will update local session parameters, overwriting the values set by client.
- connection tries to flush telemetry regardless of whether telemetry is disabled

this PR 
- decouples client and server telemetry setting, so that if user disable the telemetry expliclity, we will not send
- do not send telemetry when closing the connection if telemetry is disabled

4. (Optional) PR for stored-proc connector:
