### PR TITLE
SNOW-2027116 Allow for UUID encoding in SnowflakeRestful interface

### DIFF
--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -352,6 +352,13 @@ class SessionPool:
         self._active_sessions.clear()
         self._idle_sessions.clear()
 
+# Customizable JSONEncoder to support additional types.
+class SnowflakeRestfulJsonEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, uuid.UUID):
+            return str(o)
+
+        return super().default(o)
 
 class SnowflakeRestful:
     """Snowflake Restful class."""
@@ -499,7 +506,7 @@ class SnowflakeRestful:
             return self._post_request(
                 url,
                 headers,
-                json.dumps(body),
+                json.dumps(body, cls=SnowflakeRestfulJsonEncoder),
                 token=self.token,
                 _no_results=_no_results,
                 timeout=timeout,
@@ -561,7 +568,7 @@ class SnowflakeRestful:
         ret = self._post_request(
             url,
             headers,
-            json.dumps(body),
+            json.dumps(body, cls=SnowflakeRestfulJsonEncoder),
             token=header_token,
         )
         if ret.get("success") and ret.get("data", {}).get("sessionToken"):
@@ -659,7 +666,7 @@ class SnowflakeRestful:
                 ret = self._post_request(
                     url,
                     headers,
-                    json.dumps(body),
+                    json.dumps(body, cls=SnowflakeRestfulJsonEncoder),
                     token=self.token,
                     timeout=5,
                     no_retry=True,

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -352,6 +352,7 @@ class SessionPool:
         self._active_sessions.clear()
         self._idle_sessions.clear()
 
+
 # Customizable JSONEncoder to support additional types.
 class SnowflakeRestfulJsonEncoder(json.JSONEncoder):
     def default(self, o):
@@ -359,6 +360,7 @@ class SnowflakeRestfulJsonEncoder(json.JSONEncoder):
             return str(o)
 
         return super().default(o)
+
 
 class SnowflakeRestful:
     """Snowflake Restful class."""

--- a/test/unit/test_network.py
+++ b/test/unit/test_network.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import io
+import json
 import unittest.mock
+import uuid
+
+from src.snowflake.connector.network import SnowflakeRestfulJsonEncoder
 from test.unit.mock_utils import mock_connection
 
 import pytest
@@ -63,3 +67,14 @@ def test_fetch():
         # if no retry is set to False, the function raises an InterfaceError
         with pytest.raises(InterfaceError) as exc:
             assert rest.fetch(**default_parameters, no_retry=False)
+
+@pytest.mark.parametrize("u", [uuid.uuid1(),
+        uuid.uuid3(uuid.NAMESPACE_URL, "www.snowflake.com"),
+                             uuid.uuid4(),
+        uuid.uuid5(uuid.NAMESPACE_URL, "www.snowflake.com")])
+def test_json_serialize_uuid(u):
+    expected = f"{{\"u\": \"{u}\", \"a\": 42}}"
+
+    assert(json.dumps(u, cls=SnowflakeRestfulJsonEncoder)) == f"\"{u}\""
+
+    assert json.dumps({"u":u, "a":42}, cls=SnowflakeRestfulJsonEncoder) == expected

--- a/test/unit/test_network.py
+++ b/test/unit/test_network.py
@@ -3,11 +3,11 @@ import io
 import json
 import unittest.mock
 import uuid
-
-from src.snowflake.connector.network import SnowflakeRestfulJsonEncoder
 from test.unit.mock_utils import mock_connection
 
 import pytest
+
+from src.snowflake.connector.network import SnowflakeRestfulJsonEncoder
 
 try:
     from snowflake.connector import Error, InterfaceError
@@ -68,13 +68,19 @@ def test_fetch():
         with pytest.raises(InterfaceError) as exc:
             assert rest.fetch(**default_parameters, no_retry=False)
 
-@pytest.mark.parametrize("u", [uuid.uuid1(),
+
+@pytest.mark.parametrize(
+    "u",
+    [
+        uuid.uuid1(),
         uuid.uuid3(uuid.NAMESPACE_URL, "www.snowflake.com"),
-                             uuid.uuid4(),
-        uuid.uuid5(uuid.NAMESPACE_URL, "www.snowflake.com")])
+        uuid.uuid4(),
+        uuid.uuid5(uuid.NAMESPACE_URL, "www.snowflake.com"),
+    ],
+)
 def test_json_serialize_uuid(u):
-    expected = f"{{\"u\": \"{u}\", \"a\": 42}}"
+    expected = f'{{"u": "{u}", "a": 42}}'
 
-    assert(json.dumps(u, cls=SnowflakeRestfulJsonEncoder)) == f"\"{u}\""
+    assert (json.dumps(u, cls=SnowflakeRestfulJsonEncoder)) == f'"{u}"'
 
-    assert json.dumps({"u":u, "a":42}, cls=SnowflakeRestfulJsonEncoder) == expected
+    assert json.dumps({"u": u, "a": 42}, cls=SnowflakeRestfulJsonEncoder) == expected


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2027116

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   On the old driver CI, the restful interface failed when UUID objects are passed. Fix by using in `network.py::SnowflakeRestful` a customized JSON encoder (subclassed from Python) which adds support for Python UUID objects.

4. (Optional) PR for stored-proc connector:
   not applicable.