### PR TITLE
Add default entra app ID for Snowflake

### DIFF
--- a/src/snowflake/connector/wif_util.py
+++ b/src/snowflake/connector/wif_util.py
@@ -20,8 +20,7 @@ from .vendored.requests import Response
 
 logger = logging.getLogger(__name__)
 SNOWFLAKE_AUDIENCE = "snowflakecomputing.com"
-# TODO: use real app ID or domain name once it's available.
-DEFAULT_ENTRA_SNOWFLAKE_RESOURCE = "NOT REAL - WILL BREAK"
+DEFAULT_ENTRA_SNOWFLAKE_RESOURCE = "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
 
 
 @unique

--- a/test/unit/test_auth_workload_identity.py
+++ b/test/unit/test_auth_workload_identity.py
@@ -279,7 +279,7 @@ def test_explicit_azure_uses_default_entra_resource_if_unspecified(
     token = fake_azure_metadata_service.token
     parsed = jwt.decode(token, options={"verify_signature": False})
     assert (
-        parsed["aud"] == "NOT REAL - WILL BREAK"
+        parsed["aud"] == "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
     )  # the default entra resource defined in wif_util.py.
 
 


### PR DESCRIPTION
This is a small follow-up to #2203 which populates the default Snowflake resource for Azure / Entra ID.