### PR TITLE
Fix Python 3.13+ TypeError by decoding bytes URLs in storage client

### DIFF
--- a/src/snowflake/connector/session_manager.py
+++ b/src/snowflake/connector/session_manager.py
@@ -491,6 +491,7 @@ class SessionManager(_RequestVerbsUsingSessionMixin, _HttpConfigDirectAccessMixi
         """
         'url' is an obligatory parameter due to the need for correct proxy handling (i.e. bypassing caused by no_proxy settings).
         """
+        url = url.decode('utf-8') if isinstance(url, bytes) else url
         use_pooling = use_pooling if use_pooling is not None else self.use_pooling
         if not use_pooling:
             session = self.make_session(url=url)

--- a/src/snowflake/connector/storage_client.py
+++ b/src/snowflake/connector/storage_client.py
@@ -286,7 +286,6 @@ class SnowflakeStorageClient(ABC):
             logger.debug(f"retry #{self.retry_count[retry_id]}")
             cur_timestamp = self.credentials.timestamp
             url, rest_kwargs = get_request_args()
-            url = url.decode('utf-8') if isinstance(url, bytes) else url
             rest_kwargs["timeout"] = (REQUEST_CONNECTION_TIMEOUT, REQUEST_READ_TIMEOUT)
             try:
                 if conn:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   No relevant GH issue.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Fixes a TypeError that occurs on Python 3.13+ when performing PUT file operations. The storage client generates URLs as bytes, but the session manager (and vendored requests library) expects strings. Python 3.13's stricter type enforcement for string concatenation exposes this mismatch.

The fix decodes bytes URLs to UTF-8 strings before passing them to `use_session()`, ensuring type consistency across the request pipeline while maintaining backward compatibility with string URLs.

Note: This issue is specific to the [LocalStack Snowflake emulator](https://www.localstack.cloud/localstack-for-snowflake) environment and is not reproducible with real Snowflake services. However, the fix improves type safety and ensures proper adherence to the `use_session()` type contract (which expects `str`, not `bytes`).

4. (Optional) PR for stored-proc connector:
