### PR TITLE
SNOW-2100781: Fix use_virtual_url in GCS

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.16(TBD)
   - Added basic arrow support for Interval types.
   - Fix `write_pandas` special characters usage in the location name.
+  - Fix usage of `use_virtual_url` when building the location for gcs storage client.
 
 - v3.15.0(Apr 29,2025)
   - Bumped up min boto and botocore version to 1.24.

--- a/src/snowflake/connector/gcs_storage_client.py
+++ b/src/snowflake/connector/gcs_storage_client.py
@@ -464,7 +464,7 @@ class SnowflakeGCSRestClient(SnowflakeStorageClient):
         use_virtual_url: bool = False,
     ) -> str:
         gcs_location = SnowflakeGCSRestClient.get_location(
-            stage_location, use_regional_url, region, endpoint
+            stage_location, use_regional_url, region, endpoint, use_virtual_url
         )
         full_file_path = f"{gcs_location.path}{filename}"
 

--- a/test/unit/test_gcs_client.py
+++ b/test/unit/test_gcs_client.py
@@ -350,7 +350,7 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "region,return_url,use_regional_url,endpoint,use_virtual_url",
+    "region,return_url,use_regional_url,endpoint,use_virtual_url,complete_url",
     [
         (
             "US-CENTRAL1",
@@ -358,6 +358,7 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
             True,
             None,
             False,
+            "https://storage.us-central1.rep.googleapis.com/location/filename",
         ),
         (
             "ME-CENTRAL2",
@@ -365,17 +366,47 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
             True,
             None,
             False,
+            "https://storage.me-central2.rep.googleapis.com/location/filename",
         ),
-        ("US-CENTRAL1", "https://storage.googleapis.com", False, None, False),
-        ("US-CENTRAL1", "https://storage.googleapis.com", False, None, False),
-        ("US-CENTRAL1", "https://location.storage.googleapis.com", False, None, True),
-        ("US-CENTRAL1", "https://location.storage.googleapis.com", True, None, True),
+        (
+            "US-CENTRAL1",
+            "https://storage.googleapis.com",
+            False,
+            None,
+            False,
+            "https://storage.googleapis.com/location/filename",
+        ),
+        (
+            "US-CENTRAL1",
+            "https://storage.us-central1.rep.googleapis.com",
+            True,
+            None,
+            False,
+            "https://storage.us-central1.rep.googleapis.com/location/filename",
+        ),
+        (
+            "US-CENTRAL1",
+            "https://location.storage.googleapis.com",
+            False,
+            None,
+            True,
+            "https://location.storage.googleapis.com/filename",
+        ),
+        (
+            "US-CENTRAL1",
+            "https://location.storage.googleapis.com",
+            True,
+            None,
+            True,
+            "https://location.storage.googleapis.com/filename",
+        ),
         (
             "US-CENTRAL1",
             "https://overriddenurl.com",
             False,
             "https://overriddenurl.com",
             False,
+            "https://overriddenurl.com/location/filename",
         ),
         (
             "US-CENTRAL1",
@@ -383,6 +414,7 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
             True,
             "https://overriddenurl.com",
             False,
+            "https://overriddenurl.com/location/filename",
         ),
         (
             "US-CENTRAL1",
@@ -390,13 +422,7 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
             True,
             "https://overriddenurl.com",
             True,
-        ),
-        (
-            "US-CENTRAL1",
-            "https://overriddenurl.com",
-            False,
-            "https://overriddenurl.com",
-            False,
+            "https://overriddenurl.com/filename",
         ),
         (
             "US-CENTRAL1",
@@ -404,10 +430,13 @@ def test_get_file_header_none_with_presigned_url(tmp_path):
             False,
             "https://overriddenurl.com",
             True,
+            "https://overriddenurl.com/filename",
         ),
     ],
 )
-def test_url(region, return_url, use_regional_url, endpoint, use_virtual_url):
+def test_url(
+    region, return_url, use_regional_url, endpoint, use_virtual_url, complete_url
+):
     gcs_location = SnowflakeGCSRestClient.get_location(
         stage_location="location",
         use_regional_url=use_regional_url,
@@ -416,6 +445,17 @@ def test_url(region, return_url, use_regional_url, endpoint, use_virtual_url):
         use_virtual_url=use_virtual_url,
     )
     assert gcs_location.endpoint == return_url
+
+    generated_url = SnowflakeGCSRestClient.generate_file_url(
+        stage_location="location",
+        filename="filename",
+        use_regional_url=use_regional_url,
+        region=region,
+        endpoint=endpoint,
+        use_virtual_url=use_virtual_url,
+    )
+
+    assert generated_url == complete_url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2100781

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fix missing parameter when calculating the endpoint in GCS storage client.

4. (Optional) PR for stored-proc connector:
