### PR TITLE
NO SNOW update year in license header

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.
   - Removed the workaround for a Python 2.7 bug.
   - Added a <19.0.0 pin to pyarrow as a workaround to a bug affecting Azure Batch.
+  - Updated license header year to 2025
 
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,3 +1,3 @@
 
-Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 


### PR DESCRIPTION
License header is being added to newly created files with a git hook. The present year in header was 2023.