### PR TITLE
SNOW-2333702 Fix types for DictCursor

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for intermediate certificates as roots when they are stored in the trust store
   - Bumped up vendored `urllib3` to `2.5.0` and `requests` to `v2.32.5`
   - Dropped support for OpenSSL versions older than 1.1.1
+  - Constrained the types of `fetchone`, `fetchmany`, `fetchall`
+    - As part of this fix, `DictCursor` is no longer a subclass of `SnowflakeCursor`; use `SnowflakeCursorBase` as a superclass of both.
 
 - v3.17.3(September 02,2025)
   - Enhanced configuration file permission warning messages.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for intermediate certificates as roots when they are stored in the trust store
   - Bumped up vendored `urllib3` to `2.5.0` and `requests` to `v2.32.5`
   - Dropped support for OpenSSL versions older than 1.1.1
+  - Fixed the return type of `SnowflakeConnection.cursor(cursor_class)` to match the type of `cursor_class`
   - Constrained the types of `fetchone`, `fetchmany`, `fetchall`
     - As part of this fix, `DictCursor` is no longer a subclass of `SnowflakeCursor`; use `SnowflakeCursorBase` as a superclass of both.
 

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -432,6 +432,7 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
     @property
     @abc.abstractmethod
     def _use_dict_result(self) -> bool: ...
+        """Decides whether results from helper functions are returned as a dict."""
 
     @property
     def description(self) -> list[ResultMetadata]:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -431,8 +431,9 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
 
     @property
     @abc.abstractmethod
-    def _use_dict_result(self) -> bool: ...
+    def _use_dict_result(self) -> bool:
         """Decides whether results from helper functions are returned as a dict."""
+        pass
 
     @property
     def description(self) -> list[ResultMetadata]:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -363,13 +363,11 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
     def __init__(
         self,
         connection: SnowflakeConnection,
-        use_dict_result: bool = False,
     ) -> None:
         """Inits a SnowflakeCursor with a connection.
 
         Args:
             connection: The connection that created this cursor.
-            use_dict_result: Decides whether to use dict result or not.
         """
         self._connection: SnowflakeConnection = connection
 
@@ -404,7 +402,6 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
         self._result: Iterator[tuple] | Iterator[dict] | None = None
         self._result_set: ResultSet | None = None
         self._result_state: ResultState = ResultState.DEFAULT
-        self._use_dict_result = use_dict_result
         self.query: str | None = None
         # TODO: self._query_result_format could be defined as an enum
         self._query_result_format: str | None = None
@@ -1939,6 +1936,10 @@ class SnowflakeCursor(SnowflakeCursorBase[tuple[Any, ...]]):
         is_file_transfer: Whether, or not the current command is a put, or get.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._use_dict_result = False
+
     def fetchone(self) -> tuple[Any, ...] | None:
         row = self._fetchone()
         assert row is None or isinstance(row, tuple)
@@ -1948,11 +1949,9 @@ class SnowflakeCursor(SnowflakeCursorBase[tuple[Any, ...]]):
 class DictCursor(SnowflakeCursorBase[dict[str, Any]]):
     """Cursor returning results in a dictionary."""
 
-    def __init__(self, connection) -> None:
-        super().__init__(
-            connection,
-            use_dict_result=True,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._use_dict_result = True
 
     def fetchone(self) -> dict[str, Any] | None:
         row = self._fetchone()

--- a/test/integ/test_async.py
+++ b/test/integ/test_async.py
@@ -18,8 +18,10 @@ except ImportError:
     QueryStatus = None
 
 
-@pytest.mark.parametrize("cursor_class", [SnowflakeCursor, DictCursor])
-def test_simple_async(conn_cnx, cursor_class):
+@pytest.mark.parametrize(
+    "cursor_class, row_type", [(SnowflakeCursor, tuple), (DictCursor, dict)]
+)
+def test_simple_async(conn_cnx, cursor_class, row_type):
     """Simple test to that shows the most simple usage of fire and forget.
 
     This test also makes sure that wait_until_ready function's sleeping is tested and
@@ -29,7 +31,9 @@ def test_simple_async(conn_cnx, cursor_class):
         with con.cursor(cursor_class) as cur:
             cur.execute_async("select count(*) from table(generator(timeLimit => 5))")
             cur.get_results_from_sfqid(cur.sfqid)
-            assert len(cur.fetchall()) == 1
+            rows = cur.fetchall()
+            assert len(rows) == 1
+            assert isinstance(rows[0], row_type)
             assert cur.rowcount
             assert cur.description
 

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -78,7 +78,7 @@ def test_query_can_be_empty_with_dataframe_ast():
         cursor.execute("", _dataframe_ast="ABCD")
 
 
-@patch("snowflake.connector.cursor.SnowflakeCursor._SnowflakeCursor__cancel_query")
+@patch("snowflake.connector.cursor.SnowflakeCursor._SnowflakeCursorBase__cancel_query")
 def test_cursor_execute_timeout(mockCancelQuery):
     def mock_cmd_query(*args, **kwargs):
         time.sleep(10)


### PR DESCRIPTION
Port PR: https://github.com/snowflakedb/Stored-Proc-Python-Connector/pull/225

On main, the following code shows the following mypy errors:

```
from snowflake.connector import connect, DictCursor

def main() -> None:
    conn = connect()

    c1 = conn.cursor()
    print([row[0] for row in c1.fetchall()])

    c2: DictCursor = conn.cursor(DictCursor)
    print([row["COL1"] for row in c2.fetchall()])
```

- `error: Incompatible types in assignment (expression has type "SnowflakeCursor", variable has type "DictCursor")  [assignment]`
- `error: No overload variant of "__getitem__" of "tuple" matches argument type "str"  [call-overload]`

This change fixes both errors.