### PR TITLE
SNOW-1927118 Enable wiremock tests on Jenkins

### DIFF
--- a/ci/docker/connector_test/Dockerfile
+++ b/ci/docker/connector_test/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
 FROM $BASE_IMAGE
 
+RUN yum install -y java
+
 # This is to solve permission issue, read https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 ARG GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
 ENV GOSU_PATH $GOSU_URL

--- a/ci/docker/connector_test/Dockerfile
+++ b/ci/docker/connector_test/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
 FROM $BASE_IMAGE
 
-RUN yum install -y java
+RUN yum install -y java-11-openjdk
 
 # This is to solve permission issue, read https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 ARG GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -8,7 +8,7 @@ if [[ -n "$NEXUS_PASSWORD" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     NEXUS_USER=${USERNAME:-jenkins}
     docker login --username "$NEXUS_USER" --password "$NEXUS_PASSWORD" $INTERNAL_REPO
-    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64
+    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64:test_mkubik
     export BASE_IMAGE_MANYLINUX2014AARCH64=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_aarch64
 else
     echo "[INFO] Pull docker images from public registry"

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -8,8 +8,8 @@ if [[ -n "$NEXUS_PASSWORD" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     NEXUS_USER=${USERNAME:-jenkins}
     docker login --username "$NEXUS_USER" --password "$NEXUS_PASSWORD" $INTERNAL_REPO
-    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64:test_mkubik
-    export BASE_IMAGE_MANYLINUX2014AARCH64=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_aarch64
+    export BASE_IMAGE_MANYLINUX2014=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_x86_64:2025.02.12-1
+    export BASE_IMAGE_MANYLINUX2014AARCH64=nexus.int.snowflakecomputing.com:8086/docker/manylinux2014_aarch64:2025.02.12-1
 else
     echo "[INFO] Pull docker images from public registry"
     export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux2014_x86_64

--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -26,6 +26,9 @@ python3.10 -m pip install -U snowflake-connector-python --only-binary=cffi >& /d
 python3.10 ${THIS_DIR}/change_snowflake_test_pwd.py
 mv ${CONNECTOR_DIR}/test/parameters_jenkins.py ${CONNECTOR_DIR}/test/parameters.py
 
+# Fetch wiremock
+curl https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.11.0/wiremock-standalone-3.11.0.jar --output ${CONNECTOR_DIR}/.wiremock/wiremock-standalone.jar
+
 # Run tests
 cd $CONNECTOR_DIR
 if [[ "$is_old_driver" == "true" ]]; then

--- a/test/unit/test_wiremock_client.py
+++ b/test/unit/test_wiremock_client.py
@@ -9,13 +9,8 @@ import pytest
 # old driver support
 try:
     from snowflake.connector.vendored import requests
-    from src.snowflake.connector.test_util import RUNNING_ON_JENKINS
 except ImportError:
-    import os
-
     import requests
-
-    RUNNING_ON_JENKINS = os.getenv("JENKINS_HOME") is not None
 
 
 from ..wiremock.wiremock_utils import WiremockClient
@@ -27,7 +22,6 @@ def wiremock_client() -> Generator[WiremockClient, Any, None]:
         yield client
 
 
-@pytest.mark.skipif(RUNNING_ON_JENKINS, reason="jenkins doesn't support wiremock tests")
 def test_wiremock(wiremock_client):
     connection_reset_by_peer_mapping = {
         "mappings": [


### PR DESCRIPTION
- Use fixed version of manylinux image to enable `yum` while keeping the `latest` tag as a backup.
- Add install openjdk 11 step to Dockerfile to enable running wiremock daemon
- Enable wiremock healthcheck test on Jenkins