### PR TITLE
SNOW-1868288 log level to debug in chunk rowcount logging

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,7 +11,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.12.5(TBD)
   - Added a feature to limit the sizes of IO-bound ThreadPoolExecutors during PUT and GET commands.
   - Adding support for the new PAT authentication method.
- - Updated README.md to include instructions on how to verify package signatures using `cosign`.
+  - Updated README.md to include instructions on how to verify package signatures using `cosign`.
+  - Updated the log level for cursor's chunk rowcount from INFO to DEBUG
 
 - v3.12.4(December 3,2024)
   - Fixed a bug where multipart uploads to Azure would be missing their MD5 hashes.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1164,7 +1164,7 @@ class SnowflakeCursor:
         )
 
         if not (is_dml or self.is_file_transfer):
-            logger.info(
+            logger.debug(
                 "Number of results in first chunk: %s", result_chunks[0].rowcount
             )
 

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -154,6 +154,7 @@ def _type_from_description(named_access: bool):
 
 @pytest.mark.skipolddriver
 def test_insert_select(conn, db_parameters, caplog):
+    caplog.set_level(logging.DEBUG)
     """Inserts and selects integer data."""
     with conn() as cnx:
         c = cnx.cursor()
@@ -198,6 +199,7 @@ def test_insert_select(conn, db_parameters, caplog):
 
 @pytest.mark.skipolddriver
 def test_insert_and_select_by_separate_connection(conn, db_parameters, caplog):
+    caplog.set_level(logging.DEBUG)
     """Inserts a record and select it by a separate connection."""
     with conn() as cnx:
         result = cnx.cursor().execute(
@@ -933,6 +935,7 @@ def test_fetchmany(conn, db_parameters, caplog):
             assert c.rowcount == 6, "number of records"
 
         with cnx.cursor() as c:
+            caplog.set_level(logging.DEBUG)
             c.execute(f"select aa from {table_name} order by aa desc")
             assert "Number of results in first chunk: 6" in caplog.text
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1868288

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Apparently for some workflows (https://github.com/snowflakedb/snowflake-connector-python/issues/2126), the INFO level of current logging is excessive. Aiming to set it to DEBUG - if needed for troubleshooting, one usually uses verbose loglevels anyways.

4. (Optional) PR for stored-proc connector:
