### PR TITLE
SNOW-2057867 refactor BindUploadAgent to make it work for Python sprocs

### DIFF
--- a/src/snowflake/connector/bind_upload_agent.py
+++ b/src/snowflake/connector/bind_upload_agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
+import os
 import uuid
 from io import BytesIO
 from logging import getLogger
@@ -76,8 +77,11 @@ class BindUploadAgent:
                 if row_idx >= len(self.rows) or size >= self._stream_buffer_size:
                     break
             try:
-                self.cursor.execute(
-                    f"PUT file://{row_idx}.csv {self.stage_path}", file_stream=f
+                f.seek(0)
+                self.cursor._upload_stream(
+                    input_stream=f,
+                    stage_location=os.path.join(self.stage_path, f"{row_idx}.csv"),
+                    options={},
                 )
             except Error as err:
                 logger.debug("Failed to upload the bindings file to stage.")

--- a/src/snowflake/connector/bind_upload_agent.py
+++ b/src/snowflake/connector/bind_upload_agent.py
@@ -81,7 +81,7 @@ class BindUploadAgent:
                 self.cursor._upload_stream(
                     input_stream=f,
                     stage_location=os.path.join(self.stage_path, f"{row_idx}.csv"),
-                    options={},
+                    options={"source_compression": "auto_detect"},
                 )
             except Error as err:
                 logger.debug("Failed to upload the bindings file to stage.")

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1459,7 +1459,7 @@ class SnowflakeCursor:
                 bind_stage = None
                 if (
                     bind_size
-                    > self.connection._session_parameters[
+                    >= self.connection._session_parameters[
                         "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD"
                     ]
                     > 0

--- a/src/snowflake/connector/direct_file_operation_utils.py
+++ b/src/snowflake/connector/direct_file_operation_utils.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .errors import NotSupportedError
-
 if TYPE_CHECKING:
     from .connection import SnowflakeConnection
 
@@ -71,7 +69,7 @@ class FileOperationParser(FileOperationParserBase):
             sql = f"PUT {local_file_name} ? {options_in_sql}"
             params = [stage_location]
         else:
-            raise NotSupportedError(f"unsupported command type: {command_type}")
+            raise NotImplementedError(f"unsupported command type: {command_type}")
 
         with self._connection.cursor() as cursor:
             # Send constructed SQL to server and get back parsing result.
@@ -86,4 +84,4 @@ class StreamDownloader(StreamDownloaderBase):
         pass
 
     def download_as_stream(self, ret, decompress=False):
-        raise NotSupportedError("download_as_stream is not yet supported")
+        raise NotImplementedError("download_as_stream is not yet supported")

--- a/src/snowflake/connector/direct_file_operation_utils.py
+++ b/src/snowflake/connector/direct_file_operation_utils.py
@@ -49,29 +49,6 @@ class FileOperationParser(FileOperationParserBase):
     def __init__(self, connection: SnowflakeConnection):
         self._connection = connection
 
-    def _process_options_for_upload(self, options):
-        """Processes the options dict returns the qmark SQL and corresponding bind values.
-        Args:
-            options (dict): the options dict
-        Returns:
-            a tuple of the qmark SQL and corresponding bind values.
-        """
-        options = options or {}
-
-        options_in_sql_raw = []
-        option_bind_values = []
-
-        for k, v in options.items():
-            # Check that all option names are all valid identifiers for better safety.
-            if not k.isidentifier():
-                raise NotSupportedError(f"unsupported option {k}")
-            # Pass option value in binds for better safety.
-            option_bind_values.append(v)
-            options_in_sql_raw.append(f"{k}=?")
-        options_in_sql = " ".join(options_in_sql_raw)
-
-        return options_in_sql, option_bind_values
-
     def parse_file_operation(
         self,
         stage_location,
@@ -82,22 +59,17 @@ class FileOperationParser(FileOperationParserBase):
         has_source_from_stream=False,
     ):
         """Parses a file operation by constructing SQL and getting the SQL parsing result from server."""
-        options_in_sql, option_bind_values = self._process_options_for_upload(options)
+        options = options or {}
+        options_in_sql = " ".join(f"{k}={v}" for k, v in options.items())
 
         if command_type == CMD_TYPE_UPLOAD:
             if has_source_from_stream:
-                assert (
-                    local_file_name is None
-                ), "local_file_name shall be derived from stage_location for stream uploading."
                 stage_location, unprefixed_local_file_name = stage_location.rsplit(
                     "/", maxsplit=1
                 )
                 local_file_name = "file://" + unprefixed_local_file_name
-            # Escape single quotes.
-            local_file_name = local_file_name.replace("'", "''")
-            # Enclose local_file_name with single quotes and pass stage path by a bind for better safety.
-            sql = f"PUT '{local_file_name}' ? {options_in_sql}"
-            params = [stage_location, *option_bind_values]
+            sql = f"PUT {local_file_name} ? {options_in_sql}"
+            params = [stage_location]
         else:
             raise NotSupportedError(f"unsupported command type: {command_type}")
 

--- a/src/snowflake/connector/direct_file_operation_utils.py
+++ b/src/snowflake/connector/direct_file_operation_utils.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from .errors import NotSupportedError
+
+if TYPE_CHECKING:
+    from .connection import SnowflakeConnection
+
 from abc import ABC, abstractmethod
+
+from .constants import CMD_TYPE_UPLOAD
 
 
 class FileOperationParserBase(ABC):
@@ -37,8 +46,31 @@ class StreamDownloaderBase(ABC):
 
 
 class FileOperationParser(FileOperationParserBase):
-    def __init__(self, connection):
-        pass
+    def __init__(self, connection: SnowflakeConnection):
+        self._connection = connection
+
+    def _process_options_for_upload(self, options):
+        """Processes the options dict returns the qmark SQL and corresponding bind values.
+        Args:
+            options (dict): the options dict
+        Returns:
+            a tuple of the qmark SQL and corresponding bind values.
+        """
+        options = options or {}
+
+        options_in_sql_raw = []
+        option_bind_values = []
+
+        for k, v in options.items():
+            # Check that all option names are all valid identifiers for better safety.
+            if not k.isidentifier():
+                raise NotSupportedError(f"unsupported option {k}")
+            # Pass option value in binds for better safety.
+            option_bind_values.append(v)
+            options_in_sql_raw.append(f"{k}=?")
+        options_in_sql = " ".join(options_in_sql_raw)
+
+        return options_in_sql, option_bind_values
 
     def parse_file_operation(
         self,
@@ -49,7 +81,32 @@ class FileOperationParser(FileOperationParserBase):
         options,
         has_source_from_stream=False,
     ):
-        raise NotImplementedError("parse_file_operation is not yet supported")
+        """Parses a file operation by constructing SQL and getting the SQL parsing result from server."""
+        options_in_sql, option_bind_values = self._process_options_for_upload(options)
+
+        if command_type == CMD_TYPE_UPLOAD:
+            if has_source_from_stream:
+                assert (
+                    local_file_name is None
+                ), "local_file_name shall be derived from stage_location for stream uploading."
+                stage_location, unprefixed_local_file_name = stage_location.rsplit(
+                    "/", maxsplit=1
+                )
+                local_file_name = "file://" + unprefixed_local_file_name
+            # Escape single quotes.
+            local_file_name = local_file_name.replace("'", "''")
+            # Enclose local_file_name with single quotes and pass stage path by a bind for better safety.
+            sql = f"PUT '{local_file_name}' ? {options_in_sql}"
+            params = [stage_location, *option_bind_values]
+        else:
+            raise NotSupportedError(f"unsupported command type: {command_type}")
+
+        with self._connection.cursor() as cursor:
+            # Send constructed SQL to server and get back parsing result.
+            processed_params = cursor._connection._process_params_qmarks(params, cursor)
+            return cursor._execute_helper(
+                sql, binding_params=processed_params, is_internal=True
+            )
 
 
 class StreamDownloader(StreamDownloaderBase):
@@ -57,4 +114,4 @@ class StreamDownloader(StreamDownloaderBase):
         pass
 
     def download_as_stream(self, ret, decompress=False):
-        raise NotImplementedError("download_as_stream is not yet supported")
+        raise NotSupportedError("download_as_stream is not yet supported")

--- a/src/snowflake/connector/direct_file_operation_utils.py
+++ b/src/snowflake/connector/direct_file_operation_utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .connection import SnowflakeConnection
 
+import os
 from abc import ABC, abstractmethod
 
 from .constants import CMD_TYPE_UPLOAD
@@ -62,8 +63,8 @@ class FileOperationParser(FileOperationParserBase):
 
         if command_type == CMD_TYPE_UPLOAD:
             if has_source_from_stream:
-                stage_location, unprefixed_local_file_name = stage_location.rsplit(
-                    "/", maxsplit=1
+                stage_location, unprefixed_local_file_name = os.path.split(
+                    stage_location
                 )
                 local_file_name = "file://" + unprefixed_local_file_name
             sql = f"PUT {local_file_name} ? {options_in_sql}"

--- a/test/integ/test_direct_file_operation_utils.py
+++ b/test/integ/test_direct_file_operation_utils.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import os
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Callable, Generator
+
+import pytest
+
+from snowflake.connector._utils import TempObjectType, random_name_for_temp_object
+from snowflake.connector.errors import NotSupportedError
+
+try:
+    from snowflake.connector.options import pandas
+    from snowflake.connector.pandas_tools import (
+        _iceberg_config_statement_helper,
+        write_pandas,
+    )
+except ImportError:
+    pandas = None
+    write_pandas = None
+    _iceberg_config_statement_helper = None
+
+if TYPE_CHECKING:
+    from snowflake.connector import SnowflakeConnection, SnowflakeCursor
+
+
+def _validate_upload_content(
+    expected_content, cursor, stage_name, local_dir, base_file_name, is_compressed
+):
+    gz_suffix = ".gz"
+    stage_path = f"@{stage_name}/{base_file_name}"
+    local_path = f"{local_dir}/{base_file_name}"
+
+    cursor.execute(
+        f"GET ? 'file://{local_dir}'", params=[stage_path], _force_qmark_paramstyle=True
+    )
+    if is_compressed:
+        stage_path += gz_suffix
+        local_path += gz_suffix
+        import gzip
+
+        with gzip.open(local_path, "r") as f:
+            read_content = f.read().decode("utf-8")
+            assert read_content == expected_content, (read_content, expected_content)
+    else:
+        with open(local_path) as f:
+            read_content = f.read()
+    assert read_content == expected_content, (read_content, expected_content)
+
+
+def _test_runner(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    task: Callable[[SnowflakeCursor, str, str, str], None],
+    is_compressed: bool,
+    special_stage_name: str = None,
+    special_base_file_name: str = None,
+):
+    with conn_cnx() as conn:
+        cursor = conn.cursor()
+        stage_name = special_stage_name or random_name_for_temp_object(
+            TempObjectType.STAGE
+        )
+        cursor.execute(f"CREATE OR REPLACE SCOPED TEMP STAGE {stage_name}")
+        expected_content = "hello, world"
+        with TemporaryDirectory() as temp_dir:
+            base_file_name = special_base_file_name or "test.txt"
+            src_file_name = os.path.join(temp_dir, base_file_name)
+            with open(src_file_name, "w") as f:
+                f.write(expected_content)
+            # Run the file operation
+            task(cursor, stage_name, temp_dir, base_file_name)
+            # Clean up before validation.
+            os.remove(src_file_name)
+            # Validate result.
+            _validate_upload_content(
+                expected_content,
+                cursor,
+                stage_name,
+                temp_dir,
+                base_file_name,
+                is_compressed=is_compressed,
+            )
+
+
+@pytest.mark.parametrize("is_compressed", [False, True])
+def test_upload(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    is_compressed: bool,
+):
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={"auto_compress": is_compressed},
+        )
+
+    _test_runner(conn_cnx, upload_task, is_compressed=is_compressed)
+
+
+@pytest.mark.parametrize("is_compressed", [False, True])
+def test_upload_stream(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+    is_compressed: bool,
+):
+    def upload_stream_task(cursor, stage_name, temp_dir, base_file_name):
+        with open(f"{temp_dir}/{base_file_name}", "rb") as input_stream:
+            cursor._upload_stream(
+                input_stream=input_stream,
+                stage_location=f"@{stage_name}/{base_file_name}",
+                options={"auto_compress": is_compressed},
+            )
+
+    _test_runner(conn_cnx, upload_stream_task, is_compressed=is_compressed)
+
+
+def test_upload_special_local_file_path(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+):
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={"auto_compress": False},
+        )
+
+    _test_runner(
+        conn_cnx,
+        upload_task,
+        is_compressed=False,
+        special_base_file_name="te ;DROP TABLE foo; st.txt",
+    )
+
+
+def test_upload_invalid_option_key(
+    conn_cnx: Callable[..., Generator[SnowflakeConnection]],
+):
+    invalid_option_key = "auto;DELETE FROM TABLE foo;compress"
+
+    def upload_task(cursor, stage_name, temp_dir, base_file_name):
+        cursor._upload(
+            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            stage_location=f"@{stage_name}",
+            options={invalid_option_key: False},
+        )
+
+    with pytest.raises(
+        NotSupportedError,
+        match=invalid_option_key,
+    ):
+        _test_runner(conn_cnx, upload_task, is_compressed=False)

--- a/test/integ/test_direct_file_operation_utils.py
+++ b/test/integ/test_direct_file_operation_utils.py
@@ -34,9 +34,7 @@ def _validate_upload_content(
     local_path = os.path.join(local_dir, base_file_name)
 
     cursor.execute(
-        f"GET ? 'file://{_normalize_windows_local_path(local_dir)}'",
-        params=[stage_path],
-        _force_qmark_paramstyle=True,
+        f"GET {stage_path} 'file://{_normalize_windows_local_path(local_dir)}'",
     )
     if is_compressed:
         stage_path += gz_suffix

--- a/test/integ/test_direct_file_operation_utils.py
+++ b/test/integ/test_direct_file_operation_utils.py
@@ -27,7 +27,7 @@ def _validate_upload_content(
 ):
     gz_suffix = ".gz"
     stage_path = f"@{stage_name}/{base_file_name}"
-    local_path = f"{local_dir}/{base_file_name}"
+    local_path = os.path.join(local_dir, base_file_name)
 
     cursor.execute(
         f"GET ? 'file://{local_dir}'", params=[stage_path], _force_qmark_paramstyle=True
@@ -90,7 +90,7 @@ def test_upload(
 ):
     def upload_task(cursor, stage_name, temp_dir, base_file_name):
         cursor._upload(
-            local_file_name=f"file://{temp_dir}/{base_file_name}",
+            local_file_name=f"file://{os.path.join(temp_dir, base_file_name)}",
             stage_location=f"@{stage_name}",
             options={"auto_compress": is_compressed},
         )
@@ -105,10 +105,10 @@ def test_upload_stream(
     is_compressed: bool,
 ):
     def upload_stream_task(cursor, stage_name, temp_dir, base_file_name):
-        with open(f"{temp_dir}/{base_file_name}", "rb") as input_stream:
+        with open(f"{os.path.join(temp_dir, base_file_name)}", "rb") as input_stream:
             cursor._upload_stream(
                 input_stream=input_stream,
-                stage_location=f"@{stage_name}/{base_file_name}",
+                stage_location=f"@{os.path.join(stage_name, base_file_name)}",
                 options={"auto_compress": is_compressed},
             )
 

--- a/test/integ/test_direct_file_operation_utils.py
+++ b/test/integ/test_direct_file_operation_utils.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Callable, Generator
 
 import pytest
 
-from snowflake.connector._utils import TempObjectType, random_name_for_temp_object
-
 try:
     from snowflake.connector.options import pandas
     from snowflake.connector.pandas_tools import (
@@ -55,6 +53,8 @@ def _test_runner(
     special_stage_name: str = None,
     special_base_file_name: str = None,
 ):
+    from snowflake.connector._utils import TempObjectType, random_name_for_temp_object
+
     with conn_cnx() as conn:
         cursor = conn.cursor()
         stage_name = special_stage_name or random_name_for_temp_object(
@@ -82,6 +82,7 @@ def _test_runner(
             )
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize("is_compressed", [False, True])
 def test_upload(
     conn_cnx: Callable[..., Generator[SnowflakeConnection]],
@@ -97,6 +98,7 @@ def test_upload(
     _test_runner(conn_cnx, upload_task, is_compressed=is_compressed)
 
 
+@pytest.mark.skipolddriver
 @pytest.mark.parametrize("is_compressed", [False, True])
 def test_upload_stream(
     conn_cnx: Callable[..., Generator[SnowflakeConnection]],

--- a/test/unit/test_bind_upload_agent.py
+++ b/test/unit/test_bind_upload_agent.py
@@ -12,7 +12,8 @@ def test_bind_upload_agent_uploading_multiple_files():
     rows = [bytes(10)] * 10
     agent = BindUploadAgent(csr, rows, stream_buffer_size=10)
     agent.upload()
-    assert csr.execute.call_count == 11  # 1 for stage creation + 10 files
+    assert csr.execute.call_count == 1  # 1 for stage creation
+    assert csr._upload_stream.call_count == 10  # 10 for 10 files
 
 
 def test_bind_upload_agent_row_size_exceed_buffer_size():
@@ -22,7 +23,8 @@ def test_bind_upload_agent_row_size_exceed_buffer_size():
     rows = [bytes(15)] * 10
     agent = BindUploadAgent(csr, rows, stream_buffer_size=10)
     agent.upload()
-    assert csr.execute.call_count == 11  # 1 for stage creation + 10 files
+    assert csr.execute.call_count == 1  # 1 for stage creation
+    assert csr._upload_stream.call_count == 10  # 10 for 10 files
 
 
 def test_bind_upload_agent_scoped_temp_object():


### PR DESCRIPTION
- relax the condition of using stage solution for array bind (so we will use bind_size >= threshold instead of bind_size > threshold)
- use _upload_stream to implement BindUploadAgent

### Tests
- the new test_direct_file_operation_utils.py to validate parse_file_operation for _upload and _upload_stream
- existing test test_bindings.py to make sure the change does not break existing bind upload logic

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
