### PR TITLE
SNOW-2026002: Invalid url became valid

### DIFF
--- a/src/snowflake/connector/connection_diagnostic.py
+++ b/src/snowflake/connector/connection_diagnostic.py
@@ -579,7 +579,7 @@ class ConnectionDiagnostic:
                     cert_reqs=cert_reqs,
                 )
             resp = http.request(
-                "GET", "https://ireallyshouldnotexistatallanywhere.com", timeout=10.0
+                "GET", "https://nonexistentdomain.invalidtld", timeout=10.0
             )
 
             # squid does not throw exception.  Check HTML


### PR DESCRIPTION
ireallyshouldnotexistatallanywhere.com got registered and returns 200 when testing connection, I am changing the url to one with invalid TLD to fix connection diagnostic and prevent similar issues in the future

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
