### PR TITLE
Snow-2684150: Fix pyarrow sdist build failure in pandas CI environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,9 @@ setenv =
     integ: SNOWFLAKE_TEST_TYPE = integ
     single: SNOWFLAKE_TEST_TYPE = single
     parallel: SNOWFLAKE_PYTEST_OPTS = {env:SNOWFLAKE_PYTEST_OPTS:} -n auto
+    # pyarrow (and pandas) ship cp313/cp314 wheels on PyPI but the CI runner's pip
+    # downloads the sdist instead, then fails the CMake build (missing Arrow C++ libs).
+    # PIP_PREFER_BINARY=1 forces pip to pick the pre-built wheel over the sdist.
     pandas: PIP_PREFER_BINARY = 1
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ setenv =
     integ: SNOWFLAKE_TEST_TYPE = integ
     single: SNOWFLAKE_TEST_TYPE = single
     parallel: SNOWFLAKE_PYTEST_OPTS = {env:SNOWFLAKE_PYTEST_OPTS:} -n auto
+    pandas: PIP_PREFER_BINARY = 1
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
     SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.connector --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=


### PR DESCRIPTION
Set PIP_PREFER_BINARY=1 for pandas tox factor so pip selects pre-built wheels for pyarrow (and pandas) instead of falling back to source builds. The CI runner's pip was downloading pyarrow-23.0.1.tar.gz and failing at the CMake step (missing Arrow C++ libraries) despite cp313/cp314 wheels being available on PyPI. Affects py313-pandas-parallel-ci and py314-pandas-parallel-ci.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

4. (Optional) PR for stored-proc connector:
