### PR TITLE
delete workarround for pyton2.7

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 - v3.13.3(TBD)
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.
+  - Removed the workaround for a Python 2.7 bug.
 
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -23,7 +23,6 @@ from functools import partial
 from io import StringIO
 from logging import getLogger
 from threading import Lock
-from time import strptime
 from types import TracebackType
 from typing import Any, Callable, Generator, Iterable, Iterator, NamedTuple, Sequence
 from uuid import UUID
@@ -311,9 +310,6 @@ APPLICATION_RE = re.compile(r"[\w\d_]+")
 # adding the exception class to Connection class
 for m in [method for method in dir(errors) if callable(getattr(errors, method))]:
     setattr(sys.modules[__name__], m, getattr(errors, m))
-
-# Workaround for https://bugs.python.org/issue7980
-strptime("20150102030405", "%Y%m%d%H%M%S")
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
This workarround is only for unsoportted python 2.7

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Delete the old workarround. as documented on https://bugs.python.org/issue7980 is only for python2.7

4. (Optional) PR for stored-proc connector:
