### PR TITLE
SNOW-2329031: revert exception type for Oauth authenticator

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added the `oauth_credentials_in_body` parameter supporting an option to send the oauth client credentials in the request body
   - Fix retry behavior for `ECONNRESET` error
   - Added an option to exclude `botocore` and `boto3` dependencies by setting `SNOWFLAKE_NO_BOTO` environment variable during installation
+  - Revert changing exception type in case of token expired scenario for `Oauth` authenticator back to `DatabaseError`
 
 - v3.17.4(September 22,2025)
   - Added support for intermediate certificates as roots when they are stored in the trust store

--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -58,6 +58,7 @@ from ..sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 from ..token_cache import TokenCache, TokenKey, TokenType
 from ..version import VERSION
 from .no_auth import AuthNoAuth
+from .oauth import AuthByOAuth
 
 if TYPE_CHECKING:
     from . import AuthByPlugin
@@ -373,7 +374,11 @@ class Auth:
                         sqlstate=SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
                     )
                 )
-            elif errno == OAUTH_ACCESS_TOKEN_EXPIRED_GS_CODE:
+            elif (errno == OAUTH_ACCESS_TOKEN_EXPIRED_GS_CODE) and (
+                # SNOW-2329031: OAuth v1.0 does not support token renewal,
+                # for backward compatibility, we do not raise an exception here
+                not isinstance(auth_instance, AuthByOAuth)
+            ):
                 raise ReauthenticationRequest(
                     ProgrammingError(
                         msg=ret["message"],

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -18,11 +18,24 @@ from snowflake.connector.network import SnowflakeRestful
 from .mock_utils import mock_connection
 
 try:  # pragma: no cover
-    from snowflake.connector.auth import Auth, AuthByDefault, AuthByPlugin
+    from snowflake.connector.auth import (
+        Auth,
+        AuthByDefault,
+        AuthByOAuth,
+        AuthByOauthCode,
+        AuthByOauthCredentials,
+        AuthByPlugin,
+    )
 except ImportError:
     from snowflake.connector.auth import Auth
     from snowflake.connector.auth_by_plugin import AuthByPlugin
     from snowflake.connector.auth_default import AuthByDefault
+    from snowflake.connector.auth_oauth import AuthByOAuth
+    from snowflake.connector.auth_oauth_code import AuthByOauthCode
+    from snowflake.connector.auth_oauth_credentials import AuthByOauthCredentials
+
+from snowflake.connector.errors import DatabaseError
+from snowflake.connector.network import ReauthenticationRequest
 
 
 def _init_rest(application, post_requset):
@@ -354,3 +367,65 @@ def test_auth_by_default_prepare_body_does_not_overwrite_client_environment_fiel
             for k in req_body_before["data"]["CLIENT_ENVIRONMENT"]
         ]
     )
+
+
+def _mock_oauth_token_expired_rest_response(url, headers, body, **kwargs):
+    """Mock rest response for OAuth access token expired error."""
+    from snowflake.connector.network import OAUTH_ACCESS_TOKEN_EXPIRED_GS_CODE
+
+    return {
+        "success": False,
+        "message": "OAuth access token expired",
+        "code": OAUTH_ACCESS_TOKEN_EXPIRED_GS_CODE,
+        "data": {},
+    }
+
+
+@pytest.mark.skipolddriver
+@pytest.mark.parametrize(
+    "auth_instance, expected_exc_type",
+    [
+        (AuthByOAuth("test_oauth_token"), DatabaseError),
+        (
+            AuthByOauthCode(
+                application="testapp",
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                authentication_url="https://auth.example.com",
+                token_request_url="https://token.example.com",
+                redirect_uri="http://localhost:8080",
+                scope="session:role-any",
+                host="testaccount.snowflakecomputing.com",
+            ),
+            ReauthenticationRequest,
+        ),
+        (
+            AuthByOauthCredentials(
+                application="testapp",
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                token_request_url="https://token.example.com",
+                scope="session:role-any",
+            ),
+            ReauthenticationRequest,
+        ),
+    ],
+)
+def test_oauth_token_expired_error_handling(auth_instance, expected_exc_type):
+    """Test that OAuth authenticators handle token expiry errors differently.
+
+    - AuthByOAuth should raise DatabaseError (falls through to general error handling)
+    - AuthByOauthCode and AuthByOauthCredentials should raise ProgrammingError (via ReauthenticationRequest)
+    """
+
+    def mock_errorhandler_always_raise(connection, cursor, error_class, error_value):
+        raise error_class(**error_value)
+
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    rest = _init_rest(application, _mock_oauth_token_expired_rest_response)
+    rest._connection.errorhandler = mock_errorhandler_always_raise
+    auth = Auth(rest)
+    with pytest.raises(expected_exc_type):
+        auth.authenticate(auth_instance, account, user)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-2329031

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   During Oauth v2.0 implementation in #2135 introduced a breaking change(changing an exception type) for old authenticator. This PR reverts that to old behavior for backwards compatibility

4. (Optional) PR for stored-proc connector:
