### PR TITLE
SNOW-1562604: enhance error handling when polling query result

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Use `pathlib` instead of `os` for default config file location resolution.
   - Removed upper `cryptogaphy` version pin.
   - Removed reference to script `snowflake-export-certs` (its backing module was already removed long ago)
+  - Enhanced retry mechanism for handling transient network failures during query result polling when no server response is received.
 
 - v3.12.0(July 24,2024)
   - Set default connection timeout of 10 seconds and socket read timeout of 10 minutes for HTTP calls in file transfer.

--- a/test/integ/test_network.py
+++ b/test/integ/test_network.py
@@ -5,10 +5,19 @@
 
 from __future__ import annotations
 
+import logging
+import unittest.mock
 from logging import getLogger
 
+import pytest
+
+import snowflake.connector
 from snowflake.connector import errorcode, errors
-from snowflake.connector.network import SnowflakeRestful
+from snowflake.connector.network import (
+    QUERY_IN_PROGRESS_ASYNC_CODE,
+    QUERY_IN_PROGRESS_CODE,
+    SnowflakeRestful,
+)
 
 logger = getLogger(__name__)
 
@@ -36,3 +45,55 @@ def test_no_auth(db_parameters):
         assert e.errno == errorcode.ER_CONNECTION_IS_CLOSED
     finally:
         rest.close()
+
+
+@pytest.mark.parametrize(
+    "query_return_code", [QUERY_IN_PROGRESS_CODE, QUERY_IN_PROGRESS_ASYNC_CODE]
+)
+def test_none_object_when_querying_result(db_parameters, caplog, query_return_code):
+    # this test simulate the case where the response from the server is None
+    # the following events happen in sequence:
+    # 1. we send a simple query to the server which is a post request
+    # 2. we record the query result in a global variable
+    # 3. we mock return a query in progress code and an url to fetch the query result
+    # 4. we return None for the fetching query result request for the first time
+    # 5. for the second time, we return the code for the query result
+    # 6. in the end, we assert the result, and retry has taken place when result is None by checking logging
+
+    original_request_exec = SnowflakeRestful._request_exec
+    expected_ret = None
+    get_executed_time = 0
+
+    def side_effect_request_exec(self, *args, **kwargs):
+        nonlocal expected_ret, get_executed_time
+        # 1. we send a simple query to the server which is a post request
+        if "queries/v1/query-request" in kwargs["full_url"]:
+            ret = original_request_exec(self, *args, **kwargs)
+            expected_ret = ret  # 2. we record the query result in a global variable
+            # 3. we mock return a query in progress code and an url to fetch the query result
+            return {
+                "code": query_return_code,
+                "data": {"getResultUrl": "/queries/123/result"},
+            }
+
+        if "/queries/123/result" in kwargs["full_url"]:
+            if get_executed_time == 0:
+                # 4. we return None for the 1st time fetching query result request, this should trigger retry
+                get_executed_time += 1
+                return None
+            else:
+                # 5. for the second time, we return the code for the query result, this indicates retry success
+                return expected_ret
+
+    with snowflake.connector.connect(
+        **db_parameters
+    ) as conn, conn.cursor() as cursor, caplog.at_level(logging.INFO):
+        with unittest.mock.patch.object(
+            SnowflakeRestful, "_request_exec", new=side_effect_request_exec
+        ):
+            # 6. in the end, we assert the result, and retry has taken place when result is None by checking logging
+            assert cursor.execute("select 1").fetchone() == (1,)
+            assert (
+                "fetch query status failed and http request returned None, this is usually caused by transient network failures, retrying"
+                in caplog.text
+            )

--- a/test/integ/test_network.py
+++ b/test/integ/test_network.py
@@ -47,6 +47,7 @@ def test_no_auth(db_parameters):
         rest.close()
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize(
     "query_return_code", [QUERY_IN_PROGRESS_CODE, QUERY_IN_PROGRESS_ASYNC_CODE]
 )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1562604

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

add retry when polling query result and the response is None.
this happens when there is a 499 error happening between client and server.
without the fix, the client stopped retrying and errored out.
with the fix, we will keep retrying

4. (Optional) PR for stored-proc connector:
