### PR TITLE
SNOW-1915469 Basic support for DECFLOAT type

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - v3.14.1(TBD)
+  - Basic decimal floating-point type support.
 
 - v3.14.0(March 03, 2025)
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ if _ABLE_TO_COMPILE_EXTENSIONS and not SNOWFLAKE_DISABLE_COMPILE_ARROW_EXTENSION
                         "CArrowIterator.cpp",
                         "CArrowTableIterator.cpp",
                         "DateConverter.cpp",
+                        "DecFloatConverter.cpp",
                         "DecimalConverter.cpp",
                         "FixedSizeListConverter.cpp",
                         "FloatConverter.cpp",

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -159,3 +159,11 @@ class ArrowConverterContext:
         digits = [int(digit) for digit in str(int128) if digit != "-"]
         sign = int128 < 0
         return decimal.Decimal((sign, digits, -scale))
+
+    def DECFLOAT_to_decimal(self, exponent: int, significand: bytes) -> decimal.Decimal:
+        # significand is two's complement big endian.
+        significand = int.from_bytes(significand, byteorder="big", signed=True)
+        return decimal.Decimal(significand).scaleb(exponent)
+
+    def DECFLOAT_to_numpy_float64(self, exponent: int, significand: bytes) -> float64:
+        return numpy.float64(self.DECFLOAT_to_decimal(exponent, significand))

--- a/src/snowflake/connector/converter.py
+++ b/src/snowflake/connector/converter.py
@@ -203,6 +203,12 @@ class SnowflakeConverter:
 
             return conv
 
+    def _DECFLOAT_numpy_to_python(self, ctx: dict[str, Any]) -> Callable:
+        return numpy.float64
+
+    def _DECFLOAT_to_python(self, ctx: dict[str, Any]) -> Callable:
+        return decimal.Decimal
+
     def _REAL_to_python(self, _: dict[str, str | None] | dict[str, str]) -> Callable:
         return float
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp
@@ -12,6 +12,7 @@
 #include "BinaryConverter.hpp"
 #include "BooleanConverter.hpp"
 #include "DateConverter.hpp"
+#include "DecFloatConverter.hpp"
 #include "DecimalConverter.hpp"
 #include "FixedSizeListConverter.hpp"
 #include "FloatConverter.hpp"
@@ -468,6 +469,12 @@ std::shared_ptr<sf::IColumnConverter> getConverterFromSchema(
 
     case SnowflakeType::Type::VECTOR: {
       converter = std::make_shared<sf::FixedSizeListConverter>(array);
+      break;
+    }
+
+    case SnowflakeType::Type::DECFLOAT: {
+      converter = std::make_shared<sf::DecFloatConverter>(*array, schemaView,
+                                                          *context, useNumpy);
       break;
     }
 

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/DecFloatConverter.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/DecFloatConverter.cpp
@@ -1,0 +1,87 @@
+
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#include "DecFloatConverter.hpp"
+
+#include <cstring>
+#include <memory>
+
+#include "Python/Helpers.hpp"
+
+namespace sf {
+
+Logger* DecFloatConverter::logger =
+    new Logger("snowflake.connector.DecFloatConverter");
+
+const std::string DecFloatConverter::FIELD_NAME_EXPONENT = "exponent";
+const std::string DecFloatConverter::FIELD_NAME_SIGNIFICAND = "significand";
+
+DecFloatConverter::DecFloatConverter(ArrowArrayView& array,
+                                     ArrowSchemaView& schema, PyObject& context,
+                                     bool useNumpy)
+    : m_context(context),
+      m_array(array),
+      m_exponent(nullptr),
+      m_significand(nullptr),
+      m_useNumpy(useNumpy) {
+  if (schema.schema->n_children != 2) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] arrow schema field number does not match, "
+        "expected 2 but got %d instead",
+        schema.schema->n_children);
+    logger->error(__FILE__, __func__, __LINE__, errorInfo.c_str());
+    PyErr_SetString(PyExc_Exception, errorInfo.c_str());
+    return;
+  }
+  for (int i = 0; i < schema.schema->n_children; i += 1) {
+    ArrowSchema* c_schema = schema.schema->children[i];
+    if (std::strcmp(c_schema->name,
+                    DecFloatConverter::FIELD_NAME_EXPONENT.c_str()) == 0) {
+      m_exponent = m_array.children[i];
+    } else if (std::strcmp(c_schema->name,
+                           DecFloatConverter::FIELD_NAME_SIGNIFICAND.c_str()) ==
+               0) {
+      m_significand = m_array.children[i];
+    }
+  }
+  if (!m_exponent || !m_significand) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] arrow schema field names do not match, "
+        "expected %s and %s, but got %s and %s instead",
+        DecFloatConverter::FIELD_NAME_EXPONENT.c_str(),
+        DecFloatConverter::FIELD_NAME_SIGNIFICAND.c_str(),
+        schema.schema->children[0]->name, schema.schema->children[1]->name);
+    logger->error(__FILE__, __func__, __LINE__, errorInfo.c_str());
+    PyErr_SetString(PyExc_Exception, errorInfo.c_str());
+    return;
+  }
+}
+
+PyObject* DecFloatConverter::toPyObject(int64_t rowIndex) const {
+  if (ArrowArrayViewIsNull(&m_array, rowIndex)) {
+    Py_RETURN_NONE;
+  }
+  int64_t exponent = ArrowArrayViewGetIntUnsafe(m_exponent, rowIndex);
+  ArrowStringView stringView =
+      ArrowArrayViewGetStringUnsafe(m_significand, rowIndex);
+  if (stringView.size_bytes > 16) {
+    std::string errorInfo = Logger::formatString(
+        "[Snowflake Exception] only precisions up to 38 supported. "
+        "Please update to a newer version of the connector.");
+    logger->error(__FILE__, __func__, __LINE__, errorInfo.c_str());
+    PyErr_SetString(PyExc_Exception, errorInfo.c_str());
+    return nullptr;
+  }
+  PyObject* significand =
+      PyBytes_FromStringAndSize(stringView.data, stringView.size_bytes);
+
+  PyObject* result = PyObject_CallMethod(
+      &m_context,
+      m_useNumpy ? "DECFLOAT_to_numpy_float64" : "DECFLOAT_to_decimal", "iS",
+      exponent, significand);
+  Py_XDECREF(significand);
+  return result;
+}
+}  // namespace sf

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/DecFloatConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/DecFloatConverter.hpp
@@ -1,0 +1,39 @@
+
+//
+// Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+//
+
+#ifndef PC_DECFLOATCONVERTER_HPP
+#define PC_DECFLOATCONVERTER_HPP
+
+#include <memory>
+
+#include "IColumnConverter.hpp"
+#include "logging.hpp"
+#include "nanoarrow.h"
+
+namespace sf {
+
+class DecFloatConverter : public IColumnConverter {
+ public:
+  const static std::string FIELD_NAME_EXPONENT;
+  const static std::string FIELD_NAME_SIGNIFICAND;
+
+  explicit DecFloatConverter(ArrowArrayView& array, ArrowSchemaView& schema,
+                             PyObject& context, bool useNumpy);
+
+  PyObject* toPyObject(int64_t rowIndex) const override;
+
+ private:
+  PyObject& m_context;
+  ArrowArrayView& m_array;
+  ArrowArrayView* m_exponent;
+  ArrowArrayView* m_significand;
+  bool m_useNumpy;
+
+  static Logger* logger;
+};
+
+}  // namespace sf
+
+#endif  // PC_DECFLOATCONVERTER_HPP

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.cpp
@@ -17,6 +17,7 @@ std::unordered_map<std::string, SnowflakeType::Type>
         {"DOUBLE PRECISION", SnowflakeType::Type::REAL},
         {"DOUBLE", SnowflakeType::Type::REAL},
         {"FIXED", SnowflakeType::Type::FIXED},
+        {"DECFLOAT", SnowflakeType::Type::DECFLOAT},
         {"FLOAT", SnowflakeType::Type::REAL},
         {"MAP", SnowflakeType::Type::MAP},
         {"OBJECT", SnowflakeType::Type::OBJECT},

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/SnowflakeType.hpp
@@ -33,6 +33,7 @@ class SnowflakeType {
     VARIANT = 15,
     VECTOR = 16,
     MAP = 17,
+    DECFLOAT = 18,
   };
 
   static SnowflakeType::Type snowflakeTypeFromString(std::string str) {

--- a/test/integ/test_decfloat.py
+++ b/test/integ/test_decfloat.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import decimal
+from decimal import Decimal
+
+import numpy
+
+import snowflake.connector
+
+
+def test_decfloat_bindings(conn_cnx):
+    # set required decimal precision
+    decimal.getcontext().prec = 38
+    original_style = snowflake.connector.paramstyle
+    snowflake.connector.paramstyle = "qmark"
+    try:
+        with conn_cnx() as cnx:
+            # test decfloat bindings
+            ret = (
+                cnx.cursor()
+                .execute("select ?", [("DECFLOAT", Decimal("-1234e4000"))])
+                .fetchone()
+            )
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("-1234e4000")
+            ret = cnx.cursor().execute("select ?", [("DECFLOAT", -1e3)]).fetchone()
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("-1e3")
+            # test 38 digits
+            ret = (
+                cnx.cursor()
+                .execute(
+                    "select ?",
+                    [("DECFLOAT", Decimal("12345678901234567890123456789012345678"))],
+                )
+                .fetchone()
+            )
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("12345678901234567890123456789012345678")
+            # test w/o explicit type specification
+            ret = cnx.cursor().execute("select ?", [-1e3]).fetchone()
+            assert isinstance(ret[0], float)
+            ret = cnx.cursor().execute("select ?", [Decimal("-1e3")]).fetchone()
+            assert isinstance(ret[0], int)
+    finally:
+        snowflake.connector.paramstyle = original_style
+
+
+def test_decfloat_from_compiler(conn_cnx):
+    # set required decimal precision
+    decimal.getcontext().prec = 38
+    # test both result formats
+    for fmt in ["json", "arrow"]:
+        with conn_cnx(
+            session_parameters={
+                "PYTHON_CONNECTOR_QUERY_RESULT_FORMAT": fmt,
+                "use_cached_result": "false",
+            }
+        ) as cnx:
+            # test endianess
+            ret = cnx.cursor().execute("SELECT 555::decfloat").fetchone()
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("555")
+            # test with decimal separator
+            ret = cnx.cursor().execute("SELECT 123456789.12345678::decfloat").fetchone()
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("123456789.12345678")
+            # test 38 digits
+            ret = (
+                cnx.cursor()
+                .execute("SELECT '12345678901234567890123456789012345678'::decfloat")
+                .fetchone()
+            )
+            assert isinstance(ret[0], Decimal)
+            assert ret[0] == Decimal("12345678901234567890123456789012345678")
+    # test numpy
+    with conn_cnx(numpy=True) as cnx:
+        ret = (
+            cnx.cursor()
+            .execute(
+                "SELECT 1.234::decfloat",
+                None,
+            )
+            .fetchone()
+        )
+        assert isinstance(ret[0], numpy.float64)
+        assert ret[0] == numpy.float64("1.234")

--- a/test/unit/test_converter.py
+++ b/test/unit/test_converter.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from logging import getLogger
 
 import pytest
@@ -13,6 +14,7 @@ from snowflake.connector import ProgrammingError
 from snowflake.connector.connection import DefaultConverterClass
 from snowflake.connector.converter import SnowflakeConverter
 from snowflake.connector.converter_snowsql import SnowflakeConverterSnowSQL
+from src.snowflake.connector.arrow_context import ArrowConverterContext
 
 logger = getLogger(__name__)
 
@@ -79,6 +81,12 @@ def test_converter_to_snowflake_error():
         ProgrammingError, match=r"Binding data in type \(bogus\) is not supported"
     ):
         converter._bogus_to_snowflake("Bogus")
+
+
+def test_decfloat_to_decimal_converter():
+    ctx = ArrowConverterContext()
+    decimal = ctx.DECFLOAT_to_decimal(42, bytes.fromhex("11AA"))
+    assert decimal == Decimal("4522e42")
 
 
 def test_converter_to_snowflake_bindings_error():


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Implements [SNOW-1915469](https://snowflakecomputing.atlassian.net/browse/SNOW-1915469)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR adds basic decimal float (DECFLOAT) data type support to the python connector.
- Supports ARROW and JSON result format. DECFLOATs are converted to Decimal or numpy.float64
- Server-side binding support using explicit Snowflake type specification as Decimal is already mapped to FIXED by default
- No Pandas support

4. (Optional) PR for stored-proc connector:


[SNOW-1915469]: https://snowflakecomputing.atlassian.net/browse/SNOW-1915469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ