### PR TITLE
SNOW-2229745: Move oauth_type into client_environment

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -17,6 +17,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Add `unsafe_skip_file_permissions_check` flag to skip file permissions check on cache and config.
   - Introduce snowflake_version property to the connection
   - Added basic json support for Interval types.
+  - Moved `OAUTH_TYPE` to `CLIENT_ENVIROMENT`.
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/src/snowflake/connector/auth/_oauth_base.py
+++ b/src/snowflake/connector/auth/_oauth_base.py
@@ -270,7 +270,9 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
         """
         body["data"]["AUTHENTICATOR"] = OAUTH_AUTHENTICATOR
         body["data"]["TOKEN"] = self._access_token
-        body["data"]["OAUTH_TYPE"] = self._get_oauth_type_id()
+        if "CLIENT_ENVIRONMENT" not in body["data"]:
+            body["data"]["CLIENT_ENVIRONMENT"] = {}
+        body["data"]["CLIENT_ENVIRONMENT"]["OAUTH_TYPE"] = self._get_oauth_type_id()
 
     def _do_refresh_token(self, conn: SnowflakeConnection) -> None:
         """If a refresh token is available exchanges it with a new access token.

--- a/test/unit/test_auth_oauth_auth_code.py
+++ b/test/unit/test_auth_oauth_auth_code.py
@@ -39,7 +39,9 @@ def test_auth_oauth_auth_code_oauth_type(omit_oauth_urls_check):
     )
     body = {"data": {}}
     auth.update_body(body)
-    assert body["data"]["OAUTH_TYPE"] == "oauth_authorization_code"
+    assert (
+        body["data"]["CLIENT_ENVIRONMENT"]["OAUTH_TYPE"] == "oauth_authorization_code"
+    )
 
 
 @pytest.mark.parametrize("rtr_enabled", [True, False])

--- a/test/unit/test_oauth_token.py
+++ b/test/unit/test_oauth_token.py
@@ -551,7 +551,9 @@ def test_client_creds_oauth_type():
     )
     body = {"data": {}}
     auth.update_body(body)
-    assert body["data"]["OAUTH_TYPE"] == "oauth_client_credentials"
+    assert (
+        body["data"]["CLIENT_ENVIRONMENT"]["OAUTH_TYPE"] == "oauth_client_credentials"
+    )
 
 
 @pytest.mark.skipolddriver


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-2229745

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Move `OAUTH_TYPE` into `CLIENT_ENVIRONMENT` for login requests.

4. (Optional) PR for stored-proc connector:
