### PR TITLE
Fix wrongly used PATWithExternalSessionAuth

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -18,6 +18,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Introduce snowflake_version property to the connection
   - Added basic json support for Interval types.
   - Moved `OAUTH_TYPE` to `CLIENT_ENVIROMENT`.
+  - Fix bug where PAT with external session authenticator was used while `external_session_id` was not provided in `SnowflakeRestful.fetch`
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -169,7 +169,6 @@ CLIENT_VERSION = CLIENT_VERSION
 PYTHON_CONNECTOR_USER_AGENT = f"{CLIENT_NAME}/{SNOWFLAKE_CONNECTOR_VERSION} ({PLATFORM}) {IMPLEMENTATION}/{PYTHON_VERSION}"
 
 NO_TOKEN = "no-token"
-NO_EXTERNAL_SESSION_ID = "no-external-session-id"
 
 STATUS_TO_EXCEPTION: dict[int, type[Error]] = {
     INTERNAL_SERVER_ERROR: InternalServerError,
@@ -332,7 +331,7 @@ class PATWithExternalSessionAuth(AuthBase):
             del r.headers[HEADER_AUTHORIZATION_KEY]
         if self.token != NO_TOKEN:
             r.headers[HEADER_AUTHORIZATION_KEY] = "Bearer " + self.token
-        if self.external_session_id != NO_EXTERNAL_SESSION_ID:
+        if self.external_session_id:
             r.headers[HEADER_EXTERNAL_SESSION_KEY] = self.external_session_id
         return r
 
@@ -953,7 +952,7 @@ class SnowflakeRestful:
         retry_ctx,
         no_retry: bool = False,
         token=NO_TOKEN,
-        external_session_id=NO_EXTERNAL_SESSION_ID,
+        external_session_id=None,
         **kwargs,
     ):
         conn = self._connection

--- a/test/unit/test_network.py
+++ b/test/unit/test_network.py
@@ -12,7 +12,11 @@ from src.snowflake.connector.network import SnowflakeRestfulJsonEncoder
 
 try:
     from snowflake.connector import Error
-    from snowflake.connector.network import SnowflakeRestful
+    from snowflake.connector.network import (
+        PATWithExternalSessionAuth,
+        SnowflakeAuth,
+        SnowflakeRestful,
+    )
     from snowflake.connector.vendored.requests import HTTPError, Response
 except ImportError:
     # skipping old driver test
@@ -85,3 +89,57 @@ def test_json_serialize_uuid(u):
     assert (json.dumps(u, cls=SnowflakeRestfulJsonEncoder)) == f'"{u}"'
 
     assert json.dumps({"u": u, "a": 42}, cls=SnowflakeRestfulJsonEncoder) == expected
+
+
+def test_fetch_auth():
+    """Test checks that PATWithExternalSessionAuth is used instead of SnowflakeAuth when external_session_id is provided."""
+    connection = mock_connection()
+    rest = SnowflakeRestful(
+        host="test.snowflakecomputing.com", port=443, connection=connection
+    )
+    rest._token = "test-token"
+    rest._master_token = "test-master-token"
+
+    captured_auth = None
+
+    def mock_request(**kwargs):
+        nonlocal captured_auth
+        captured_auth = kwargs.get("auth")
+        mock_response = unittest.mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True}
+        return mock_response
+
+    with unittest.mock.patch(
+        "snowflake.connector.network.requests.Session"
+    ) as mock_session_class:
+        mock_session = unittest.mock.MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_session.request = mock_request
+
+        # Call fetch without providing external_session_id - should use SnowflakeAuth
+        rest.fetch(
+            method="POST",
+            full_url="https://test.snowflakecomputing.com/test",
+            headers={},
+            data={},
+        )
+    assert isinstance(captured_auth, SnowflakeAuth)
+
+    with unittest.mock.patch(
+        "snowflake.connector.network.requests.Session"
+    ) as mock_session_class:
+        mock_session = unittest.mock.MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_session.request = mock_request
+
+        # Call fetch with providing external_session_id - should use PATWithExternalSessionAuth
+        rest.fetch(
+            method="POST",
+            full_url="https://test.snowflakecomputing.com/test",
+            headers={},
+            data={},
+            external_session_id="dummy-external-session-id",
+        )
+    assert isinstance(captured_auth, PATWithExternalSessionAuth)
+    assert captured_auth.external_session_id == "dummy-external-session-id"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2226821

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Unify marking not provided `external_session_id` to None (instead of sometimes None, sometimes `NO_EXTERNAL_SESSION_ID` string) 
