### PR TITLE
Fix doc that indicates JSON temporary credential is encrypted

### DIFF
--- a/src/snowflake/connector/token_cache.py
+++ b/src/snowflake/connector/token_cache.py
@@ -69,7 +69,7 @@ class TokenCache(ABC):
 
     Platform-specific implementations:
     - macOS/Windows: Uses OS keyring (Keychain/Credential Manager) via 'keyring' library
-    - Linux: Uses encrypted JSON file in ~/.cache/snowflake/ with 0o600 permissions
+    - Linux: Uses JSON file in ~/.cache/snowflake/ with 0o600 permissions
     - Fallback: NoopTokenCache (no caching) if secure storage unavailable
 
     Tokens are keyed by (host, user, token_type) to support multiple accounts.


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

I just put up this issue.

   Fixes #2768

This is just a docstring fix

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fixing a doc string that indicates that the JSON file that is created for the temporary credential is encrypted. I could be wrong but I don't see anything in the code that encrypts that file. The file is a readable JSON file. The doc string was written in [this PR](https://github.com/snowflakedb/snowflake-connector-python/pull/2626)

4. (Optional) PR for stored-proc connector:
