### PR TITLE
SNOW-2350569 remove upper cffi pin

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed `get_results_from_sfqid` when using `DictCursor` and executing multiple statements at once
   - Added the `oauth_credentials_in_body` parameter supporting an option to send the oauth client credentials in the request body
   - Added support for intermediate certificates as roots when they are stored in the trust store
+  - Removed upper pin from `cffi` package to reinstate compatibility with newer `cryptography` packages
 
 - v3.17.3(September 02,2025)
   - Enhanced configuration file permission warning messages.

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     asn1crypto>0.24.0,<2.0.0
     boto3>=1.24
     botocore>=1.24
-    cffi>=1.9,<2.0.0
+    cffi>=1.9
     cryptography>=3.1.0
     pyOpenSSL>=22.0.0,<26.0.0
     pyjwt<3.0.0


### PR DESCRIPTION
### Description 

   Addresses https://github.com/snowflakedb/snowflake-connector-python/issues/2541. 
   
   `cffi` was pinned to `<2` in https://github.com/snowflakedb/snowflake-connector-python/commit/7c2653f9b0b300c2e705f178bdbaa54aed9f5e58 , 6 years ago. However in the linked jira or any other docs and other jiras associated with them, could not really find context why this pin was necessary.

   Now with the release of `cryptography==46.0.1` they require `cffi>=2.0.0` which makes impossible to install the Snowflake Python driver together with this version of `cryptography`. 

  This PR aims to remove the upper `cffi` bind as it apparently not even semantically versioned (unconfirmed). 

