### PR TITLE
Freeze pytest-rerunfailures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ development =
     pexpect
     pytest<7.5.0
     pytest-cov
-    pytest-rerunfailures
+    pytest-rerunfailures<16.0
     pytest-timeout
     pytest-xdist
     pytzdata


### PR DESCRIPTION
Freeze `pytest-rerunfailures` dependency on last stable version