### PR TITLE
Replace return with raise in error check

### DIFF
--- a/src/snowflake/connector/auth/workload_identity.py
+++ b/src/snowflake/connector/auth/workload_identity.py
@@ -44,7 +44,7 @@ class ApiFederatedAuthenticationType(Enum):
             return ApiFederatedAuthenticationType.GCP
         if attestation.provider == AttestationProvider.OIDC:
             return ApiFederatedAuthenticationType.OIDC
-        return ValueError(f"Unknown attestation provider '{attestation.provider}'")
+        raise ValueError(f"Unknown attestation provider '{attestation.provider}'")
 
 
 class AuthByWorkloadIdentity(AuthByPlugin):


### PR DESCRIPTION
This is a tiny bug fix to https://github.com/snowflakedb/snowflake-connector-python/pull/2203 which added support for Workload Identity Federation. Instead of raising an error, this line was accidentally returning it.