### PR TITLE
NO-SNOW: Fix duplicate artifact names in build matrix causing CI failures

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       test_matrix: ${{ steps.test_matrix.outputs.test_matrix }}
+      build_matrix: ${{ steps.test_matrix.outputs.build_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -47,11 +48,13 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Using full matrix"
-            echo "test_matrix=$(jq -c . < ./.github/workflows/generated_full_matrix.json)" >> "$GITHUB_OUTPUT"
+            MATRIX=$(jq -c . < ./.github/workflows/generated_full_matrix.json)
           else
             echo "Using PR matrix"
-            echo "test_matrix=$(jq -c . < ./.github/workflows/generated_pr_matrix.json)" >> "$GITHUB_OUTPUT"
+            MATRIX=$(jq -c . < ./.github/workflows/generated_pr_matrix.json)
           fi
+          echo "test_matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$(echo "$MATRIX" | jq -c '[group_by(.os_download_name, .["python-version"]) | .[] | first]')" >> "$GITHUB_OUTPUT"
   lint:
     name: Check linting
     runs-on: ubuntu-latest
@@ -100,12 +103,8 @@ jobs:
     needs: [lint, define-matrix]
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.define-matrix.outputs.test_matrix) }}
+        include: ${{ fromJSON(needs.define-matrix.outputs.build_matrix) }}
     name: Build ${{ matrix.os_download_name }}-py${{ matrix.python-version }}
-    # Build is independent of cloud-provider, so we only run it once per (os, python) combo.
-    # Without this, multiple matrix entries would try to upload artifacts with the same name,
-    # causing 409 Conflict errors on workflow re-runs.
-    if: ${{ matrix.cloud-provider == 'aws' }}
     runs-on: ${{ matrix.os_image_name }}
     steps:
       - name: Set shortver


### PR DESCRIPTION
The build job reuses the test matrix which includes cloud-provider, but builds are cloud-provider independent. This results in multiple jobs trying to upload artifacts with the same name, causing 409 Conflict errors on workflow re-runs. Skip non-aws build entries since only one build per (os, python) combo is needed.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
