### PR TITLE
Environment variable to force browser-based auth

### DIFF
--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -165,15 +165,19 @@ class AuthByWebBrowser(AuthByPlugin):
                 return
 
             print(
-                "Initiating login request with your identity provider. A "
-                "browser window should have opened for you to complete the "
-                "login. If you can't see it, check existing browser windows, "
-                "or your OS settings. Press CTRL+C to abort and try again..."
+                "Initiating login request with your identity provider. Press CTRL+C to abort and try again..."
             )
 
             logger.debug("step 2: open a browser")
             print(f"Going to open: {sso_url} to authenticate...")
             browser_opened = self._webbrowser.open_new(sso_url)
+            if browser_opened:
+                print(
+                    "A browser window should have opened for you to complete the "
+                    "login. If you can't see it, check existing browser windows, "
+                    "or your OS settings."
+                )
+
             if (
                 browser_opened
                 or os.getenv("SNOWFLAKE_FORCE_AUTH_SERVER", "False").lower() == "true"

--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -173,7 +173,14 @@ class AuthByWebBrowser(AuthByPlugin):
 
             logger.debug("step 2: open a browser")
             print(f"Going to open: {sso_url} to authenticate...")
-            if not self._webbrowser.open_new(sso_url):
+            browser_opened = self._webbrowser.open_new(sso_url)
+            if (
+                browser_opened
+                or os.getenv("SNOWFLAKE_FORCE_AUTH_SERVER", "False").lower() == "true"
+            ):
+                logger.debug("step 3: accept SAML token")
+                self._receive_saml_token(conn, socket_connection)
+            else:
                 print(
                     "We were unable to open a browser window for you, "
                     "please open the url above manually then paste the "
@@ -195,9 +202,6 @@ class AuthByWebBrowser(AuthByPlugin):
                         },
                     )
                     return
-            else:
-                logger.debug("step 3: accept SAML token")
-                self._receive_saml_token(conn, socket_connection)
         finally:
             socket_connection.close()
 


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Addresses #2537. It's not the optimal solution IMO (as it still requires a port-forward / network access), but is minimally invasive.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

An interactive console isn't always available, and we can't open a browser from inside docker. However, if the `SNOWFLAKE_FORCE_AUTH_SERVER` is set, we'll ignore browser-open failures, and listen for the token anyways.
