### PR TITLE
SNOW-2069227 : Update jira workflows

### DIFF
--- a/.github/workflows/jira_close.yml
+++ b/.github/workflows/jira_close.yml
@@ -8,19 +8,6 @@ jobs:
   close-issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: snowflakedb/gh-actions
-          ref: jira_v1
-          token: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }} # stored in GitHub secrets
-          path: .
-      - name: Jira login
-        uses: atlassian/gajira-login@master
-        env:
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
       - name: Extract issue from title
         id: extract
         env:
@@ -28,8 +15,29 @@ jobs:
         run: |
           jira=$(echo -n $TITLE | awk '{print $1}' | sed -e 's/://')
           echo ::set-output name=jira::$jira
-      - name: Close issue
-        uses: ./jira/gajira-close
+
+      - name: Close Jira Issue
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
-        with:
-          issue: "${{ steps.extract.outputs.jira }}"
+        run: |
+          ISSUE_KEY="${{ steps.extract.outputs.jira }}"
+          JIRA_API_URL="${{ secrets.JIRA_BASE_URL }}/rest/api/2/issue/${ISSUE_KEY}/transitions"
+
+          curl -X POST \
+            --url "$JIRA_API_URL" \
+            --user "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
+            --header "Content-Type: application/json" \
+            --data "{
+              \"update\": {
+                \"comment\": [
+                  { \"add\": { \"body\": \"Closed on GitHub\" } }
+                ]
+              },
+              \"fields\": {
+                \"customfield_12860\": { \"id\": \"11506\" },
+                \"customfield_10800\": { \"id\": \"-1\" },
+                \"customfield_12500\": { \"id\": \"11302\" },
+                \"customfield_12400\": { \"id\": \"-1\" },
+                \"resolution\": { \"name\": \"Done\" }
+              },
+              \"transition\": { \"id\": \"71\" }
+            }"

--- a/.github/workflows/jira_close.yml
+++ b/.github/workflows/jira_close.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Close Jira Issue
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
+        env:
+          ISSUE_KEY: ${{ steps.extract.outputs.jira }}
+          JIRA_API_URL: ${{ secrets.JIRA_BASE_URL }}/rest/api/2/issue/${{ steps.extract.outputs.jira }}/transitions
         run: |
-          ISSUE_KEY="${{ steps.extract.outputs.jira }}"
-          JIRA_API_URL="${{ secrets.JIRA_BASE_URL }}/rest/api/2/issue/${ISSUE_KEY}/transitions"
-
           curl -X POST \
             --url "$JIRA_API_URL" \
             --user "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \

--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -13,38 +13,62 @@ jobs:
       issues: write
     if: ((github.event_name == 'issue_comment' && github.event.comment.body == 'recreate jira' && github.event.comment.user.login == 'sfc-gh-mkeller') || (github.event_name == 'issues' && github.event.pull_request.user.login != 'whitesource-for-github-com[bot]'))
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: snowflakedb/gh-actions
-          ref: jira_v1
-          token: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }} # stored in GitHub secrets
-          path: .
-
-      - name: Login
-        uses: atlassian/gajira-login@v2.0.0
+      - name: Create JIRA Ticket
+        id: create
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          # Escape special characters in title and body
+          TITLE=$(echo '${{ github.event.issue.title }}' | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
+          BODY=$(echo '${{ github.event.issue.body }}' | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
 
-      - name: Create JIRA Ticket
-        id: create
-        uses: atlassian/gajira-create@v3.0.1
-        with:
-          project: SNOW
-          issuetype: Bug
-          summary: '${{ github.event.issue.title }}'
-          description: |
-            ${{ github.event.issue.body }} \\ \\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
-          fields: '{"customfield_11401":{"id":"14723"},"assignee":{"id":"712020:e527ae71-55cc-4e02-9217-1ca4ca8028a2"},"components":[{"id":"16413"}], "labels": ["oss"], "priority": {"id": "10001"} }'
+          # Create JIRA issue using REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+            "$JIRA_BASE_URL/rest/api/2/issue" \
+            -d '{
+              "fields": {
+                "project": {
+                  "key": "SNOW"
+                },
+                "issuetype": {
+                  "name": "Bug"
+                },
+                "summary": "'"$TITLE"'",
+                "description": "'"$BODY"' \\\\ \\\\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}",
+                "customfield_11401": {"id": "14723"},
+                "assignee": {"id": "712020:e527ae71-55cc-4e02-9217-1ca4ca8028a2"},
+                "components": [{"id": "19292"}],
+                "labels": ["oss"],
+                "priority": {"id": "10001"}
+              }
+            }')
+
+          # Extract JIRA issue key from response
+          JIRA_KEY=$(echo "$RESPONSE" | jq -r '.key')
+
+          if [ "$JIRA_KEY" = "null" ] || [ -z "$JIRA_KEY" ]; then
+            echo "Failed to create JIRA issue"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "Created JIRA issue: $JIRA_KEY"
+          echo "jira_key=$JIRA_KEY" >> $GITHUB_OUTPUT
 
       - name: Update GitHub Issue
-        uses: ./jira/gajira-issue-update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          issue_number: "{{ event.issue.id }}"
-          owner: "{{ event.repository.owner.login }}"
-          name: "{{ event.repository.name }}"
-          jira: "${{ steps.create.outputs.issue }}"
+        run: |
+          # Add comment to GitHub issue with JIRA link
+          curl -s -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -d '{
+              "body": "JIRA ticket created: [${{ steps.create.outputs.jira_key }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.jira_key }})"
+            }'


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

Workflows like jira_close.yml use deprecated atlassian JIRA actions and have a dependency on the gh-actions repo. This is not ideal and unecessarily complex.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Updated jira_close workflow to use direct API calls via curl. It preserves custom fields used too.

4. (Optional) PR for stored-proc connector:
