### PR TITLE
feat: [SNOW-2466332] do not require user when using OAUTH_CLIENT_CRED…

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fix compilation error when building from sources with libc++.
   - Pin lower versions of dependencies to oldest version without vulnerabilities.
   - Added no_proxy parameter for proxy configuration without using environmental variables.
+  - Added OAUTH_AUTHORIZATION_CODE and OAUTH_CLIENT_CREDENTIALS to list of authenticators that don't require user to be set
 
 - v4.0.0(October 09,2025)
   - Added support for checking certificates revocation using revocation lists (CRLs)

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -1694,6 +1694,8 @@ class SnowflakeConnection:
             WORKLOAD_IDENTITY_AUTHENTICATOR,
             PROGRAMMATIC_ACCESS_TOKEN,
             PAT_WITH_EXTERNAL_SESSION,
+            OAUTH_AUTHORIZATION_CODE,
+            OAUTH_CLIENT_CREDENTIALS,
         }
 
         if not (self._master_token and self._session_token):

--- a/test/unit/test_auth_oauth_auth_code.py
+++ b/test/unit/test_auth_oauth_auth_code.py
@@ -285,3 +285,46 @@ def test_oauth_authorization_code_authenticator_is_case_insensitive(
     assert isinstance(conn.auth_class, AuthByOauthCode)
 
     conn.close()
+
+
+@pytest.mark.skipolddriver
+def test_oauth_authorization_code_allows_empty_user(monkeypatch, omit_oauth_urls_check):
+    """Test that OAUTH_AUTHORIZATION_CODE authenticator allows connection without user parameter."""
+    import snowflake.connector
+
+    def mock_post_request(self, url, headers, json_body, **kwargs):
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+                "idToken": None,
+                "parameters": [{"name": "SERVICE_NAME", "value": "FAKE_SERVICE_NAME"}],
+            },
+        }
+
+    monkeypatch.setattr(
+        snowflake.connector.network.SnowflakeRestful, "_post_request", mock_post_request
+    )
+
+    # Mock the OAuth authorization flow to avoid opening browser and starting HTTP server
+    def mock_request_tokens(self, **kwargs):
+        # Simulate successful token retrieval
+        return ("mock_access_token", "mock_refresh_token")
+
+    monkeypatch.setattr(AuthByOauthCode, "_request_tokens", mock_request_tokens)
+
+    # Test connection without user parameter - should succeed
+    conn = snowflake.connector.connect(
+        account="testaccount",
+        authenticator="OAUTH_AUTHORIZATION_CODE",
+        oauth_client_id="test_client_id",
+        oauth_client_secret="test_client_secret",
+    )
+
+    # Verify that the connection was successful
+    assert conn is not None
+    assert isinstance(conn.auth_class, AuthByOauthCode)
+
+    conn.close()


### PR DESCRIPTION
…ENTIALS and OAUTH_AUTHORIZATION_CODE authenticators

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   None, tracked in SNOW-2466332

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We want to simplify minimal setup for newer OAUTH based authenticators, where user needs to provide username in browser as well. Such change has already been implemented in [node driver](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/4bbd094494365a169dbe22642e566e985e833513/lib/connection/connection_config.js#L206-L207)

4. (Optional) PR for stored-proc connector:
