### PR TITLE
SNOW-2057867 refactor and fixes to make stage related bind and pandas…

### DIFF
--- a/src/snowflake/connector/bind_upload_agent.py
+++ b/src/snowflake/connector/bind_upload_agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
+import os
 import uuid
 from io import BytesIO
 from logging import getLogger
@@ -76,8 +77,11 @@ class BindUploadAgent:
                 if row_idx >= len(self.rows) or size >= self._stream_buffer_size:
                     break
             try:
-                self.cursor.execute(
-                    f"PUT file://{row_idx}.csv {self.stage_path}", file_stream=f
+                f.seek(0)
+                self.cursor._upload_stream(
+                    input_stream=f,
+                    stage_location=os.path.join(self.stage_path, f"{row_idx}.csv"),
+                    options={},
                 )
             except Error as err:
                 logger.debug("Failed to upload the bindings file to stage.")

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1459,7 +1459,7 @@ class SnowflakeCursor:
                 bind_stage = None
                 if (
                     bind_size
-                    > self.connection._session_parameters[
+                    >= self.connection._session_parameters[
                         "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"
                     ]
                     > 0

--- a/src/snowflake/connector/direct_file_operation_utils.py
+++ b/src/snowflake/connector/direct_file_operation_utils.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from .errors import NotSupportedError
+
+if TYPE_CHECKING:
+    from .connection import SnowflakeConnection
+
 from abc import ABC, abstractmethod
+
+from .constants import CMD_TYPE_UPLOAD
 
 
 class FileOperationParserBase(ABC):
@@ -37,8 +46,31 @@ class StreamDownloaderBase(ABC):
 
 
 class FileOperationParser(FileOperationParserBase):
-    def __init__(self, connection):
-        pass
+    def __init__(self, connection: SnowflakeConnection):
+        self._connection = connection
+
+    def _process_options_for_upload(self, options):
+        """Processes the options dict returns the qmark SQL and corresponding bind values.
+        Args:
+            options (dict): the options dict
+        Returns:
+            a tuple of the qmark SQL and corresponding bind values.
+        """
+        options = options or {}
+
+        options_in_sql_raw = []
+        option_bind_values = []
+
+        for k, v in options.items():
+            # Check that all option names are all valid identifiers for better safety.
+            if not k.isidentifier():
+                raise NotSupportedError(f"unsupported option {k}")
+            # Pass option value in binds for better safety.
+            option_bind_values.append(v)
+            options_in_sql_raw.append(f"{k}=?")
+        options_in_sql = " ".join(options_in_sql_raw)
+
+        return options_in_sql, option_bind_values
 
     def parse_file_operation(
         self,
@@ -49,7 +81,32 @@ class FileOperationParser(FileOperationParserBase):
         options,
         has_source_from_stream=False,
     ):
-        raise NotImplementedError("parse_file_operation is not yet supported")
+        """Parses a file operation by constructing SQL and getting the SQL parsing result from server."""
+        options_in_sql, option_bind_values = self._process_options_for_upload(options)
+
+        if command_type == CMD_TYPE_UPLOAD:
+            if has_source_from_stream:
+                assert (
+                    local_file_name is None
+                ), "local_file_name shall be derived from stage_location for stream uploading."
+                stage_location, unprefixed_local_file_name = stage_location.rsplit(
+                    "/", maxsplit=1
+                )
+                local_file_name = "file://" + unprefixed_local_file_name
+            # Escape single quotes.
+            local_file_name = local_file_name.replace("'", "''")
+            # Enclose local_file_name with single quotes and pass stage path by a bind for better safety.
+            sql = f"PUT '{local_file_name}' ? {options_in_sql}"
+            params = [stage_location, *option_bind_values]
+        else:
+            raise NotSupportedError(f"unsupported command type: {command_type}")
+
+        with self._connection.cursor() as cursor:
+            # Send constructed SQL to server and get back parsing result.
+            processed_params = cursor._connection._process_params_qmarks(params, cursor)
+            return cursor._execute_helper(
+                sql, binding_params=processed_params, is_internal=True
+            )
 
 
 class StreamDownloader(StreamDownloaderBase):
@@ -57,4 +114,4 @@ class StreamDownloader(StreamDownloaderBase):
         pass
 
     def download_as_stream(self, ret, decompress=False):
-        raise NotImplementedError("download_as_stream is not yet supported")
+        raise NotSupportedError("download_as_stream is not yet supported")

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -818,7 +818,7 @@ class SnowflakeFileTransferAgent:
 
                     rowset.append(
                         [
-                            meta.dst_file_name,
+                            meta.name,
                             dst_file_size,
                             meta.result_status,
                             error_details,

--- a/test/integ/pandas/test_pandas_tools.py
+++ b/test/integ/pandas/test_pandas_tools.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Generator
 from unittest import mock
+from unittest.mock import MagicMock
 
 import numpy.random
 import pytest
@@ -543,7 +544,10 @@ def test_table_location_building(
         with mock.patch(
             "snowflake.connector.cursor.SnowflakeCursor.execute",
             side_effect=mocked_execute,
-        ) as m_execute:
+        ) as m_execute, mock.patch(
+            "snowflake.connector.cursor.SnowflakeCursor._upload",
+            side_effect=MagicMock(),
+        ) as _:
             success, nchunks, nrows, _ = write_pandas(
                 cnx,
                 sf_connector_version_df.get(),
@@ -557,6 +561,7 @@ def test_table_location_building(
             )
 
 
+# @pytest.mark.skipolddriver
 @pytest.mark.parametrize(
     "database,schema,quote_identifiers,expected_db_schema",
     [
@@ -591,7 +596,10 @@ def test_stage_location_building(
         with mock.patch(
             "snowflake.connector.cursor.SnowflakeCursor.execute",
             side_effect=mocked_execute,
-        ) as m_execute:
+        ) as m_execute, mock.patch(
+            "snowflake.connector.cursor.SnowflakeCursor._upload",
+            side_effect=MagicMock(),
+        ) as _:
             success, nchunks, nrows, _ = write_pandas(
                 cnx,
                 sf_connector_version_df.get(),
@@ -643,7 +651,10 @@ def test_use_scoped_object(
         with mock.patch(
             "snowflake.connector.cursor.SnowflakeCursor.execute",
             side_effect=mocked_execute,
-        ) as m_execute:
+        ) as m_execute, mock.patch(
+            "snowflake.connector.cursor.SnowflakeCursor._upload",
+            side_effect=MagicMock(),
+        ) as _:
             cnx._update_parameters({"PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS": True})
             success, nchunks, nrows, _ = write_pandas(
                 cnx,
@@ -701,7 +712,10 @@ def test_file_format_location_building(
         with mock.patch(
             "snowflake.connector.cursor.SnowflakeCursor.execute",
             side_effect=mocked_execute,
-        ) as m_execute:
+        ) as m_execute, mock.patch(
+            "snowflake.connector.cursor.SnowflakeCursor._upload",
+            side_effect=MagicMock(),
+        ) as _:
             success, nchunks, nrows, _ = write_pandas(
                 cnx,
                 sf_connector_version_df.get(),

--- a/test/integ/test_direct_file_operation_utils.py
+++ b/test/integ/test_direct_file_operation_utils.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import os
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Callable, Generator
+
+import pytest
+
+from snowflake.connector._utils import TempObjectType, random_name_for_temp_object
+from snowflake.connector.errors import NotSupportedError
+
+try:
+    from snowflake.connector.options import pandas
+    from snowflake.connector.pandas_tools import (
+        _iceberg_config_statement_helper,
+        write_pandas,
+    )
+except ImportError:
+    pandas = None
+    write_pandas = None
+    _iceberg_config_statement_helper = None
+
+if TYPE_CHECKING:
+    from snowflake.connector import SnowflakeConnection, SnowflakeCursor
+
+
+def _validate_upload_content(
+    expected_content, cursor, stage_name, local_dir, base_file_name, is_compressed
+):
+    gz_suffix = ".gz"
+    stage_path = f"@{stage_name}/{base_file_name}"
+    local_path = f"{local_dir}/{base_file_name}"
+
+    cursor.execute(
+        f"GET ? 'file://{local_dir}'", params=[stage_path], _force_qmark_paramstyle=True
+    )
+    if is_compressed:
+        stage_path += gz_suffix
+        local_path += gz_suffix
+        import gzip
+
+        with gzip.open(local_path, "r") as f:
+            read_content = f.read().decode("utf-8")
+            assert read_content == expected_content, (read_content, expected_content)
+    else:
+        with open(local_path) as f:
+            read_content = f.read()
+    assert read_content == expected_content, (read_content, expected_content)
+
+
+def _test_runner(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    task: Callable[[SnowflakeCursor, str, str, str], None],
+    is_compressed: bool,
+    special_stage_name: str = None,
+    special_base_file_name: str = None,
+):
+    with conn_cnx() as conn:
+        cursor = conn.cursor()
+        stage_name = special_stage_name or random_name_for_temp_object(
+            TempObjectType.STAGE
+        )
+        cursor.execute(f"CREATE OR REPLACE SCOPED TEMP STAGE {stage_name}")
+        expected_content = "hello, world"
+        with TemporaryDirectory() as temp_dir:
+            base_file_name = special_base_file_name or "test.txt"
+            src_file_name = os.path.join(temp_dir, base_file_name)
+            with open(src_file_name, "w") as f:
+                f.write(expected_content)
+            # Run the file operation
+            task(cursor, stage_name, temp_dir, base_file_name)
+            # Clean up before validation.
+            os.remove(src_file_name)
+            # Validate result.
+            _validate_upload_content(
+                expected_content,
+                cursor,
+                stage_name,
+                temp_dir,
+                base_file_name,
+                is_compressed=is_compressed,
+            )
+
+
+@pytest.mark.parametrize("is_compressed", [False, True])
+def test_upload(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    is_compressed: bool,
+):
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={"auto_compress": is_compressed},
+        )
+
+    _test_runner(conn_cnx, upload_task, is_compressed=is_compressed)
+
+
+@pytest.mark.parametrize("is_compressed", [False, True])
+def test_upload_stream(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    is_compressed: bool,
+):
+    def upload_stream_task(cursor, stage_name, temp_dir, base_file_name):
+        with open(f"{temp_dir}/{base_file_name}", "rb") as input_stream:
+            cursor._upload_stream(
+                input_stream=input_stream,
+                stage_location=f"@{stage_name}/{base_file_name}",
+                options={"auto_compress": is_compressed},
+            )
+
+    _test_runner(conn_cnx, upload_stream_task, is_compressed=is_compressed)
+
+
+def test_upload_special_local_file_path(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+):
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={"auto_compress": False},
+        )
+
+    _test_runner(
+        conn_cnx,
+        upload_task,
+        is_compressed=False,
+        special_base_file_name="te ;DROP TABLE foo; st.txt",
+    )
+
+
+def test_upload_invalid_option_key(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+):
+    invalid_option_key = "auto;DELETE FROM TABLE foo;compress"
+
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={invalid_option_key: False},
+        )
+
+    with pytest.raises(
+        NotSupportedError,
+        match=invalid_option_key,
+    ):
+        _test_runner(conn_cnx, upload_task, is_compressed=False)


### PR DESCRIPTION
… write work for Python sprocs

- relax the condition of using stage solution for array bind (so we will use bind_size >= threshold instead of bind_size > threshold)
- use `_upload_stream` to implement BindUploadAgent
- use `_upload` to implement write_pandas
- correctly use scoped keyword and temp naming pattern for write_pandas
- fix a minor bug where file_transfer_agent returns meta.dst_file_name as file name in download (dst_file_name may contain sub-directories, whereas name will be the base file name without any sub-directory prefixes. We should keep it consistent with upload, where we use meta.name as file name

### Tests
- the new test_direct_file_operation_utils.py to validate parse_file_operation for _upload and _upload_stream
- existing test test_bindings.py to make sure the change does not break existing bind upload logic
- existing test_pandas_tools.py to make sure the change does not break existing write_pandas logic
- existing test_put_get.py to make sure the change does not break file_transfer_agent logic

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
