### PR TITLE
Fix bug in AWS sovereign partition support

### DIFF
--- a/test/csp_helpers.py
+++ b/test/csp_helpers.py
@@ -358,9 +358,6 @@ class FakeAwsEnvironment:
     def get_region(self):
         return self.region
 
-    def get_arn(self):
-        return self.arn
-
     def get_credentials(self):
         return self.credentials
 
@@ -401,11 +398,6 @@ class FakeAwsEnvironment:
             mock.patch(
                 "snowflake.connector.wif_util.get_aws_region",
                 side_effect=self.get_region,
-            )
-        )
-        self.patchers.append(
-            mock.patch(
-                "snowflake.connector.wif_util.get_aws_arn", side_effect=self.get_arn
             )
         )
         self.patchers.append(

--- a/test/unit/test_auth_workload_identity.py
+++ b/test/unit/test_auth_workload_identity.py
@@ -15,11 +15,7 @@ from snowflake.connector.vendored.requests.exceptions import (
     HTTPError,
     Timeout,
 )
-from snowflake.connector.wif_util import (
-    AttestationProvider,
-    get_aws_partition,
-    get_aws_sts_hostname,
-)
+from snowflake.connector.wif_util import AttestationProvider, get_aws_sts_hostname
 
 from ..csp_helpers import FakeAwsEnvironment, FakeGceMetadataService, gen_dummy_id_token
 
@@ -129,8 +125,19 @@ def test_explicit_aws_encodes_audience_host_signature_to_api(
     verify_aws_token(data["TOKEN"], fake_aws_environment.region)
 
 
-def test_explicit_aws_uses_regional_hostname(fake_aws_environment: FakeAwsEnvironment):
-    fake_aws_environment.region = "antarctica-northeast-3"
+@pytest.mark.parametrize(
+    "region,expected_hostname",
+    [
+        ("us-east-1", "sts.us-east-1.amazonaws.com"),
+        ("af-south-1", "sts.af-south-1.amazonaws.com"),
+        ("us-gov-west-1", "sts.us-gov-west-1.amazonaws.com"),
+        ("cn-north-1", "sts.cn-north-1.amazonaws.com.cn"),
+    ],
+)
+def test_explicit_aws_uses_regional_hostnames(
+    fake_aws_environment: FakeAwsEnvironment, region: str, expected_hostname: str
+):
+    fake_aws_environment.region = region
 
     auth_class = AuthByWorkloadIdentity(provider=AttestationProvider.AWS)
     auth_class.prepare()
@@ -140,7 +147,6 @@ def test_explicit_aws_uses_regional_hostname(fake_aws_environment: FakeAwsEnviro
     hostname_from_url = urlparse(decoded_token["url"]).hostname
     hostname_from_header = decoded_token["headers"]["Host"]
 
-    expected_hostname = "sts.antarctica-northeast-3.amazonaws.com"
     assert expected_hostname == hostname_from_url
     assert expected_hostname == hostname_from_header
 
@@ -148,49 +154,14 @@ def test_explicit_aws_uses_regional_hostname(fake_aws_environment: FakeAwsEnviro
 def test_explicit_aws_generates_unique_assertion_content(
     fake_aws_environment: FakeAwsEnvironment,
 ):
-    fake_aws_environment.arn = (
-        "arn:aws:sts::123456789:assumed-role/A-Different-Role/i-34afe100cad287fab"
-    )
+    fake_aws_environment.region = "us-east-1"
     auth_class = AuthByWorkloadIdentity(provider=AttestationProvider.AWS)
     auth_class.prepare()
 
     assert (
-        '{"_provider":"AWS","arn":"arn:aws:sts::123456789:assumed-role/A-Different-Role/i-34afe100cad287fab"}'
+        '{"_provider":"AWS","partition":"aws","region":"us-east-1"}'
         == auth_class.assertion_content
     )
-
-
-@pytest.mark.parametrize(
-    "arn, expected_partition",
-    [
-        ("arn:aws:iam::123456789012:role/MyTestRole", "aws"),
-        (
-            "arn:aws-cn:ec2:cn-north-1:987654321098:instance/i-1234567890abcdef0",
-            "aws-cn",
-        ),
-        ("arn:aws-us-gov:s3:::my-gov-bucket", "aws-us-gov"),
-        ("arn:aws:s3:::my-bucket/my/key", "aws"),
-        ("arn:aws:lambda:us-east-1:123456789012:function:my-function", "aws"),
-        ("arn:aws:sns:eu-west-1:111122223333:my-topic", "aws"),
-        ("arn:aws:iam:", "aws"),  # Incomplete ARN, but partition is present
-    ],
-)
-def test_get_aws_partition_valid_arns(arn, expected_partition):
-    assert get_aws_partition(arn) == expected_partition
-
-
-@pytest.mark.parametrize(
-    "arn",
-    [
-        "invalid-arn",
-        "arn::service:region:account:resource",  # Missing partition
-        "",  # Empty string
-    ],
-)
-def test_get_aws_partition_invalid_arns(arn):
-    with pytest.raises(ProgrammingError) as excinfo:
-        get_aws_partition(arn)
-    assert "Invalid AWS ARN" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Our [previous attempt](https://github.com/snowflakedb/snowflake-connector-python/pull/2367) to support AWS sovereign partitions parsed the partition out of the caller's ARN, which required a call to `get_caller_identity()` first. Unfortunately, in non-default partitions, a naive call to `session.client("sts").get_caller_identity()` will use STS in the default partition, rather than the current partition. The only way to fix this is to provide the partition, which would defeat the purpose.

Luckily, we can also extract the partition from the region, which we already have. The region's partition is guaranteed to match the identity's partition when running on AWS. boto provides a library function to extract the partition out of the region.

As a bonus, this removes one more API call from the authentication hot path.

This bug was discovered by @sfc-gh-xizhao when testing the driver on a real AWS VM in a US-GOV region. The fix was validated on that same VM.