### PR TITLE
SNOW-2161716: Fix config file permissions check and skip warning using env variable

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,12 +7,13 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
-- v3.17.2(August 23,2025)
-  - Fixed a bug where platform_detection was retrying failed requests with warnings to non-existent endpoints.
-  - Added disabling endpoint-based platform detection by setting `platform_detection_timeout_seconds` to zero.
+- v3.18(TBD)
   - Enhanced configuration file permission warning messages.
     - Improved warning messages for readable permission issues to include clear instructions on how to skip warnings using the `SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE` environment variable.
 
+- v3.17.2(August 23,2025)
+  - Fixed a bug where platform_detection was retrying failed requests with warnings to non-existent endpoints.
+  - Added disabling endpoint-based platform detection by setting `platform_detection_timeout_seconds` to zero.
 
 - v3.17.1(August 17,2025)
   - Added `infer_schema` parameter to `write_pandas` to perform schema inference on the passed data.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.17.2(August 23,2025)
   - Fixed a bug where platform_detection was retrying failed requests with warnings to non-existent endpoints.
   - Added disabling endpoint-based platform detection by setting `platform_detection_timeout_seconds` to zero.
+  - Enhanced configuration file permission warning messages.
+    - Improved warning messages for readable permission issues to include clear instructions on how to skip warnings using the `SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE` environment variable.
+
 
 - v3.17.1(August 17,2025)
   - Added `infer_schema` parameter to `write_pandas` to perform schema inference on the passed data.

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -30,9 +30,11 @@ READABLE_BY_OTHERS = stat.S_IRGRP | stat.S_IROTH
 WRITABLE_BY_OTHERS = stat.S_IWGRP | stat.S_IWOTH
 
 SKIP_WARNING_ENV_VAR = "SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE"
-SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE = (
-    os.getenv(SKIP_WARNING_ENV_VAR, "false").lower() == "true"
-)
+
+
+def _should_skip_warning_for_read_permissions_on_config_file() -> bool:
+    """Check if the warning should be skipped based on environment variable."""
+    return os.getenv(SKIP_WARNING_ENV_VAR, "false").lower() == "true"
 
 
 class ConfigSliceOptions(NamedTuple):
@@ -363,7 +365,7 @@ class ConfigManager:
             ):
                 chmod_message = f'.\n * To change owner, run `chown $USER "{str(filep)}"`.\n * To restrict permissions, run `chmod 0600 "{str(filep)}"`.\n * To skip this warning, set environment variable {SKIP_WARNING_ENV_VAR}=true.\n'
 
-                if not SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE:
+                if not _should_skip_warning_for_read_permissions_on_config_file():
                     warn(f"Bad owner or permissions on {str(filep)}{chmod_message}")
             LOGGER.debug(f"reading configuration file from {str(filep)}")
             try:

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -27,7 +27,7 @@ _T = TypeVar("_T")
 
 LOGGER = logging.getLogger(__name__)
 READABLE_BY_OTHERS = stat.S_IRGRP | stat.S_IROTH
-WRITABLE_BY_OTHERS = stat.S_IWGRP | stat.S_IWOTH
+
 
 SKIP_WARNING_ENV_VAR = "SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE"
 
@@ -336,18 +336,6 @@ class ConfigManager:
                     f"Fail to read configuration file from {str(filep)} due to no permission on its parent directory"
                 )
                 continue
-
-            # Check for writable by others - this should raise an error
-            if (
-                not IS_WINDOWS  # Skip checking on Windows
-                and sliceoptions.check_permissions  # Skip checking if this file couldn't hold sensitive information
-                and filep.stat().st_mode & WRITABLE_BY_OTHERS != 0
-            ):
-                file_stat = filep.stat()
-                file_permissions = oct(file_stat.st_mode)[-3:]
-                raise ConfigSourceError(
-                    f"file '{str(filep)}' is writable by group or others — this poses a security risk because it allows unauthorized users to modify sensitive settings. Your Permission: {file_permissions}"
-                )
 
             # Check for readable by others or wrong ownership - this should warn
             if (

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -567,7 +567,7 @@ def test_warn_config_file_owner(tmp_path, monkeypatch):
         assert (
             str(c[0].message)
             == f"Bad owner or permissions on {str(c_file)}"
-            + f'.\n * To change owner, run `chown $USER "{str(c_file)}"`.\n * To restrict permissions, run `chmod 0600 "{str(c_file)}"`.\n'
+            + f'.\n * To change owner, run `chown $USER "{str(c_file)}"`.\n * To restrict permissions, run `chmod 0600 "{str(c_file)}"`.\n * To skip this warning, set environment variable SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE=true.\n'
         )
 
 
@@ -587,7 +587,7 @@ def test_warn_config_file_permissions(tmp_path):
     with warnings.catch_warnings(record=True) as c:
         assert c1["b"] is True
     assert len(c) == 1
-    chmod_message = f'.\n * To change owner, run `chown $USER "{str(c_file)}"`.\n * To restrict permissions, run `chmod 0600 "{str(c_file)}"`.\n'
+    chmod_message = f'.\n * To change owner, run `chown $USER "{str(c_file)}"`.\n * To restrict permissions, run `chmod 0600 "{str(c_file)}"`.\n * To skip this warning, set environment variable SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE=true.\n'
     assert (
         str(c[0].message)
         == f"Bad owner or permissions on {str(c_file)}" + chmod_message

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -639,6 +639,55 @@ def test_log_debug_config_file_parent_dir_permissions(tmp_path, caplog):
     shutil.rmtree(tmp_dir)
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="chmod doesn't work on Windows")
+def test_error_config_file_writable_by_others(tmp_path):
+    c_file = tmp_path / "config.toml"
+    c1 = ConfigManager(file_path=c_file, name="root_parser")
+    c1.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c_file.write_text(
+        dedent(
+            """\
+            b = true
+            """
+        )
+    )
+    # Make file writable by others
+    c_file.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IWOTH)
+    file_permissions = oct(c_file.stat().st_mode)[-3:]
+
+    with pytest.raises(
+        ConfigSourceError,
+        match=re.escape(
+            f"file '{str(c_file)}' is writable by group or others — this poses a security risk because it allows unauthorized users to modify sensitive settings. Your Permission: {file_permissions}"
+        ),
+    ):
+        c1["b"]
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="chmod doesn't work on Windows")
+def test_skip_warning_config_file_permissions(tmp_path, monkeypatch):
+    c_file = tmp_path / "config.toml"
+    c1 = ConfigManager(file_path=c_file, name="root_parser")
+    c1.add_option(name="b", parse_str=lambda e: e.lower() == "true")
+    c_file.write_text(
+        dedent(
+            """\
+            b = true
+            """
+        )
+    )
+    # Make file readable by others (would normally trigger warning)
+    c_file.chmod(stat.S_IMODE(c_file.stat().st_mode) | stat.S_IROTH)
+
+    with monkeypatch.context() as m:
+        # Set environment variable to skip warning
+        m.setenv("SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE", "true")
+        with warnings.catch_warnings(record=True) as c:
+            assert c1["b"] is True
+        # Should have no warnings when skip is enabled
+        assert len(c) == 0
+
+
 def test_configoption_missing_root_manager():
     with pytest.raises(
         TypeError,

--- a/test/unit/test_configmanager.py
+++ b/test/unit/test_configmanager.py
@@ -640,31 +640,6 @@ def test_log_debug_config_file_parent_dir_permissions(tmp_path, caplog):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="chmod doesn't work on Windows")
-def test_error_config_file_writable_by_others(tmp_path):
-    c_file = tmp_path / "config.toml"
-    c1 = ConfigManager(file_path=c_file, name="root_parser")
-    c1.add_option(name="b", parse_str=lambda e: e.lower() == "true")
-    c_file.write_text(
-        dedent(
-            """\
-            b = true
-            """
-        )
-    )
-    # Make file writable by others
-    c_file.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IWOTH)
-    file_permissions = oct(c_file.stat().st_mode)[-3:]
-
-    with pytest.raises(
-        ConfigSourceError,
-        match=re.escape(
-            f"file '{str(c_file)}' is writable by group or others — this poses a security risk because it allows unauthorized users to modify sensitive settings. Your Permission: {file_permissions}"
-        ),
-    ):
-        c1["b"]
-
-
-@pytest.mark.skipif(IS_WINDOWS, reason="chmod doesn't work on Windows")
 def test_skip_warning_config_file_permissions(tmp_path, monkeypatch):
     c_file = tmp_path / "config.toml"
     c1 = ConfigManager(file_path=c_file, name="root_parser")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-216171 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

The convention for the connections.toml file permissions is that if the file is writable by others, then an error should be raised. If the file is readable by others, a warning should be printed, with the possibility to skip the warning using an environment variable.

4. (Optional) PR for stored-proc connector:
