### PR TITLE
SNOW-1969802: sending sessionId with query execution request

### DIFF
--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1396,6 +1396,8 @@ class SnowflakeConnection:
             queryContext = self.get_query_context()
             #  Here queryContextDTO should be a dict object field, same with `parameters` field
             data["queryContextDTO"] = queryContext
+        if self.session_id is not None:
+            data["sessionId"] = self.session_id
         client = "sfsql_file_transfer" if is_file_transfer else "sfsql"
 
         if logger.getEffectiveLevel() <= logging.DEBUG:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

With dbt project, we are planning on supporting multiple session insides procs. So we have added new API to `_snowflake` to create a _pristine_ cloned version of the default server session. Using this, we will create a new new Snowpark session (a new object with new connection obj) and we will set the session_id of the connection (will be done in C API). On the server side to know what session a create query belongs to, connector needs to send the session_id with the rest request.

What connector sends will be used on the server-side using the changes in https://github.com/snowflakedb/snowflake/pull/265467.

TODO: Update public connector as well.

For more info on the multi-session project see this design doc: https://docs.google.com/document/d/1lwqyykHo549Vx3UWpFLWot1LIdYrwUjGKtGbQGaCnd8/edit?tab=t.0#heading=h.sil75ywnlm6n
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
