### PR TITLE
Fix Jenkins build

### DIFF
--- a/test/integ/test_dbapi.py
+++ b/test/integ/test_dbapi.py
@@ -857,7 +857,8 @@ def test_callproc_invalid(conn_cnx):
             # stored procedure does not exist
             with pytest.raises(errors.ProgrammingError) as pe:
                 cur.callproc(name_sp)
-            assert pe.value.errno == 2140
+            # this value might differ between Snowflake environments
+            assert pe.value.errno in [2140, 2139]
 
             cur.execute(
                 f"""


### PR DESCRIPTION
Newest bptp-stable seem to change error sent as a response to invalid stored procedure call, yet it remains unchanged for prod. This PR adjusts test assertion