### PR TITLE
Auto close SAML auth success tab after 10 seconds

### DIFF
--- a/src/snowflake/connector/auth/webbrowser.py
+++ b/src/snowflake/connector/auth/webbrowser.py
@@ -353,7 +353,7 @@ class AuthByWebBrowser(AuthByPlugin):
             msg = f"""
 <!DOCTYPE html><html><head><meta charset="UTF-8"/>
 <link rel="icon" href="data:,">
-<title>SAML Response for Snowflake</title></head>
+<title>SAML Response for Snowflake</title><script>window.setTimeout(() => window.close(), 10000);</script></head>
 <body>
 Your identity was confirmed and propagated to Snowflake {self._application}.
 You can close this window now and go back where you started from.


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2635

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [X ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Adds a single line of javascript to auto close the external browser auth window after 10s.

