### PR TITLE
SNOW-1825495 Improve HTTP server targeted at serving OAuth redirects with timeouts and tests

### DIFF
--- a/src/snowflake/connector/auth/_http_server.py
+++ b/src/snowflake/connector/auth/_http_server.py
@@ -2,6 +2,10 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
 from __future__ import annotations
 
 import logging
@@ -9,6 +13,9 @@ import os
 import select
 import socket
 import time
+from collections.abc import Callable
+from types import TracebackType
+from typing import Self
 
 from ..compat import IS_WINDOWS
 from ..errorcode import ER_NO_HOSTNAME_FOUND
@@ -17,29 +24,64 @@ from ..errors import OperationalError
 logger = logging.getLogger(__name__)
 
 
+def _use_msg_dont_wait() -> bool:
+    if os.getenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "false").lower() != "true":
+        return False
+    if IS_WINDOWS:
+        logger.warning(
+            "Configuration SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT is not available in Windows. Ignoring."
+        )
+        return False
+    return True
+
+
+def _wrap_socket_recv() -> Callable[[socket.socket, int], bytes]:
+    dont_wait = _use_msg_dont_wait()
+    if dont_wait:
+        # WSL containerized environment sometimes causes socket_client.recv to hang indefinetly
+        #   To avoid this, passing the socket.MSG_DONTWAIT flag which raises BlockingIOError if
+        #   operation would block
+        logger.debug(
+            "Will call socket.recv with MSG_DONTWAIT flag due to SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT env var"
+        )
+    socket_recv = (
+        (lambda sock, buf_size: socket.socket.recv(sock, buf_size, socket.MSG_DONTWAIT))
+        if dont_wait
+        else (lambda sock, buf_size: socket.socket.recv(sock, buf_size))
+    )
+
+    def socket_recv_checked(sock: socket.socket, buf_size: int) -> bytes:
+        raw = socket_recv(sock, buf_size)
+        # when running in a containerized environment, socket_client.recv occasionally returns an empty byte array
+        #   an immediate successive call to socket_client.recv gets the actual data
+        if len(raw) == 0:
+            raw = socket_recv(sock, buf_size)
+        return raw
+
+    return socket_recv_checked
+
+
 class AuthHttpServer:
     """Simple HTTP server to receive callbacks through for auth purposes."""
 
     def __init__(
         self,
-        hostname: str = "localhost",
+        hostname: str = "127.0.0.1",
         buf_size: int = 16384,
     ) -> None:
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.hostname = hostname
         self.buf_size = buf_size
-        self._socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
         if os.getenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "False").lower() == "true":
             if IS_WINDOWS:
                 logger.warning(
                     "Configuration SNOWFLAKE_AUTH_SOCKET_REUSE_PORT is not available in Windows. Ignoring."
                 )
             else:
-                self._socket_connection.setsockopt(
-                    socket.SOL_SOCKET, socket.SO_REUSEPORT, 1
-                )
+                self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
         try:
-            self._socket_connection.bind(
+            self._socket.bind(
                 (
                     os.getenv("SF_AUTH_SOCKET_ADDR", hostname),
                     int(os.getenv("SF_AUTH_SOCKET_PORT", 0)),
@@ -53,76 +95,78 @@ class AuthHttpServer:
                     errno=ER_NO_HOSTNAME_FOUND,
                 )
             raise
+
         try:
-            self._socket_connection.listen(0)  # no backlog
-            self.port = self._socket_connection.getsockname()[1]
-        except Exception:
-            self._socket_connection.close()
+            self._socket.listen(0)  # no backlog
+            self.port = self._socket.getsockname()[1]
+        except Exception as ex:
+            logger.error(f"Failed to start listening for auth callback: {ex}")
+            self.close()
+            raise
+
+    def _try_poll(self, timeout: float | None) -> socket.socket | None:
+        read_sockets = select.select([self._socket], [], [], timeout)[0]
+        if read_sockets and read_sockets[0] is not None:
+            return self._socket.accept()[0]
+
+    def _try_receive_block(
+        self, recv: Callable[[socket.socket, int], bytes], timeout: float | None
+    ) -> (bytes | None, socket.socket | None):
+        client_socket = self._try_poll(timeout)
+        if client_socket is not None:
+            return recv(client_socket, self.buf_size), client_socket
+        return None, None
 
     def receive_block(
         self,
         max_attempts: int = 15,
-    ) -> tuple[list[str], socket.socket]:
-        """Receive a message with a maximum attempt count, blocking."""
-        socket_client = None
-        while True:
+        timeout: float | None = 30.0,
+    ) -> (list[str] | None, socket.socket | None):
+        """Receive a message with a maximum attempt count and a timeout in seconds, blocking."""
+        if not self._socket:
+            raise RuntimeError(
+                "Operation is not supported, server was already shut down."
+            )
+        recv = _wrap_socket_recv()
+        attempt_timeout = timeout / max_attempts if timeout else None
+        for attempt in range(max_attempts):
             try:
-                attempts = 0
-                raw_data = bytearray()
-
-                msg_dont_wait = (
-                    os.getenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", "false").lower()
-                    == "true"
+                raw_block, client_socket = self._try_receive_block(
+                    recv, attempt_timeout
                 )
-                if IS_WINDOWS:
-                    if msg_dont_wait:
-                        logger.warning(
-                            "Configuration SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT is not available in Windows. Ignoring."
-                        )
-                    msg_dont_wait = False
+                if raw_block:
+                    return raw_block.decode("utf-8").split("\r\n"), client_socket
+                elif client_socket:
+                    client_socket.shutdown(socket.SHUT_RDWR)
+                    client_socket.close()
+            except BlockingIOError:
+                logger.debug(
+                    f"BlockingIOError raised from socket.recv on attempt {1+attempt}"
+                    " to retrieve callback request"
+                )
+                if attempt < max_attempts - 1:
+                    cooldown = min(attempt_timeout, 0.25) if attempt_timeout else 0.25
+                    logger.debug(f"Waiting for {cooldown} seconds before trying again")
+                    time.sleep(cooldown)
+        return None, None
 
-                # when running in a containerized environment, socket_client.recv ocassionally returns an empty byte array
-                #   an immediate successive call to socket_client.recv gets the actual data
-                while len(raw_data) == 0 and attempts < max_attempts:
-                    attempts += 1
-                    read_sockets, _write_sockets, _exception_sockets = select.select(
-                        [self._socket_connection], [], []
-                    )
+    def close(self) -> None:
+        """Closes the underlying socket.
+        After having close() being called the server object cannot be reused.
+        """
+        if self._socket:
+            self._socket.close()
+            self._socket = None
 
-                    if read_sockets[0] is not None:
-                        # Receive the data in small chunks and retransmit it
-                        socket_client, _ = self._socket_connection.accept()
+    def __enter__(self) -> Self:
+        """Context manager."""
+        return self
 
-                        try:
-                            if msg_dont_wait:
-                                # WSL containerized environment sometimes causes socket_client.recv to hang indefinetly
-                                #   To avoid this, passing the socket.MSG_DONTWAIT flag which raises BlockingIOError if
-                                #   operation would block
-                                logger.debug(
-                                    "Calling socket_client.recv with MSG_DONTWAIT flag due to SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT env var"
-                                )
-                                raw_data = socket_client.recv(
-                                    BUF_SIZE, socket.MSG_DONTWAIT
-                                )
-                            else:
-                                raw_data = socket_client.recv(self.buf_size)
-
-                        except BlockingIOError:
-                            logger.debug(
-                                "BlockingIOError raised from socket.recv while attempting to retrieve callback request"
-                            )
-                            if attempts < max_attempts:
-                                sleep_time = 0.25
-                                logger.debug(
-                                    f"Waiting {sleep_time} seconds before trying again"
-                                )
-                                time.sleep(sleep_time)
-                            else:
-                                logger.debug("Exceeded retry count")
-
-                assert socket_client is not None
-                return raw_data.decode("utf-8").split("\r\n"), socket_client
-            except Exception:
-                if socket_client is not None:
-                    socket_client.shutdown(socket.SHUT_RDWR)
-                    socket_client.close()
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Context manager with disposing underlying networking objects."""
+        self.close()

--- a/src/snowflake/connector/auth/_http_server.py
+++ b/src/snowflake/connector/auth/_http_server.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-#
-# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
-#
-
 from __future__ import annotations
 
 import logging

--- a/test/unit/test_auth_callback_server.py
+++ b/test/unit/test_auth_callback_server.py
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+import socket
+import time
+from threading import Thread
+
+import pytest
+
+from snowflake.connector.auth._http_server import AuthHttpServer
+from snowflake.connector.vendored import requests
+
+
+@pytest.mark.parametrize(
+    "dontwait",
+    ["false", "true"],
+)
+@pytest.mark.parametrize("timeout", [None, 0.01])
+@pytest.mark.parametrize("reuse_port", ["true"])
+def test_auth_callback_success(monkeypatch, dontwait, timeout, reuse_port) -> None:
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", reuse_port)
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", dontwait)
+    test_response: requests.Response | None = None
+    with AuthHttpServer() as callback_server:
+
+        def request_callback():
+            nonlocal test_response
+            if timeout:
+                time.sleep(timeout / 2)
+            test_response = requests.get(
+                f"http://{callback_server.hostname}:{callback_server.port}/test_request"
+            )
+
+        request_callback_thread = Thread(target=request_callback)
+        request_callback_thread.start()
+        block, client_socket = callback_server.receive_block(timeout=timeout)
+        test_callback_request = block[0]
+        response = ["HTTP/1.1 200 OK", "Content-Type: text/html", "", "test_response"]
+        client_socket.sendall("\r\n".join(response).encode("utf-8"))
+        client_socket.shutdown(socket.SHUT_RDWR)
+        client_socket.close()
+        request_callback_thread.join()
+        assert test_response.ok
+        assert test_response.text == "test_response"
+        assert test_callback_request == "GET /test_request HTTP/1.1"
+
+
+@pytest.mark.parametrize(
+    "dontwait",
+    ["false", "true"],
+)
+@pytest.mark.parametrize("timeout", [0.01])
+@pytest.mark.parametrize("reuse_port", ["true"])
+def test_auth_callback_timeout(monkeypatch, dontwait, timeout, reuse_port) -> None:
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", reuse_port)
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", dontwait)
+    with AuthHttpServer() as callback_server:
+        block, client_socket = callback_server.receive_block(timeout=timeout)
+        assert block is None
+        assert client_socket is None

--- a/test/unit/test_auth_callback_server.py
+++ b/test/unit/test_auth_callback_server.py
@@ -18,7 +18,7 @@ from snowflake.connector.vendored import requests
     "dontwait",
     ["false", "true"],
 )
-@pytest.mark.parametrize("timeout", [None, 0.01])
+@pytest.mark.parametrize("timeout", [None, 0.05])
 @pytest.mark.parametrize("reuse_port", ["true"])
 def test_auth_callback_success(monkeypatch, dontwait, timeout, reuse_port) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", reuse_port)
@@ -29,7 +29,7 @@ def test_auth_callback_success(monkeypatch, dontwait, timeout, reuse_port) -> No
         def request_callback():
             nonlocal test_response
             if timeout:
-                time.sleep(timeout / 2)
+                time.sleep(timeout / 5)
             test_response = requests.get(
                 f"http://{callback_server.hostname}:{callback_server.port}/test_request"
             )
@@ -52,7 +52,7 @@ def test_auth_callback_success(monkeypatch, dontwait, timeout, reuse_port) -> No
     "dontwait",
     ["false", "true"],
 )
-@pytest.mark.parametrize("timeout", [0.01])
+@pytest.mark.parametrize("timeout", [0.05])
 @pytest.mark.parametrize("reuse_port", ["true"])
 def test_auth_callback_timeout(monkeypatch, dontwait, timeout, reuse_port) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", reuse_port)


### PR DESCRIPTION
- [x] Added unit tests for the server
- [x] Added support for setting a timeout for waiting redirect request
- [x] Added ContextManager support
- [x] Refactored(decomposed) `receive_block` method