### PR TITLE
SNOW-2007887: improve error message handling related to timeout

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.14.1(TBD)
   - Basic decimal floating-point type support.
   - Added handling of PAT provided in `password` field.
+  - Improved error message for client-side query cancellations due to timeouts.
 
 - v3.14.0(March 03, 2025)
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1085,7 +1085,15 @@ class SnowflakeCursor:
             logger.debug(ret)
             err = ret["message"]
             code = ret.get("code", -1)
-            if self._timebomb and self._timebomb.executed:
+            if (
+                self._timebomb
+                and self._timebomb.executed
+                and "SQL execution canceled" in err
+            ):
+                # we only modify the error message when the error message returned from the server
+                # indicates that the query was indeed canceled
+                # otherwise the query might have encountered error already before query cancellation if the timeout
+                # is very short
                 err = (
                     f"SQL execution was cancelled by the client due to a timeout. "
                     f"Error message received from the server: {err}"

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1090,10 +1090,10 @@ class SnowflakeCursor:
                 and self._timebomb.executed
                 and "SQL execution canceled" in err
             ):
-                # we only modify the error message when the error message returned from the server
-                # indicates that the query was indeed canceled
-                # otherwise the query might have encountered error already before query cancellation if the timeout
-                # is very short
+                # Modify the error message only if the server error response indicates the query was canceled.
+                # If the error occurs before the cancellation request reaches the backend
+                # (e.g., due to a very short timeout), we retain the original error message
+                # as the query might have encountered an issue prior to cancellation.
                 err = (
                     f"SQL execution was cancelled by the client due to a timeout. "
                     f"Error message received from the server: {err}"

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -827,6 +827,7 @@ def test_invalid_bind_data_type(conn_cnx):
             cnx.cursor().execute("select 1 from dual where 1=%s", ([1, 2, 3],))
 
 
+@pytest.mark.skipolddriver
 def test_timeout_query(conn_cnx):
     with conn_cnx() as cnx:
         with cnx.cursor() as c:
@@ -842,7 +843,7 @@ def test_timeout_query(conn_cnx):
             )
 
             with pytest.raises(errors.ProgrammingError) as err:
-                # we can not preciously control the timing to send cancel query request right after server
+                # we can not precisely control the timing to send cancel query request right after server
                 # executes the query but before returning the results back to client
                 # it depends on python scheduling and server processing speed, so we mock here
                 with mock.patch.object(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2007887

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

there's possibility that we cancellation request is sent but the backend query execution already errored out
in this PR we improve error message related to time out
only modify error message when the server error message indicated query cancellation happened, for other error messages unrelated to cancellation, we return directly




4. (Optional) PR for stored-proc connector:
