### PR TITLE
SNOW-2026002: Change invalid TLD to be RFC compliant

### DIFF
--- a/src/snowflake/connector/connection_diagnostic.py
+++ b/src/snowflake/connector/connection_diagnostic.py
@@ -579,7 +579,7 @@ class ConnectionDiagnostic:
                     cert_reqs=cert_reqs,
                 )
             resp = http.request(
-                "GET", "https://nonexistentdomain.invalidtld", timeout=10.0
+                "GET", "https://nonexistentdomain.invalid", timeout=10.0
             )
 
             # squid does not throw exception.  Check HTML


### PR DESCRIPTION
>       ".invalid" is intended for use in online construction of domain
>       names that are sure to be invalid and which it is obvious at a
>       glance are invalid.