### PR TITLE
SNOW-2119489: Add support for interval types in json format

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fix OAuth authenticator values.
   - Add `unsafe_skip_file_permissions_check` flag to skip file permissions check on cache and config.
   - Introduce snowflake_version property to the connection
+  - Added basic json support for Interval types.
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/src/snowflake/connector/arrow_context.py
+++ b/src/snowflake/connector/arrow_context.py
@@ -13,6 +13,7 @@ from pytz import UTC
 
 from .constants import PARAMETER_TIMEZONE
 from .converter import _generate_tzinfo_from_tzoffset
+from .interval_util import interval_year_month_to_string
 
 if TYPE_CHECKING:
     from numpy import datetime64, float64, int64, timedelta64
@@ -163,6 +164,9 @@ class ArrowConverterContext:
 
     def DECFLOAT_to_numpy_float64(self, exponent: int, significand: bytes) -> float64:
         return numpy.float64(self.DECFLOAT_to_decimal(exponent, significand))
+
+    def INTERVAL_YEAR_MONTH_to_str(self, months: int) -> str:
+        return interval_year_month_to_string(months)
 
     def INTERVAL_YEAR_MONTH_to_numpy_timedelta(self, months: int) -> timedelta64:
         return numpy.timedelta64(months, "M")

--- a/src/snowflake/connector/interval_util.py
+++ b/src/snowflake/connector/interval_util.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+def interval_year_month_to_string(interval: int) -> str:
+    """Convert a year-month interval to a string.
+
+    Args:
+        interval: The year-month interval.
+
+    Returns:
+        The string representation of the interval.
+    """
+    sign = "+" if interval >= 0 else "-"
+    interval = abs(interval)
+    years = interval // 12
+    months = interval % 12
+    return f"{sign}{years}-{months:02}"

--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/IntervalConverter.hpp
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/IntervalConverter.hpp
@@ -20,7 +20,7 @@ class IntervalYearMonthConverter : public IColumnConverter {
  private:
   ArrowArrayView* m_array;
   PyObject* m_context;
-  bool m_useNumpy;
+  const char* m_method;
 };
 
 class IntervalDayTimeConverterInt : public IColumnConverter {

--- a/test/integ/test_arrow_result.py
+++ b/test/integ/test_arrow_result.py
@@ -1235,65 +1235,6 @@ select '2019-08-10'::date, '2019-01-02 12:34:56.1234'::timestamp_ntz(4),
         assert val[3] == numpy.datetime64("2019-01-02 12:34:56.12345678")
 
 
-@pytest.mark.parametrize("use_numpy", [True, False])
-def test_select_year_month_interval_arrow(conn_cnx, use_numpy):
-    cases = ["0-0", "1-2", "-1-3", "999999999-11", "-999999999-11"]
-    expected = [0, 14, -15, 11_999_999_999, -11_999_999_999]
-    if use_numpy:
-        expected = [numpy.timedelta64(e, "M") for e in expected]
-
-    table = "test_arrow_day_time_interval"
-    values = "(" + "),(".join([f"'{c}'" for c in cases]) + ")"
-    with conn_cnx(numpy=use_numpy) as conn:
-        cursor = conn.cursor()
-        cursor.execute("alter session set python_connector_query_result_format='arrow'")
-
-        cursor.execute("alter session set feature_interval_types=enabled")
-        cursor.execute(f"create or replace table {table} (c1 interval year to month)")
-        cursor.execute(f"insert into {table} values {values}")
-        result = conn.cursor().execute(f"select * from {table}").fetchall()
-        result = [r[0] for r in result]
-        assert result == expected
-
-
-@pytest.mark.skip(
-    reason="SNOW-1878635: Add support for day-time interval in ArrowStreamWriter"
-)
-@pytest.mark.parametrize("use_numpy", [True, False])
-def test_select_day_time_interval_arrow(conn_cnx, use_numpy):
-    cases = [
-        "0 0:0:0.0",
-        "12 3:4:5.678",
-        "-1 2:3:4.567",
-        "99999 23:59:59.999999",
-        "-99999 23:59:59.999999",
-    ]
-    expected = [
-        timedelta(days=0),
-        timedelta(days=12, hours=3, minutes=4, seconds=5.678),
-        -timedelta(days=1, hours=2, minutes=3, seconds=4.567),
-        timedelta(days=99999, hours=23, minutes=59, seconds=59.999999),
-        -timedelta(days=99999, hours=23, minutes=59, seconds=59.999999),
-    ]
-    if use_numpy:
-        expected = [numpy.timedelta64(e) for e in expected]
-
-    table = "test_arrow_day_time_interval"
-    values = "(" + "),(".join([f"'{c}'" for c in cases]) + ")"
-    with conn_cnx(numpy=use_numpy) as conn:
-        cursor = conn.cursor()
-        cursor.execute("alter session set python_connector_query_result_format='arrow'")
-
-        cursor.execute("alter session set feature_interval_types=enabled")
-        cursor.execute(
-            f"create or replace table {table} (c1 interval day(5) to second)"
-        )
-        cursor.execute(f"insert into {table} values {values}")
-        result = conn.cursor().execute(f"select * from {table}").fetchall()
-        result = [r[0] for r in result]
-        assert result == expected
-
-
 def get_random_seed():
     random.seed(datetime.now().timestamp())
     return random.randint(0, 10000)

--- a/test/integ/test_interval_types.py
+++ b/test/integ/test_interval_types.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+from datetime import timedelta
+
+import numpy
+import pytest
+
+pytestmark = pytest.mark.skipolddriver  # old test driver tests won't run this module
+
+
+@pytest.mark.parametrize("use_numpy", [True, False])
+@pytest.mark.parametrize("result_format", ["json", "arrow"])
+def test_select_year_month_interval(conn_cnx, use_numpy, result_format):
+    cases = ["0-0", "1-2", "-1-3", "999999999-11", "-999999999-11"]
+    expected = [0, 14, -15, 11_999_999_999, -11_999_999_999]
+    if use_numpy:
+        expected = [numpy.timedelta64(e, "M") for e in expected]
+    else:
+        expected = ["+0-00", "+1-02", "-1-03", "+999999999-11", "-999999999-11"]
+
+    table = "test_arrow_day_time_interval"
+    values = "(" + "),(".join([f"'{c}'" for c in cases]) + ")"
+    with conn_cnx(numpy=use_numpy) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            f"alter session set python_connector_query_result_format='{result_format}'"
+        )
+
+        cursor.execute("alter session set feature_interval_types=enabled")
+        cursor.execute(f"create or replace table {table} (c1 interval year to month)")
+        cursor.execute(f"insert into {table} values {values}")
+        result = conn.cursor().execute(f"select * from {table}").fetchall()
+        result = [r[0] for r in result]
+        assert result == expected
+
+
+@pytest.mark.skip(
+    reason="SNOW-1878635: Add support for day-time interval in ArrowStreamWriter"
+)
+@pytest.mark.parametrize("use_numpy", [True, False])
+@pytest.mark.parametrize("result_format", ["json", "arrow"])
+def test_select_day_time_interval(conn_cnx, use_numpy, result_format):
+    cases = [
+        "0 0:0:0.0",
+        "12 3:4:5.678",
+        "-1 2:3:4.567",
+        "99999 23:59:59.999999",
+        "-99999 23:59:59.999999",
+    ]
+    expected = [
+        timedelta(days=0),
+        timedelta(days=12, hours=3, minutes=4, seconds=5.678),
+        -timedelta(days=1, hours=2, minutes=3, seconds=4.567),
+        timedelta(days=99999, hours=23, minutes=59, seconds=59.999999),
+        -timedelta(days=99999, hours=23, minutes=59, seconds=59.999999),
+    ]
+    if use_numpy:
+        expected = [numpy.timedelta64(e) for e in expected]
+
+    table = "test_arrow_day_time_interval"
+    values = "(" + "),(".join([f"'{c}'" for c in cases]) + ")"
+    with conn_cnx(numpy=use_numpy) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            f"alter session set python_connector_query_result_format='{result_format}'"
+        )
+
+        cursor.execute("alter session set feature_interval_types=enabled")
+        cursor.execute(
+            f"create or replace table {table} (c1 interval day(5) to second)"
+        )
+        cursor.execute(f"insert into {table} values {values}")
+        result = conn.cursor().execute(f"select * from {table}").fetchall()
+        result = [r[0] for r in result]
+        assert result == expected


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2119489

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR adds support for INTERVAL YEAR MONTH and INTERVAL DAY TIME to the python connector in JSON format.

Implementation details:

For year-month interval we receive number of months as integer (represented as string) from server. Python timedelta only supports days, seconds and microseconds so this is mapped to ANSI formatted interval string. In numpy it is mapped to numpy.timedelta64.
For day-time interval we receive number of nanoseconds as integer (represented as string). We convert this to timedelta and numpy.timedelta64.

4. (Optional) PR for stored-proc connector:
