### PR TITLE
SNOW-2688693: fixed on_error parameter passing in write_pandas

### DIFF
--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -592,11 +592,10 @@ def write_pandas(
             f"{' BINARY_AS_TEXT=FALSE' if auto_create_table or overwrite or infer_schema else ''}"
             f"{sql_use_logical_type}"
             f") "
-            f"PURGE=TRUE ON_ERROR=?"
+            f"PURGE=TRUE ON_ERROR='{on_error}'"
         )
         params = (
             target_table_location,
-            on_error,
         )
         logger.debug(f"copying into with '{copy_into_sql}'. params: %s", params)
         copy_results = cursor.execute(


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2638.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously, the `on_error` parameter to the `COPY INTO` statement in `write_pandas` was passed via qmark style parameters. If there is an error in the `COPY INTO` command, instead of the actual error returning to the caller, we get `invalid value [?] for parameter 'ON_ERROR'`. I.e., there is an error passing the parameter to the statement.

   All other parameters except for table name are passed in via string interpolation, and this PR changes the `on_error` parameter to be passed via string interpolation as well. After this change, the actual underlying error is passed back to the caller.

4. (Optional) PR for stored-proc connector: