### PR TITLE
skip decfloat test in olddriver tests

### DIFF
--- a/test/integ/test_decfloat.py
+++ b/test/integ/test_decfloat.py
@@ -9,10 +9,12 @@ import decimal
 from decimal import Decimal
 
 import numpy
+import pytest
 
 import snowflake.connector
 
 
+@pytest.mark.skipolddriver
 def test_decfloat_bindings(conn_cnx):
     # set required decimal precision
     decimal.getcontext().prec = 38
@@ -51,6 +53,7 @@ def test_decfloat_bindings(conn_cnx):
         snowflake.connector.paramstyle = original_style
 
 
+@pytest.mark.skipolddriver
 def test_decfloat_from_compiler(conn_cnx):
     # set required decimal precision
     decimal.getcontext().prec = 38

--- a/test/unit/test_converter.py
+++ b/test/unit/test_converter.py
@@ -14,7 +14,11 @@ from snowflake.connector import ProgrammingError
 from snowflake.connector.connection import DefaultConverterClass
 from snowflake.connector.converter import SnowflakeConverter
 from snowflake.connector.converter_snowsql import SnowflakeConverterSnowSQL
-from src.snowflake.connector.arrow_context import ArrowConverterContext
+
+try:
+    from src.snowflake.connector.arrow_context import ArrowConverterContext
+except ImportError:
+    pass
 
 logger = getLogger(__name__)
 
@@ -83,6 +87,7 @@ def test_converter_to_snowflake_error():
         converter._bogus_to_snowflake("Bogus")
 
 
+@pytest.mark.skipolddriver
 def test_decfloat_to_decimal_converter():
     ctx = ArrowConverterContext()
     decimal = ctx.DECFLOAT_to_decimal(42, bytes.fromhex("11AA"))


### PR DESCRIPTION
Recently merged changes were causing the old driver tests to fail due to missing dependency. This PR skips the decfloat test on the old driver to prevent the failure.