### PR TITLE
SNOW-1891253 bump pyopenssl upper boundary to <26.0.0 from <25.0.0

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,6 +7,9 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
+- v3.13.3(TBD)
+  - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.
+
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     asn1crypto>0.24.0,<2.0.0
     cffi>=1.9,<2.0.0
     cryptography>=3.1.0
-    pyOpenSSL>=22.0.0,<25.0.0
+    pyOpenSSL>=22.0.0,<26.0.0
     pyjwt<3.0.0
     pytz
     requests<3.0.0


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1891253

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   From the linked issue https://github.com/snowflakedb/snowflake-connector-python/issues/2140 it looks like we're now incompatible with other tools, which require pyopenssl 25.0.0. Checking the CHANGELOG over there, there's no claim for backward-incompatible changes, so bumping the requirement upper boundary. 

4. (Optional) PR for stored-proc connector:
