### PR TITLE
SNOW-2255664: Populate type_code for interval types in ResultMetadata

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -20,6 +20,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Moved `OAUTH_TYPE` to `CLIENT_ENVIROMENT`.
   - Fix bug where PAT with external session authenticator was used while `external_session_id` was not provided in `SnowflakeRestful.fetch`
   - Added support for parameter `use_vectorized_scanner` in function `write_pandas`.
+  - Populate type_code in ResultMetadata for interval types.
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -183,6 +183,16 @@ FIELD_TYPES: tuple[FieldType, ...] = (
     FieldType(
         name="FILE", dbapi_type=[DBAPI_TYPE_STRING], pa_type=lambda _: pa.string()
     ),
+    FieldType(
+        name="INTERVAL_YEAR_MONTH",
+        dbapi_type=[DBAPI_TYPE_NUMBER],
+        pa_type=lambda _: pa.int64(),
+    ),
+    FieldType(
+        name="INTERVAL_DAY_TIME",
+        dbapi_type=[DBAPI_TYPE_NUMBER],
+        pa_type=lambda _: pa.int64(),
+    ),
 )
 
 FIELD_NAME_TO_ID: DefaultDict[Any, int] = defaultdict(int)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2255664

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Added interval types to FIELD_TYPES tuple.

4. (Optional) PR for stored-proc connector:
