### PR TITLE
NO-SNOW: Add 10-minute per-test timeout to CI for observability

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ extras =
 package = wheel
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
-    ci: SNOWFLAKE_PYTEST_OPTS = -vvv
+    ci: SNOWFLAKE_PYTEST_OPTS = -vvv --timeout 600
     # Set test type, either notset, unit, integ, or both
     unit-integ: SNOWFLAKE_TEST_TYPE = (unit or integ)
     !unit-!integ: SNOWFLAKE_TEST_TYPE = (unit or integ)


### PR DESCRIPTION
Baseline run from main with only --timeout 600 added. No other changes. Compares against the rerunfailures fix branch to isolate whether the timeout alone prevents hangs or if the pytest_unconfigure fix is needed.

Made with [Cursor](https://cursor.com)