### PR TITLE
SNOW-1944208 add unsafe write flag

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,8 +16,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for iceberg tables to `write_pandas`.
   - Fixed base64 encoded private key tests.
   - Added Wiremock tests.
-  - Fixed a bug where file permission check happened on Windows
+  - Fixed a bug where file permission check happened on Windows.
   - Added support for File types.
+  - Added `unsafe_file_write` connection parameter that restores the previous behaviour of saving files downloaded with GET with 644 permissions.
 
 - v3.13.2(January 29, 2025)
   - Changed not to use scoped temporary objects.

--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -65,8 +65,15 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
         chunk_size: int,
         stage_info: dict[str, Any],
         use_s3_regional_url: bool = False,
+        unsafe_file_write: bool = False,
     ) -> None:
-        super().__init__(meta, stage_info, chunk_size, credentials=credentials)
+        super().__init__(
+            meta,
+            stage_info,
+            chunk_size,
+            credentials=credentials,
+            unsafe_file_write=unsafe_file_write,
+        )
         end_point: str = stage_info["endPoint"]
         if end_point.startswith("blob."):
             end_point = end_point[len("blob.") :]

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -379,6 +379,7 @@ class SnowflakeConnection:
         server_session_keep_alive: When true, the connector does not destroy the session on the Snowflake server side
           before the connector shuts down. Default value is false.
         token_file_path: The file path of the token file. If both token and token_file_path are provided, the token in token_file_path will be used.
+        unsafe_file_write: When true, files downloaded by GET will be saved with 644 permissions. Otherwise, files will be saved with safe - owner-only permissions: 600.
     """
 
     OCSP_ENV_LOCK = Lock()
@@ -735,6 +736,14 @@ class SnowflakeConnection:
     @property
     def iobound_tpe_limit(self) -> int | None:
         return self._iobound_tpe_limit
+
+    @property
+    def unsafe_file_write(self) -> bool:
+        return self._unsafe_file_write
+
+    @unsafe_file_write.setter
+    def unsafe_file_write(self, value: bool) -> None:
+        self._unsafe_file_write = value
 
     def connect(self, **kwargs) -> None:
         """Establishes connection to Snowflake."""

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1216,6 +1216,11 @@ class SnowflakeConnection:
             if "protocol" not in kwargs:
                 self._protocol = "https"
 
+        if "unsafe_file_write" in kwargs:
+            self._unsafe_file_write = kwargs["unsafe_file_write"]
+        else:
+            self._unsafe_file_write = False
+
         logger.info(
             f"Connecting to {_DOMAIN_NAME_MAP.get(extract_top_level_domain_from_hostname(self._host), 'GLOBAL')} Snowflake domain"
         )

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1060,6 +1060,7 @@ class SnowflakeCursor:
                     multipart_threshold=data.get("threshold"),
                     use_s3_regional_url=self._connection.enable_stage_s3_privatelink_for_us_east_1,
                     iobound_tpe_limit=self._connection.iobound_tpe_limit,
+                    unsafe_file_write=self._connection.unsafe_file_write,
                 )
                 sf_file_transfer_agent.execute()
                 data = sf_file_transfer_agent.result()

--- a/src/snowflake/connector/encryption_util.py
+++ b/src/snowflake/connector/encryption_util.py
@@ -195,6 +195,7 @@ class SnowflakeEncryptionUtil:
         in_filename: str,
         chunk_size: int = 64 * kilobyte,
         tmp_dir: str | None = None,
+        unsafe_file_write: bool = False,
     ) -> str:
         """Decrypts a file and stores the output in the temporary directory.
 
@@ -213,8 +214,10 @@ class SnowflakeEncryptionUtil:
             temp_output_file = os.path.join(tmp_dir, temp_output_file)
 
         logger.debug("encrypted file: %s, tmp file: %s", in_filename, temp_output_file)
+
+        file_opener = None if unsafe_file_write else owner_rw_opener
         with open(in_filename, "rb") as infile:
-            with open(temp_output_file, "wb", opener=owner_rw_opener) as outfile:
+            with open(temp_output_file, "wb", opener=file_opener) as outfile:
                 SnowflakeEncryptionUtil.decrypt_stream(
                     metadata, encryption_material, infile, outfile, chunk_size
                 )

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -355,6 +355,7 @@ class SnowflakeFileTransferAgent:
         source_from_stream: IO[bytes] | None = None,
         use_s3_regional_url: bool = False,
         iobound_tpe_limit: int | None = None,
+        unsafe_file_write: bool = False,
     ) -> None:
         self._cursor = cursor
         self._command = command
@@ -386,6 +387,7 @@ class SnowflakeFileTransferAgent:
         self._use_s3_regional_url = use_s3_regional_url
         self._credentials: StorageCredential | None = None
         self._iobound_tpe_limit = iobound_tpe_limit
+        self._unsafe_file_write = unsafe_file_write
 
     def execute(self) -> None:
         self._parse_command()
@@ -673,6 +675,7 @@ class SnowflakeFileTransferAgent:
                 meta,
                 self._stage_info,
                 4 * megabyte,
+                unsafe_file_write=self._unsafe_file_write,
             )
         elif self._stage_location_type == AZURE_FS:
             return SnowflakeAzureRestClient(
@@ -681,6 +684,7 @@ class SnowflakeFileTransferAgent:
                 AZURE_CHUNK_SIZE,
                 self._stage_info,
                 use_s3_regional_url=self._use_s3_regional_url,
+                unsafe_file_write=self._unsafe_file_write,
             )
         elif self._stage_location_type == S3_FS:
             return SnowflakeS3RestClient(
@@ -690,6 +694,7 @@ class SnowflakeFileTransferAgent:
                 _chunk_size_calculator(meta.src_file_size),
                 use_accelerate_endpoint=self._use_accelerate_endpoint,
                 use_s3_regional_url=self._use_s3_regional_url,
+                unsafe_file_write=self._unsafe_file_write,
             )
         elif self._stage_location_type == GCS_FS:
             return SnowflakeGCSRestClient(
@@ -699,6 +704,7 @@ class SnowflakeFileTransferAgent:
                 self._cursor._connection,
                 self._command,
                 use_s3_regional_url=self._use_s3_regional_url,
+                unsafe_file_write=self._unsafe_file_write,
             )
         raise Exception(f"{self._stage_location_type} is an unknown stage type")
 

--- a/src/snowflake/connector/file_util.py
+++ b/src/snowflake/connector/file_util.py
@@ -8,6 +8,7 @@ import base64
 import gzip
 import os
 import shutil
+import stat
 import struct
 from io import BytesIO
 from logging import getLogger
@@ -22,7 +23,7 @@ logger = getLogger(__name__)
 
 
 def owner_rw_opener(path, flags) -> int:
-    return os.open(path, flags, mode=0o600)
+    return os.open(path, flags, mode=stat.S_IRUSR | stat.S_IWUSR)
 
 
 class SnowflakeFileUtil:

--- a/src/snowflake/connector/file_util.py
+++ b/src/snowflake/connector/file_util.py
@@ -8,7 +8,6 @@ import base64
 import gzip
 import os
 import shutil
-import stat
 import struct
 from io import BytesIO
 from logging import getLogger
@@ -23,7 +22,7 @@ logger = getLogger(__name__)
 
 
 def owner_rw_opener(path, flags) -> int:
-    return os.open(path, flags, mode=stat.S_IRUSR | stat.S_IWUSR)
+    return os.open(path, flags, mode=0o600)
 
 
 class SnowflakeFileUtil:

--- a/src/snowflake/connector/gcs_storage_client.py
+++ b/src/snowflake/connector/gcs_storage_client.py
@@ -54,6 +54,7 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
         cnx: SnowflakeConnection,
         command: str,
         use_s3_regional_url: bool = False,
+        unsafe_file_write: bool = False,
     ) -> None:
         """Creates a client object with given stage credentials.
 
@@ -64,7 +65,12 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
             The client to communicate with GCS.
         """
         super().__init__(
-            meta, stage_info, -1, credentials=credentials, chunked_transfer=False
+            meta,
+            stage_info,
+            -1,
+            credentials=credentials,
+            chunked_transfer=False,
+            unsafe_file_write=unsafe_file_write,
         )
         self.stage_info = stage_info
         self._command = command

--- a/src/snowflake/connector/local_storage_client.py
+++ b/src/snowflake/connector/local_storage_client.py
@@ -26,8 +26,11 @@ class SnowflakeLocalStorageClient(SnowflakeStorageClient):
         meta: SnowflakeFileMeta,
         stage_info: dict[str, Any],
         chunk_size: int,
+        unsafe_file_write: bool = False,
     ) -> None:
-        super().__init__(meta, stage_info, chunk_size)
+        super().__init__(
+            meta, stage_info, chunk_size, unsafe_file_write=unsafe_file_write
+        )
         self.data_file = meta.src_file_name
         self.full_dst_file_name: str = os.path.join(
             stage_info["location"], os.path.basename(meta.dst_file_name)

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -61,13 +61,20 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         chunk_size: int,
         use_accelerate_endpoint: bool | None = None,
         use_s3_regional_url: bool = False,
+        unsafe_file_write: bool = False,
     ) -> None:
         """Rest client for S3 storage.
 
         Args:
             stage_info:
         """
-        super().__init__(meta, stage_info, chunk_size, credentials=credentials)
+        super().__init__(
+            meta,
+            stage_info,
+            chunk_size,
+            credentials=credentials,
+            unsafe_file_write=unsafe_file_write,
+        )
         # Signature version V4
         # Addressing style Virtual Host
         self.region_name: str = stage_info["region"]

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -237,7 +237,7 @@ put file://{test_data.test_data_dir}/ExecPlatform/Database/data/orders_10*.csv @
             cur.execute("drop table pytest_putget_t1")
 
 
-# @pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.skipif(
     not CONNECTION_PARAMETERS_ADMIN, reason="Snowflake admin account is not accessible."
 )

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -756,7 +756,12 @@ def test_get_file_permission(tmp_path, conn_cnx, caplog):
                 cur.execute(f"GET @{stage_name}/data.csv file://{tmp_path}")
             assert "FileNotFoundError" not in caplog.text
 
-            assert oct(os.stat(test_file).st_mode)[-3:] == oct(0o600)[-3:]
+            default_mask = os.umask(0)
+            os.umask(default_mask)
+
+            assert (
+                oct(os.stat(test_file).st_mode)[-3:] == oct(0o600 & ~default_mask)[-3:]
+            )
 
 
 @pytest.mark.skipolddriver

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -785,6 +785,7 @@ def test_get_unsafe_file_permission_when_flag_set(tmp_path, conn_cnx, caplog):
             assert (
                 oct(os.stat(test_file).st_mode)[-3:] == oct(0o666 & ~default_mask)[-3:]
             )
+        cnx.unsafe_file_write = False
 
 
 @pytest.mark.skipolddriver

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -19,7 +19,13 @@ from unittest import mock
 import pytest
 
 from snowflake.connector import OperationalError
-from src.snowflake.connector.compat import IS_WINDOWS
+
+try:
+    from src.snowflake.connector.compat import IS_WINDOWS
+except ImportError:
+    import platform
+
+    IS_WINDOWS = platform.system() == "Windows"
 
 try:
     from snowflake.connector.util_text import random_string

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -19,6 +19,7 @@ from unittest import mock
 import pytest
 
 from snowflake.connector import OperationalError
+from src.snowflake.connector.compat import IS_WINDOWS
 
 try:
     from snowflake.connector.util_text import random_string
@@ -740,6 +741,7 @@ def test_get_empty_file(tmp_path, conn_cnx):
 
 
 @pytest.mark.skipolddriver
+@pytest.mark.skipif(IS_WINDOWS, reason="not supported on Windows")
 def test_get_file_permission(tmp_path, conn_cnx, caplog):
     test_file = tmp_path / "data.csv"
     test_file.write_text("1,2,3\n")
@@ -765,6 +767,7 @@ def test_get_file_permission(tmp_path, conn_cnx, caplog):
 
 
 @pytest.mark.skipolddriver
+@pytest.mark.skipif(IS_WINDOWS, reason="not supported on Windows")
 def test_get_unsafe_file_permission_when_flag_set(tmp_path, conn_cnx, caplog):
     test_file = tmp_path / "data.csv"
     test_file.write_text("1,2,3\n")


### PR DESCRIPTION
This PR adds `unsafe_file_write` flag to connection class. The security patch applied in 3.13.1 has narrowed the permissions of files downloaded with GET to 600. This change seems to be inconvenient for some customers that were relying on the previous behaviour in their workflows so after discussion with the support team we decided to add a flag that restores the previous behaviour of saving files downloaded with GET with 644.

The parameter was added to all cloud interfaces, the default value is False which means the strict permissions will be applied.

The test had to be fixed since due to the compression on PUT the permissions weren't verified on the proper file.