### PR TITLE
SNOW-1886670 pin pyarrow

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.13.3(TBD)
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.
   - Removed the workaround for a Python 2.7 bug.
+  - Added a <19.0.0 pin to pyarrow as a workaround to a bug affecting Azure Batch.
 
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,6 @@ development =
     pytzdata
 pandas =
     pandas>=1.0.0,<3.0.0
-    pyarrow
+    pyarrow<19.0.0
 secure-local-storage =
     keyring>=23.1.0,<26.0.0


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1886670

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We are seeing a strange bug on Azure Batch where `pyarrow==19.0.0` is causing our nanoarrow implementation to not work. While we are investigating this issue I'm going to introduce a version pin to not allow users to break.
   This should be a short-term workaround only and the pin should not sick around for long!

4. (Optional) PR for stored-proc connector:
