### PR TITLE
NO-SNOW fix jira creation

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -19,25 +19,30 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           # debug
           set -x
           # Escape special characters in title and body
           TITLE=$(echo '${{ github.event.issue.title }}' | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
-          BODY=$(echo '${{ github.event.issue.body }}' | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
-          DESCRIPTION="$BODY\\n\\n_Created from GitHub Action_ for $ISSUE_URL"
+
+          read -r -d '' TMP_BODY <<'EOF'
+          ${{ github.event.issue.body }}
+
+
+          _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
+          EOF
+
+          BODY=$(echo "$TMP_BODY" | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
+
           PAYLOAD=$(jq -n \
           --arg issuetitle "$TITLE" \
           --arg issuebody "$BODY" \
-          --arg issueurl "$ISSUE_URL" \
-          --arg description "$DESCRIPTION" \
           '{
             fields: {
               project: { key: "SNOW" },
               issuetype: { name: "Bug" },
               summary: $issuetitle,
-              description: $description,
+              description: $issuebody,
               customfield_11401: { id: "14723" },
               assignee: { id: "712020:e527ae71-55cc-4e02-9217-1ca4ca8028a2" },
               components: [{ id: "16413" }],


### PR DESCRIPTION
### Description 
Still no code was changed. Continuation of https://github.com/snowflakedb/snowflake-connector-python/pull/2687 ; closure works now.

Adding debug allowed to see where we crashing
```
-bash: command substitution: line 36: syntax error near unexpected token `('
-bash: command substitution: line 36: `      ch.setFormatter(logging.Formatter('%(asctime)s - %(threadName)s %(filename)s:%(lineno)d - %(funcName)s() - %(levelname)s - %(message)s'))'
```

which is the 'add logs' field; so trying to cram it in a heredoc, worked locally. 