### PR TITLE
pin qemu used for arm64 linux wheels 

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -93,6 +93,9 @@ jobs:
         if: ${{ matrix.os.id == 'manylinux_aarch64' }}
         uses: docker/setup-qemu-action@v2
         with:
+          # xref https://github.com/docker/setup-qemu-action/issues/188
+          # xref https://github.com/tonistiigi/binfmt/issues/215
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: all
       - uses: actions/checkout@v4
       - name: Building wheel


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   QEMU assisted Linux Arm64 wheel compilation is having a hard time since Friday. In this PR I pin it back to an old version which seems to be working. Please see https://github.com/tonistiigi/binfmt/issues/215 for more information!
4. (Optional) PR for stored-proc connector:
