### PR TITLE
SNOW-2013774 support server side semi structured types bindings

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -23,6 +23,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Allow the connector to inherit a UUID4 generated upstream, provided in statement parameters (field: `requestId`), rather than automatically generate a UUID4 to use for the HTTP Request ID.
   - Fix expired S3 credentials update and increment retry when expired credentials are found.
   - Added `client_fetch_threads` experimental parameter to better utilize threads for fetching query results.
+  - Add `snowflake_type` parameter to execute method of a cursor. When set to `OBJECT` or `ARRAY` it allows binding of these semi-structured types.
 
 - v3.14.0(March 03, 2025)
   - Bumped pyOpenSSL dependency upper boundary from <25.0.0 to <26.0.0.

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -839,6 +839,7 @@ class SnowflakeCursor:
         file_stream: IO[bytes] | None = None,
         num_statements: int | None = None,
         _dataframe_ast: str | None = None,
+        snowflake_type: str | None = None,
     ) -> Self | None: ...
 
     @overload
@@ -869,6 +870,7 @@ class SnowflakeCursor:
         file_stream: IO[bytes] | None = None,
         num_statements: int | None = None,
         _dataframe_ast: str | None = None,
+        snowflake_type: str | None = None,
     ) -> dict[str, Any] | None: ...
 
     def execute(
@@ -899,6 +901,7 @@ class SnowflakeCursor:
         num_statements: int | None = None,
         _force_qmark_paramstyle: bool = False,
         _dataframe_ast: str | None = None,
+        snowflake_type: str | None = None,
     ) -> Self | dict[str, Any] | None:
         """Executes a command/query.
 
@@ -935,6 +938,7 @@ class SnowflakeCursor:
             statements being submitted (or 0 if submitting an uncounted number) when using a multi-statement query.
             _force_qmark_paramstyle: Force the use of qmark paramstyle regardless of the connection's paramstyle.
             _dataframe_ast: Base64-encoded dataframe request abstract syntax tree.
+            snowflake_type: Type for parameter binding. Enables server-side semi-structured types binding if set to ARRAY, OBJECT or VARIANT.
 
         Returns:
             The cursor itself, or None if some error happened, or the response returned
@@ -1000,7 +1004,7 @@ class SnowflakeCursor:
                     )
 
                 kwargs["binding_params"] = self._connection._process_params_qmarks(
-                    params, self
+                    params, self, snowflake_type=snowflake_type
                 )
 
         m = DESC_TABLE_RE.match(query)

--- a/test/integ/test_bindings.py
+++ b/test/integ/test_bindings.py
@@ -492,6 +492,7 @@ def test_binding_insert_date(conn_cnx, db_parameters):
 
 @pytest.mark.skipolddriver
 def test_binding_variant(conn_cnx):
+    pytest.skip("Server side binding of VARIANT type is not supported")
     bind_query = "INSERT INTO TEST_TABLE1 SELECT (?)"
     with conn_cnx(paramstyle="qmark") as cnx, cnx.cursor() as cursor:
         snowflake_type = "VARIANT"

--- a/test/integ/test_bindings.py
+++ b/test/integ/test_bindings.py
@@ -492,7 +492,7 @@ def test_binding_insert_date(conn_cnx, db_parameters):
 
 @pytest.mark.skipolddriver
 def test_binding_variant(conn_cnx):
-    pytest.skip("Server side binding of VARIANT type is not supported")
+    pytest.skip("Server-side binding of VARIANT type is not supported")
     bind_query = "INSERT INTO TEST_TABLE1 SELECT (?)"
     with conn_cnx(paramstyle="qmark") as cnx, cnx.cursor() as cursor:
         snowflake_type = "VARIANT"


### PR DESCRIPTION
Changes:
- add `snowflake_type` parameter to `cursor.execute` that indicates what is the desired snowflake type. If it's one of the semi-structured types, there's a special handling that includes serialising the object to JSON string that gets passed to the backend with appropriate type.
- integ tests

No snowflake_type provided or snowflake_type other than ARRAY, OBJECT or VARIANT doesn't change the processing flow. If user provides the primitive type e.g. BOOLEAN but the binding logic interprets it differently it results in a warning.

[SNOW-2013774]: https://snowflakecomputing.atlassian.net/browse/SNOW-2013774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ