### PR TITLE
Pin lower dependencies

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added the `SNOWFLAKE_AUTH_FORCE_SERVER` environment variable to force the use of the local-listening server when using the `externalbrowser` auth method.
     - This allows headless environments (like Docker or Airflow) running locally to auth via a browser URL.
   - Fix compilation error when building from sources with libc++.
+  - Pin lower versions of dependencies to oldest version without vulnerabilities.
 
 - v4.0.0(October 09,2025)
   - Added support for checking certificates revocation using revocation lists (CRLs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,16 +46,16 @@ install_requires =
     # [boto] extension is added by default unless SNOWFLAKE_NO_BOTO variable is set
     # check setup.py
     asn1crypto>0.24.0,<2.0.0
-    cryptography>=3.1.0
-    pyOpenSSL>=22.0.0,<26.0.0
-    pyjwt<3.0.0
+    cryptography>=44.0.1
+    pyOpenSSL>=24.0.0,<26.0.0
+    pyjwt>=2.10.1,<3.0.0
     pytz
-    requests<3.0.0
+    requests>=2.32.4,<3.0.0
     packaging
     charset_normalizer>=2,<4
-    idna>=2.5,<4
-    urllib3>=1.21.1,<2.0.0; python_version < '3.10'
-    certifi>=2017.4.17
+    idna>=3.7,<4
+    urllib3>=1.26.5,<2.0.0; python_version < '3.10'
+    certifi>=2024.7.4
     typing_extensions>=4.3,<5
     filelock>=3.5,<4
     sortedcontainers>=2.4.0
@@ -97,6 +97,6 @@ development =
     responses
 pandas =
     pandas>=2.1.2,<3.0.0
-    pyarrow
+    pyarrow>=14.0.1
 secure-local-storage =
     keyring>=23.1.0,<26.0.0


### PR DESCRIPTION
Pin lower dependencies version to oldest non-vulnerable version according to snyk (https://security.snyk.io/package/pip/cryptography/versions?page=1)
