### PR TITLE
Refactor default config location resolution to use pathlib instead of os

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.12.1(TBD)
   - Fixed a bug that session token is logged when renewing session.
+  - Fixed default config location resolution on Windows OS
 
 - v3.12.0(July 24,2024)
   - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,7 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.12.1(TBD)
   - Fixed a bug that session token is logged when renewing session.
-  - Fixed default config location resolution on Windows OS
+  - Use `pathlib` instead of `os` for default config file location resolution
 
 - v3.12.0(July 24,2024)
   - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.

--- a/src/snowflake/connector/sf_dirs.py
+++ b/src/snowflake/connector/sf_dirs.py
@@ -31,12 +31,12 @@ def _resolve_platform_dirs() -> PlatformDirsProto:
         "appname": "snowflake",
         "appauthor": False,
     }
-    snowflake_home = os.path.expanduser(
+    snowflake_home = pathlib.Path(
         os.environ.get("SNOWFLAKE_HOME", "~/.snowflake/"),
-    )
-    if os.path.exists(snowflake_home):
+    ).expanduser()
+    if snowflake_home.exists():
         return SFPlatformDirs(
-            snowflake_home,
+            str(snowflake_home),
             **platformdir_kwargs,
         )
     else:

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -522,9 +522,10 @@ def test_sf_dirs(tmp_path, version):
 
 
 def test_config_file_resolution_sfdirs_default():
-    default_loc = os.path.expanduser("~/.snowflake")
-    existed_before = os.path.exists(default_loc)
-    os.makedirs(default_loc, exist_ok=True)
+    from pathlib import Path
+    default_loc = Path("~/.snowflake").expanduser()
+    existed_before = default_loc.exists()
+    default_loc.mkdir(exist_ok=True)
     try:
         assert isinstance(_resolve_platform_dirs(), SFPlatformDirs)
     finally:

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -523,6 +523,7 @@ def test_sf_dirs(tmp_path, version):
 
 def test_config_file_resolution_sfdirs_default():
     from pathlib import Path
+
     default_loc = Path("~/.snowflake").expanduser()
     existed_before = default_loc.exists()
     default_loc.mkdir(exist_ok=True)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [#2018](https://github.com/snowflakedb/snowflake-connector-python/issues/2018)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use `pathlib` instead of `os` to resolve default config file paths 

4. (Optional) PR for stored-proc connector:
