### PR TITLE
Separate server and redirect URIs in `AuthHttpServer`

### DIFF
--- a/test/unit/test_auth_callback_server.py
+++ b/test/unit/test_auth_callback_server.py
@@ -138,6 +138,59 @@ def test_auth_callback_server_updates_localhost_redirect_uri_port_to_match_socke
     ],
 )
 @pytest.mark.parametrize(
+    "redirect_host",
+    [
+        "127.0.0.1",
+        "localhost",
+    ],
+)
+@pytest.mark.parametrize(
+    "redirect_port",
+    [
+        54321,
+        54320,
+    ],
+)
+@pytest.mark.parametrize(
+    "dontwait",
+    ["false", "true"],
+)
+@pytest.mark.parametrize("reuse_port", ["true", "false"])
+def test_auth_callback_server_uses_redirect_uri_port_when_specified(
+    monkeypatch,
+    socket_host,
+    socket_port,
+    redirect_host,
+    redirect_port,
+    dontwait,
+    reuse_port,
+) -> None:
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", reuse_port)
+    monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_MSG_DONTWAIT", dontwait)
+    with AuthHttpServer(
+        uri=f"http://{socket_host}{socket_port}/test_request",
+        redirect_uri=f"http://{redirect_host}:{redirect_port}/test_request",
+    ) as callback_server:
+        assert callback_server.port == redirect_port
+        assert callback_server._redirect_uri.port == redirect_port
+
+
+@pytest.mark.parametrize(
+    "socket_host",
+    [
+        "127.0.0.1",
+        "localhost",
+    ],
+)
+@pytest.mark.parametrize(
+    "socket_port",
+    [
+        "",
+        ":0",
+        ":12345",
+    ],
+)
+@pytest.mark.parametrize(
     "redirect_port",
     [
         "",

--- a/test/unit/test_auth_oauth_auth_code.py
+++ b/test/unit/test_auth_oauth_auth_code.py
@@ -4,7 +4,7 @@
 #
 
 import unittest.mock as mock
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -209,3 +209,69 @@ def test_eligible_for_default_client_credentials_via_constructor(
             assert_initialized_correctly()
     else:
         assert_initialized_correctly()
+
+
+@pytest.mark.parametrize("redirect_uri", ["https://redirect/uri"])
+@pytest.mark.parametrize("rtr_enabled", [True, False])
+def test_auth_oauth_auth_code_uses_redirect_uri(
+    redirect_uri, rtr_enabled: bool, omit_oauth_urls_check
+):
+    """Test that the redirect URI is used correctly in the OAuth authorization code flow."""
+    auth = AuthByOauthCode(
+        "app",
+        "clientId",
+        "clientSecret",
+        "auth_url",
+        "tokenRequestUrl",
+        redirect_uri,
+        "scope",
+        "host",
+        pkce_enabled=False,
+        enable_single_use_refresh_tokens=rtr_enabled,
+    )
+
+    def fake_get_request_token_response(_, fields: dict[str, str]):
+        if rtr_enabled:
+            assert fields.get("enable_single_use_refresh_tokens") == "true"
+        else:
+            assert "enable_single_use_refresh_tokens" not in fields
+        return ("access_token", "refresh_token")
+
+    with patch(
+        "snowflake.connector.auth.AuthByOauthCode._construct_authorization_request",
+        return_value="authorization_request",
+    ) as mock_construct_authorization_request:
+        with patch(
+            "snowflake.connector.auth.AuthByOauthCode._receive_authorization_callback",
+            return_value=("code", auth._state),
+        ):
+            with patch(
+                "snowflake.connector.auth.AuthByOauthCode._ask_authorization_callback_from_user",
+                return_value=("code", auth._state),
+            ):
+                with patch(
+                    "snowflake.connector.auth.AuthByOauthCode._get_request_token_response",
+                    side_effect=fake_get_request_token_response,
+                ) as mock_get_request_token_response:
+                    with patch(
+                        "snowflake.connector.auth._http_server.AuthHttpServer.redirect_uri",
+                        return_value=redirect_uri,
+                        new_callable=PropertyMock,
+                    ):
+                        auth.prepare(
+                            conn=None,
+                            authenticator=OAUTH_AUTHORIZATION_CODE,
+                            service_name=None,
+                            account="acc",
+                            user="user",
+                        )
+                        mock_construct_authorization_request.assert_called_once_with(
+                            redirect_uri
+                        )
+                        assert mock_get_request_token_response.call_count == 1
+                        assert (
+                            mock_get_request_token_response.call_args[0][1][
+                                "redirect_uri"
+                            ]
+                            == redirect_uri
+                        )

--- a/test/unit/test_oauth_token.py
+++ b/test/unit/test_oauth_token.py
@@ -142,6 +142,7 @@ def test_oauth_code_successful_flow(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir / "successful_flow.json"
@@ -184,6 +185,7 @@ def test_oauth_code_invalid_state(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir / "invalid_state_error.json"
@@ -219,6 +221,7 @@ def test_oauth_code_scope_error(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir / "invalid_scope_error.json"
@@ -255,6 +258,7 @@ def test_oauth_code_token_request_error(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     with WiremockClient() as wiremock_client:
         wiremock_client.import_mapping(
@@ -293,6 +297,7 @@ def test_oauth_code_browser_timeout(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir
@@ -334,6 +339,7 @@ def test_oauth_code_custom_urls(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir / "external_idp_custom_urls.json"
@@ -377,6 +383,7 @@ def test_oauth_code_local_application_custom_urls_successful_flow(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_oauth_authorization_code_dir
@@ -421,6 +428,7 @@ def test_oauth_code_successful_refresh_token_flow(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_generic_mappings_dir / "snowflake_login_failed.json"
@@ -481,6 +489,7 @@ def test_oauth_code_expired_refresh_token_flow(
     omit_oauth_urls_check,
 ) -> None:
     monkeypatch.setenv("SNOWFLAKE_AUTH_SOCKET_REUSE_PORT", "true")
+    monkeypatch.setenv("SNOWFLAKE_OAUTH_SOCKET_PORT", "8009")
 
     wiremock_client.import_mapping(
         wiremock_generic_mappings_dir / "snowflake_login_failed.json"
@@ -561,6 +570,10 @@ def test_client_creds_successful_flow(
     wiremock_generic_mappings_dir,
     monkeypatch,
 ) -> None:
+    monkeypatch.setenv(
+        "SNOWFLAKE_OAUTH_SOCKET_PORT", wiremock_client.wiremock_http_port
+    )
+
     wiremock_client.import_mapping(
         wiremock_oauth_client_creds_dir / "successful_flow.json"
     )
@@ -595,6 +608,10 @@ def test_client_creds_token_request_error(
     wiremock_generic_mappings_dir,
     monkeypatch,
 ) -> None:
+    monkeypatch.setenv(
+        "SNOWFLAKE_OAUTH_SOCKET_PORT", wiremock_client.wiremock_http_port
+    )
+
     wiremock_client.import_mapping(
         wiremock_oauth_client_creds_dir / "token_request_error.json"
     )
@@ -634,6 +651,10 @@ def test_client_creds_successful_refresh_token_flow(
     monkeypatch,
     temp_cache,
 ) -> None:
+    monkeypatch.setenv(
+        "SNOWFLAKE_OAUTH_SOCKET_PORT", wiremock_client.wiremock_http_port
+    )
+
     wiremock_client.import_mapping(
         wiremock_generic_mappings_dir / "snowflake_login_failed.json"
     )
@@ -688,6 +709,10 @@ def test_client_creds_expired_refresh_token_flow(
     monkeypatch,
     temp_cache,
 ) -> None:
+    monkeypatch.setenv(
+        "SNOWFLAKE_OAUTH_SOCKET_PORT", wiremock_client.wiremock_http_port
+    )
+
     wiremock_client.import_mapping(
         wiremock_generic_mappings_dir / "snowflake_login_failed.json"
     )


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2396

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Allowing redirect URI to be different from server URI allows users to provide non-localhost redirect URIs (common in cloud IDEs) without preventing the server to start up on localhost.
   - Backwards compatible.
     - Default server URI host is localhost, which is the same as what users used to provide (non-localhost does not work).
     - Server's port is the port in the redirect URI (or random), which is the same as before.
