### PR TITLE
NO-SNOW skip tests of custom requestId on olddriver

### DIFF
--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1967,6 +1967,7 @@ def test_nanoarrow_usage_deprecation():
         )
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize(
     "request_id",
     [
@@ -1988,6 +1989,7 @@ def test_custom_request_id_negative(request_id, conn_cnx):
                 )
 
 
+@pytest.mark.skipolddriver
 def test_custom_request_id(conn_cnx):
     request_id = uuid.uuid4()
 


### PR DESCRIPTION
add `@pytest.mark.skipolddriver` to fix failing github actions checks
