### PR TITLE
[SNOW-1669128]: Ensure SnowflakeConnection atexit function is registered on import

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 
+- v3.12.3(DATE TBD)
+  - Ensure `snowflake.connector.SnowflakeConnection`'s `atexit` function is registered on import.
+
 - v3.12.2(September 11,2024)
   - Improved error handling for asynchronous queries, providing more detailed and informative error messages when an async query fails.
   - Improved inference of top-level domains for accounts specifying a region in China, now defaulting to snowflakecomputing.cn.


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1669128

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Previously, the close_at_exit function for the SnowflakeConnection object
was registered with the `atexit` module during initialization of a SnowflakeConnection object.
This caused the Snowpark Session object's atexit function to be registered before the
SnowflakeConnection's object when the Session was made without an existing SnowflakeConnection
object, because the SnowflakeConnection object's atexit was only registered after it was initialized
whereas the Snowpark Session object's atexit was registered when the file was imported. During the
atexit for the Snowpark Session, it attempts to send telemetry regarding cleanup operations, but since
it's connection is already closed, it fails to send the telemetry. Moving the registration of the atexit
function here means that it will happen when the SnowflakeConnection object is imported - and so the
Snowpark Session's atexit function will be registered after, and the order will be correct.

4. (Optional) PR for stored-proc connector:
