### PR TITLE
SNOW-2182766 no 3.15.1 release yet we have release notes for it

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,8 +13,6 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Add `bulk_upload_chunks` parameter to `write_pandas` function. Setting this parameter to True changes the behaviour of write_pandas function to first write all the data chunks to the local disk and then perform the wildcard upload of the chunks folder to the stage. In default behaviour the chunks are being saved, uploaded and deleted one by one.
   - Added support for new authentication mechanism PAT with external session ID.
   - Added `client_fetch_use_mp` parameter that enables multiprocessed fetching of result batches.
-
-- v3.15.1(May 20, 2025)
   - Added basic arrow support for Interval types.
   - Fix `write_pandas` special characters usage in the location name.
   - Fix usage of `use_virtual_url` when building the location for gcs storage client.


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

  Doc only change, no code was modified.

   Fixes https://github.com/snowflakedb/snowflake-connector-python/issues/2380
   There's a small confusion about the 2 entries in the release notes, there's a section for 3.15.1 (which was never released) and a separate section for upcoming 3.16. release.
   It looks like 3.15.1 itself is still upcoming - which i guess, would mean the changes populated under 3.15.1 will be released with 3.16.


