### PR TITLE
NO-SNOW skip out of range year test on old driver

### DIFF
--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1790,6 +1790,7 @@ def test_out_of_range_year(conn_cnx, result_format, cursor_type, fetch_method):
                 fetch_next_fn()
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize("result_format", ("json", "arrow"))
 def test_out_of_range_year_followed_by_correct_year(conn_cnx, result_format):
     """Tests whether the year 10000 is out of range exception is raised as expected."""


### PR DESCRIPTION
The bugfix test rightfully tests on the old driver thus needs to be skipped