### PR TITLE
SNOW-1920533 match privatelink in hostname to setup correct privatelink OCSP Cache url even if user specifies account in UPPERCASE

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.
   - Removed the workaround for a Python 2.7 bug.
   - Added a <19.0.0 pin to pyarrow as a workaround to a bug affecting Azure Batch.
+  - Fixed a bug where privatelink OCSP Cache url could not be determined if privatelink account name was specified in uppercase
 
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -957,8 +957,10 @@ class SnowflakeConnection:
                 os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"],
             )
 
-        if ".privatelink.snowflakecomputing." in self.host:
-            SnowflakeConnection.setup_ocsp_privatelink(self.application, self.host)
+        if ".privatelink.snowflakecomputing." in self.host.lower():
+            SnowflakeConnection.setup_ocsp_privatelink(
+                self.application, self.host.lower()
+            )
         else:
             if "SF_OCSP_RESPONSE_CACHE_SERVER_URL" in os.environ:
                 del os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"]

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -926,6 +926,7 @@ class SnowflakeConnection:
 
     @staticmethod
     def setup_ocsp_privatelink(app, hostname) -> None:
+        hostname = hostname.lower()
         SnowflakeConnection.OCSP_ENV_LOCK.acquire()
         ocsp_cache_server = f"http://ocsp.{hostname}/ocsp_response_cache.json"
         os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"] = ocsp_cache_server
@@ -958,9 +959,7 @@ class SnowflakeConnection:
             )
 
         if ".privatelink.snowflakecomputing." in self.host.lower():
-            SnowflakeConnection.setup_ocsp_privatelink(
-                self.application, self.host.lower()
-            )
+            SnowflakeConnection.setup_ocsp_privatelink(self.application, self.host)
         else:
             if "SF_OCSP_RESPONSE_CACHE_SERVER_URL" in os.environ:
                 del os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"]

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -671,6 +671,17 @@ def test_privatelink_ocsp_url_creation():
         == "http://ocsp.testaccount.us-east-1.privatelink.snowflakecomputing.com/ocsp_response_cache.json"
     )
 
+    del os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"]
+
+    account = "TESTACCOUNT.US-EAST-1.PRIVATELINK"
+    hostname = account + ".snowflakecomputing.com"
+    SnowflakeConnection.setup_ocsp_privatelink(CLIENT_NAME, hostname)
+    ocsp_cache_server = os.getenv("SF_OCSP_RESPONSE_CACHE_SERVER_URL", None)
+    assert (
+        ocsp_cache_server
+        == "http://ocsp.testaccount.us-east-1.privatelink.snowflakecomputing.com/ocsp_response_cache.json"
+    )
+
 
 def test_privatelink_ocsp_url_multithreaded():
     bucket = queue.Queue()

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -671,10 +671,12 @@ def test_privatelink_ocsp_url_creation():
         == "http://ocsp.testaccount.us-east-1.privatelink.snowflakecomputing.com/ocsp_response_cache.json"
     )
 
-    del os.environ["SF_OCSP_RESPONSE_CACHE_SERVER_URL"]
 
+@pytest.mark.skipolddriver
+def test_uppercase_privatelink_ocsp_url_creation():
     account = "TESTACCOUNT.US-EAST-1.PRIVATELINK"
     hostname = account + ".snowflakecomputing.com"
+
     SnowflakeConnection.setup_ocsp_privatelink(CLIENT_NAME, hostname)
     ocsp_cache_server = os.getenv("SF_OCSP_RESPONSE_CACHE_SERVER_URL", None)
     assert (


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1920533

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Public link OCSP Cache server url is `ocsp.snowflakecomputing.com` but in privatelink environment it works differently, and should look like `ocsp.accountname.region.privatelink.snowflakcomputing.com`. This hostname for OCSP Cache is determined based on the connection configuration (account/host). 
   Since earlier we were looking for pattern `.privatelink.snowflakecomputing.` to be present in account/host, if user specified account as `MYACCOUNT.REGION.PRIVATELINK`, it resulted host becoming partly uppercase and thus not matching the above pattern.
   
   Fix aims to lowercase the hostname before trying to match it to privatelink pattern. Added  test with uppercased account/hostname.

4. (Optional) PR for stored-proc connector:
