### PR TITLE
SNOW-2306340: Add pki-oversight as a joint owner for PKI-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @snowflakedb/snow-drivers-warsaw
+/src/snowflake/connector/ocsp_* @snowflakedb/pki-oversight @snowflakedb/snow-drivers-warsaw
+/src/snowflake/connector/crl.py @snowflakedb/pki-oversight @snowflakedb/snow-drivers-warsaw
+/src/snowflake/connector/crl_cache.py @snowflakedb/pki-oversight @snowflakedb/snow-drivers-warsaw
+/src/snowflake/connector/ssl_wrap_socket.py @snowflakedb/pki-oversight @snowflakedb/snow-drivers-warsaw


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2306340

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add @snowflakedb/pki-oversight to all PKI-related files. Similar to https://github.com/snowflakedb/gosnowflake/pull/1581.

4. (Optional) PR for stored-proc connector:
