### PR TITLE
SNOW-1759084: Adjust aio telemetry events

### DIFF
--- a/src/snowflake/connector/aio/_network.py
+++ b/src/snowflake/connector/aio/_network.py
@@ -178,6 +178,8 @@ class SnowflakeRestful(SnowflakeRestfulSync):
         _include_retry_params: bool = False,
         _no_retry: bool = False,
     ):
+        # log to reflect vendored.urllib3.connectionpool:connectionpool.py:474
+        logger.debug("%s %s", method.upper(), url)
         if body is None:
             body = {}
         if self.master_token is None and self.token is None:

--- a/src/snowflake/connector/aio/_result_set.py
+++ b/src/snowflake/connector/aio/_result_set.py
@@ -103,8 +103,7 @@ class ResultSetIterator:
                         item,
                     )
             rets.extend(batch)
-            # yield to avoid blocking the event loop for too long when processing large result sets
-            # await asyncio.sleep(0)
+        await self._final()
         return rets
 
     async def generator(self):
@@ -285,7 +284,6 @@ class ResultSet(ResultSetSync):
 
     async def _report_metrics(self) -> None:
         """Report metrics for the result set."""
-        # TODO: SNOW-1572217 async telemetry
         """Report all metrics totalled up.
 
         This includes TIME_CONSUME_LAST_RESULT, TIME_DOWNLOADING_CHUNKS and

--- a/test/integ/aio_it/test_connection_async.py
+++ b/test/integ/aio_it/test_connection_async.py
@@ -1408,9 +1408,7 @@ async def test_mock_non_existing_server(conn_cnx, caplog):
         )
 
 
-@pytest.mark.xfail(
-    reason="TODO: SNOW-1759084 await anext(self._generator, None) does not execute code after yield"
-)
+@pytest.mark.skipolddriver
 async def test_disable_telemetry(conn_cnx, caplog):
     # default behavior, closing connection, it will send telemetry
     with caplog.at_level(logging.DEBUG):
@@ -1419,7 +1417,7 @@ async def test_disable_telemetry(conn_cnx, caplog):
                 await (await cur.execute("select 1")).fetchall()
             assert (
                 len(conn._telemetry._log_batch) == 3
-            )  # 3 events are `import package`, `fetch first`, it's missing `fetch last` because of SNOW-1759084
+            )  # 3 events are `import package`, `fetch first`, `fetch last`
 
     assert "POST /telemetry/send" in caplog.text
     caplog.clear()


### PR DESCRIPTION
There's a difference in `fetchall` implementation between sync and aio code. In sync code the `fetchall` calls `fetchone` under the hood. In AIO code the implementation is different and as a result does not call `_report_metrics` after fetching all result.