### PR TITLE
Fixup Jenkins build

### DIFF
--- a/src/snowflake/connector/crl.py
+++ b/src/snowflake/connector/crl.py
@@ -63,7 +63,7 @@ class CRLConfig:
     crl_cache_dir: Path | str | None = None
     crl_cache_removal_delay_days: int = 7
     crl_cache_cleanup_interval_hours: int = 1
-    crl_cache_start_cleanup: bool = True
+    crl_cache_start_cleanup: bool = False
 
     @classmethod
     def from_connection(cls, sf_connection) -> CRLConfig:


### PR DESCRIPTION
CRL cache tests were spawning additional process which was never killed and caused Jenkins build to become idle and timing out. This is a quick workaround, to be properly handled in future

Build with CRL tests without change (`pczajka_debug_jenkins~1`): https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/view/PythonConnector/job/RT-PyConnector310-Mac64/811
Build with CRL tests with the change (`pczajka_debug_jenkins`): https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/view/PythonConnector/job/RT-PyConnector310-Mac64/812