### PR TITLE
SNOW-2047992 Include VCRedist library into Windows wheels and get rid of PyArrow version constraint

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,7 +7,7 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
-- v3.16.1(TBD)
+- v3.17 (TBD)
   - Added new authentication methods support for Workload Identity Federation (WIF).
     - Added the `WORKLOAD_IDENTITY` value for authenticator type.
     - Added the `workload_identity_provider` and `workload_identity_entra_resource` parameters.
@@ -23,6 +23,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Moved `OAUTH_TYPE` to `CLIENT_ENVIROMENT`.
   - Fix bug where PAT with external session authenticator was used while `external_session_id` was not provided in `SnowflakeRestful.fetch`
   - Added support for parameter `use_vectorized_scanner` in function `write_pandas`.
+  - Relaxed `pyarrow` version constraint, versions >= 19 can be used.
 
 - v3.16.0(July 04,2025)
   - Bumped numpy dependency from <2.1.0 to <=2.2.4.

--- a/ci/build_windows.bat
+++ b/ci/build_windows.bat
@@ -36,11 +36,17 @@ EXIT /B %ERRORLEVEL%
 set pv=%~1
 
 echo Going to compile wheel for Python %pv%
-py -%pv% -m pip install --upgrade pip setuptools wheel build
+py -%pv% -m pip install --upgrade pip setuptools wheel build delvewheel
 if %errorlevel% neq 0 goto :error
 
-py -%pv% -m build --wheel .
+py -%pv% -m build --outdir dist\rawwheel --wheel .
 if %errorlevel% neq 0 goto :error
+
+:: patch the wheel by including its dependencies
+py -%pv% -m delvewheel repair -vv -w dist dist\rawwheel\*
+if %errorlevel% neq 0 goto :error
+
+rd /s /q dist\rawwheel
 
 EXIT /B 0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,6 @@ development =
     pytzdata
 pandas =
     pandas>=2.1.2,<3.0.0
-    pyarrow<19.0.0
+    pyarrow
 secure-local-storage =
     keyring>=23.1.0,<26.0.0


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
