### PR TITLE
SNOW-2483517 avoid test build recipe issue with recently available GCC 15.x.x

### DIFF
--- a/ci/anaconda/recipe/meta.yaml
+++ b/ci/anaconda/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - libgcc-ng
-    - libstdcxx-ng
+    - libgcc-ng <15.0.0
+    - libstdcxx-ng <15.0.0
     - patch     # [not win]
   host:
     - setuptools >=40.6.0


### PR DESCRIPTION

(Test-only) Use GCC < 15.0.0 because GCC 15.0.0+ will force some C++ symbol check, causing nano arrow fail to build

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
