### PR TITLE
SNOW-2217228 introduce snowflake_version property to connection

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,6 +15,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed a bug where timezoned timestamps fetched as pandas.DataFrame or pyarrow.Table would overflow for the sake of unnecessary precision. In the case where an overflow cannot be prevented a clear error will be raised now.
   - Fix OAuth authenticator values.
   - Add `unsafe_skip_file_permissions_check` flag to skip file permissions check on cache and config.
+  - Introduce snowflake_version property to the connection
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -15,7 +15,7 @@ from concurrent.futures import as_completed
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import suppress
 from difflib import get_close_matches
-from functools import partial
+from functools import cached_property, partial
 from io import StringIO
 from logging import getLogger
 from threading import Lock
@@ -883,6 +883,14 @@ class SnowflakeConnection:
     @property
     def check_arrow_conversion_error_on_every_column(self) -> bool:
         return self._check_arrow_conversion_error_on_every_column
+
+    @cached_property
+    def snowflake_version(self) -> str:
+        # The result from SELECT CURRENT_VERSION() is `<version> <internal hash>`,
+        # and we only need the first part
+        return str(
+            self.cursor().execute("SELECT CURRENT_VERSION()").fetchall()[0][0]
+        ).split(" ")[0]
 
     @check_arrow_conversion_error_on_every_column.setter
     def check_arrow_conversion_error_on_every_column(self, value: bool) -> bool:

--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -1693,3 +1693,27 @@ def test_unsafe_skip_file_permissions_check_skips_config_permissions_check(
     assert (
         len(permission_warnings) == 0
     ), "Expected no permission warning when unsafe_skip_file_permissions_check=True"
+
+
+# The property snowflake_version is newly introduced and therefore should not be tested on old drivers.
+@pytest.mark.skipolddriver
+def test_snowflake_version():
+    import re
+
+    conn = create_connection("default")
+    # Assert that conn has a snowflake_version attribute
+    assert hasattr(
+        conn, "snowflake_version"
+    ), "conn should have a snowflake_version attribute"
+
+    # Assert that conn.snowflake_version is a string.
+    assert isinstance(
+        conn.snowflake_version, str
+    ), f"snowflake_version should be a string, but got {type(conn.snowflake_version)}"
+
+    # Assert that conn.snowflake_version is in the format of "x.y.z", where
+    # x, y and z are numbers.
+    version_pattern = r"^\d+\.\d+\.\d+$"
+    assert re.match(
+        version_pattern, conn.snowflake_version
+    ), f"snowflake_version should match pattern 'x.y.z', but got '{conn.snowflake_version}'"


### PR DESCRIPTION
Some Python sprocs will rely on this property.  Let's make it available to all,  given that it makes sense in regular (non-sproc) sessions as well
- Do not port changes to SP because it is in SP already

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
