### PR TITLE
SNOW-1650640 changed OCSP fail-open warning message loglevel to warning (from error)

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.12.2 (TBD)
   - Improved implementation of `snowflake.connector.util_text.random_string` to avoid collisions.
   - If the account specifies a region, and that region is in China, the TLD is now inferred to be snowflakecomputing.cn.
+  - Changed loglevel to WARNING for OCSP fail-open warning messages (was: ERROR)
 
 - v3.12.1(August 20,2024)
   - Fixed a bug that logged the session token when renewing a session.

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -1076,7 +1076,7 @@ class SnowflakeOCSP:
             "responder. Details:"
         )
         ocsp_warning = f"{static_warning} \n {ocsp_log}"
-        logger.error(ocsp_warning)
+        logger.warning(ocsp_warning)
 
     def validate_by_direct_connection(
         self,


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Relevant to https://github.com/snowflakedb/snowflake-connector-python/issues/2044

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Default behaviour for OCSP is Fail-Open when we cannot do a proper OCSP check; the driver continues to connect to Snowflake while logging a message which is intended to be warning (since the connection still happens). The verbiage of the warning text is clearly reflecting the intention of it being warning - however, we log this warning line at `ERROR` loglevel instead of `WARNING`, which apparently causes unnecessary log cluttering in certain scenarios. 
   This small PR aims to change the loglevel for the OCSP Fail-Open message to match the actual verbiage and severity of the event: `WARNING`

4. (Optional) PR for stored-proc connector:
