### PR TITLE
SNOW-1613751 remove reference to script `snowflake-export-certs`

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug that disabling client telemetry does not work.
   - Use `pathlib` instead of `os` for default config file location resolution.
   - Removed upper `cryptogaphy` version pin.
+  - Removed reference to script `snowflake-export-certs` (its backing module was already removed long ago)
 
 - v3.12.0(July 24,2024)
   - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,6 @@ console_scripts =
     snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
     snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
     snowflake-dump-certs = snowflake.connector.tool.dump_certs:main
-    snowflake-export-certs = snowflake.connector.tool.export_certs:main
 
 [options.extras_require]
 development =


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   It's for https://github.com/snowflakedb/snowflake-connector-python/issues/2015

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `snowflake-export-certs` script is still referenced in `setup.cfg`, despite its backing module was removed ~6 years ago already in https://github.com/snowflakedb/snowflake-connector-python/pull/138 (commit https://github.com/snowflakedb/snowflake-connector-python/commit/061f20d6da0f8a294e6b77e106e1ecedd456985f, released with PythonConnector 1.7.2). This PR removes the reference to the script.
