### PR TITLE
Make test build script compatible with newer pip

### DIFF
--- a/ci/anaconda/recipe/meta.yaml
+++ b/ci/anaconda/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
     - export ENABLE_EXT_MODULES=true             # [unix]
-    - {{ PYTHON }} -m pip install . --no-use-pep517 --no-deps -vvv
+    - {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vvv
   entry_points:
     - snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
     - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main


### PR DESCRIPTION
- The new pip (25.3) is available now. It fully removes support for -no-use-pep517`, but nano arrow build replies on it.
- We take Anaconda's strategy by changing `-no-use-pep517` to `--no-build-isolation`

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
