### PR TITLE
SNOW-2111939: Bind cryptography to latest known working version

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added basic arrow support for Interval types.
   - Fix `write_pandas` special characters usage in the location name.
   - Fix usage of `use_virtual_url` when building the location for gcs storage client.
+  - Bind cryptography to <=44.0.3 to avoid issues with 45.0.0.
 
 - v3.15.0(Apr 29,2025)
   - Bumped up min boto and botocore version to 1.24.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     boto3>=1.24
     botocore>=1.24
     cffi>=1.9,<2.0.0
-    cryptography>=3.1.0
+    cryptography>=3.1.0,<=44.0.3
     pyOpenSSL>=22.0.0,<26.0.0
     pyjwt<3.0.0
     pytz


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-2111939

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Since cryptography v.45, some of the keys are not properly deserialized, causing the driver to fail.

4. (Optional) PR for stored-proc connector:
