### PR TITLE
[SNOW-3296990] fix spcs token related flow for python driver

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -11,6 +11,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added HTTP 307/308 redirect status codes to the retryable set as defense-in-depth, with redirect-aware logging in both sync and async paths.
   - Consolidated keyring token cache to use a single service name with hashed account keys, reducing macOS Keychain password prompts. Legacy entries are auto-migrated on first read.
   - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
+  - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
 
 - v4.4.0(March 25,2026)
   - Bump the lower boundary of cryptography to 46.0.5 due to CVE-2026-26007.

--- a/src/snowflake/connector/_utils.py
+++ b/src/snowflake/connector/_utils.py
@@ -109,30 +109,29 @@ def get_application_path() -> str:
         return "unknown"
 
 
-_SPCS_TOKEN_ENV_VAR_NAME = "SF_SPCS_TOKEN_PATH"
-_SPCS_TOKEN_DEFAULT_PATH = "/snowflake/session/spcs_token"
+_SPCS_ENV_VAR = "SNOWFLAKE_RUNNING_INSIDE_SPCS"
+_SPCS_TOKEN_PATH = "/snowflake/session/spcs_token"
 
 
 def get_spcs_token() -> str | None:
-    """Return the SPCS token read from the configured path, or None.
+    """Return the SPCS token if running inside an SPCS container, or None.
 
-    The path is determined by the SF_SPCS_TOKEN_PATH environment variable,
-    falling back to ``/snowflake/session/spcs_token`` when unset.
+    The token is only read when the SNOWFLAKE_RUNNING_INSIDE_SPCS environment
+    variable is set.  The file at /snowflake/session/spcs_token is read as
+    UTF-8 text and leading/trailing whitespace is stripped.
 
-    Any I/O errors or missing/empty files are treated as \"no token\" and
-    will not cause authentication to fail.
+    Any read failure is logged as a warning and None is returned.
     """
-    path = os.getenv(_SPCS_TOKEN_ENV_VAR_NAME) or _SPCS_TOKEN_DEFAULT_PATH
+    if not os.environ.get(_SPCS_ENV_VAR):
+        return None
     try:
-        if not os.path.isfile(path):
-            return None
-        with open(path, encoding="utf-8") as f:
+        with open(_SPCS_TOKEN_PATH, encoding="utf-8") as f:
             token = f.read().strip()
         if not token:
             return None
         return token
-    except Exception as exc:  # pragma: no cover - best-effort logging only
-        logger.debug("Failed to read SPCS token from %s: %s", path, exc)
+    except Exception as exc:
+        logger.warning("Failed to read SPCS token from %s: %s", _SPCS_TOKEN_PATH, exc)
         return None
 
 

--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -105,8 +105,8 @@ class Auth:
     def _add_spcs_token_to_body(self, body: dict[Any, Any]) -> None:
         """Inject SPCS_TOKEN into the login request body when available.
 
-        This reads the SPCS token from the path specified by SF_SPCS_TOKEN_PATH,
-        or from ``/snowflake/session/spcs_token`` when the env var is unset.
+        The token is read from /snowflake/session/spcs_token when
+        SNOWFLAKE_RUNNING_INSIDE_SPCS is set.
         """
         spcs_token = get_spcs_token()
         if spcs_token is not None:

--- a/test/unit/aio/test_spcs_token_async.py
+++ b/test/unit/aio/test_spcs_token_async.py
@@ -8,143 +8,95 @@ import pytest
 import snowflake.connector.aio
 
 
-@pytest.mark.skipolddriver
-async def test_spcs_token_included_in_login_request_async(monkeypatch):
-    """Verify that SPCS_TOKEN is injected into async login request body when present."""
+async def _mock_post_factory(captured_requests):
+    async def mock_post_request(url, headers, body, **kwargs):
+        captured_requests.append((url, json.loads(body)))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN_ASYNC",
+                "masterToken": "MASTER_TOKEN_ASYNC",
+            },
+        }
 
-    custom_path = "/custom/path/to/spcs_token"
-    monkeypatch.setenv("SF_SPCS_TOKEN_PATH", custom_path)
-    monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == custom_path,
-        raising=False,
-    )
+    return mock_post_request
+
+
+async def _connect_and_capture(captured_requests):
+    mock_post = await _mock_post_factory(captured_requests)
+    with mock.patch(
+        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
+        side_effect=mock_post,
+    ):
+        conn = snowflake.connector.aio.SnowflakeConnection(
+            account="testaccount",
+            user="testuser",
+            password="testpwd",
+            host="testaccount.snowflakecomputing.com",
+        )
+        await conn.connect()
+        assert conn._rest.token == "TOKEN_ASYNC"
+        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
+        await conn.close()
+
+    return [body for (url, body) in captured_requests if "login-request" in url]
+
+
+@pytest.mark.skipolddriver
+async def test_spcs_token_present_async(monkeypatch):
+    """SPCS_TOKEN is injected into async login request when env var is set and file exists."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN_ASYNC")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
 
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
     assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"
+    assert login_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"
 
 
 @pytest.mark.skipolddriver
-async def test_spcs_token_not_included_when_file_missing_async(monkeypatch):
-    """Verify that SPCS_TOKEN is not added to async login request when file does not exist."""
-
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    captured_requests: list[tuple[str, dict]] = []
-
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
-    assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert "SPCS_TOKEN" not in body["data"]
-
-
-@pytest.mark.skipolddriver
-async def test_spcs_token_default_path_used_when_env_unset_async(
-    monkeypatch,
-):
-    """When SF_SPCS_TOKEN_PATH is not set, default path should be used (async)."""
-
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    default_path = "/snowflake/session/spcs_token"
+async def test_spcs_token_absent_async(monkeypatch):
+    """SPCS_TOKEN is not added to async login request when file does not exist."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == default_path,
+        "snowflake.connector._utils.open",
+        mock.Mock(side_effect=FileNotFoundError("No such file")),
         raising=False,
     )
-    mock_open = mock.mock_open(read_data="DEFAULT_PATH_SPCS_TOKEN_ASYNC")
+
+    captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
+
+    assert len(login_bodies) == 1
+    assert "SPCS_TOKEN" not in login_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+async def test_not_in_spcs_async(monkeypatch):
+    """SPCS_TOKEN is not added when SNOWFLAKE_RUNNING_INSIDE_SPCS is not set (async)."""
+    monkeypatch.delenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", raising=False)
+    mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN_ASYNC")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
 
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
     assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "DEFAULT_PATH_SPCS_TOKEN_ASYNC"
+    assert "SPCS_TOKEN" not in login_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+async def test_spcs_token_with_whitespace_async(monkeypatch):
+    """SPCS_TOKEN value has leading/trailing whitespace stripped (async)."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
+    mock_open = mock.mock_open(read_data="  \n TEST_SPCS_TOKEN_ASYNC \n  ")
+    monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
+
+    captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
+
+    assert len(login_bodies) == 1
+    assert login_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"

--- a/test/unit/test_spcs_token.py
+++ b/test/unit/test_spcs_token.py
@@ -8,137 +8,90 @@ import pytest
 import snowflake.connector
 
 
-@pytest.mark.skipolddriver
-def test_spcs_token_included_in_login_request(monkeypatch):
-    """Verify that SPCS_TOKEN is injected into the login request body when present."""
+def _mock_post_factory(captured_bodies):
+    def mock_post_request(url, headers, body, **kwargs):
+        captured_bodies.append(json.loads(body))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+            },
+        }
 
-    # Use a custom SPCS token path and mock its existence and contents
-    custom_path = "/custom/path/to/spcs_token"
-    monkeypatch.setenv("SF_SPCS_TOKEN_PATH", custom_path)
-    monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == custom_path,
-        raising=False,
-    )
+    return mock_post_request
+
+
+def _connect_and_capture(captured_bodies):
+    with mock.patch(
+        "snowflake.connector.network.SnowflakeRestful._post_request",
+        side_effect=_mock_post_factory(captured_bodies),
+    ):
+        conn = snowflake.connector.connect(
+            account="testaccount",
+            user="testuser",
+            password="testpwd",
+            host="testaccount.snowflakecomputing.com",
+        )
+        assert conn._rest.token == "TOKEN"
+        assert conn._rest.master_token == "MASTER_TOKEN"
+
+
+@pytest.mark.skipolddriver
+def test_spcs_token_present(monkeypatch):
+    """SPCS_TOKEN is injected into the login request when env var is set and file exists."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
 
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        # Return a minimal successful login response
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
     assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"
+    assert captured_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"
 
 
 @pytest.mark.skipolddriver
-def test_spcs_token_not_included_when_file_missing(monkeypatch):
-    """Verify that SPCS_TOKEN is not added when the token file does not exist."""
-
-    # Ensure env var is unset so default path is used, but not created
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    captured_bodies: list[dict] = []
-
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
-    assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert "SPCS_TOKEN" not in body["data"]
-
-
-@pytest.mark.skipolddriver
-def test_spcs_token_default_path_used_when_env_unset(monkeypatch):
-    """When SF_SPCS_TOKEN_PATH is not set, default path should be used."""
-
-    # Ensure env var is unset so default path logic is exercised
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    # Default SPCS path inside SPCS container
-    default_path = "/snowflake/session/spcs_token"
+def test_spcs_token_absent(monkeypatch):
+    """SPCS_TOKEN is not added when env var is set but token file does not exist."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == default_path,
+        "snowflake.connector._utils.open",
+        mock.Mock(side_effect=FileNotFoundError("No such file")),
         raising=False,
     )
-    mock_open = mock.mock_open(read_data="DEFAULT_PATH_SPCS_TOKEN")
+
+    captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
+
+    assert len(captured_bodies) == 1
+    assert "SPCS_TOKEN" not in captured_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+def test_not_in_spcs(monkeypatch):
+    """SPCS_TOKEN is not added when SNOWFLAKE_RUNNING_INSIDE_SPCS is not set."""
+    monkeypatch.delenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", raising=False)
+    mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
 
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
     assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "DEFAULT_PATH_SPCS_TOKEN"
+    assert "SPCS_TOKEN" not in captured_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+def test_spcs_token_with_whitespace(monkeypatch):
+    """SPCS_TOKEN value has leading/trailing whitespace stripped."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
+    mock_open = mock.mock_open(read_data="  \n TEST_SPCS_TOKEN \n  ")
+    monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
+
+    captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
+
+    assert len(captured_bodies) == 1
+    assert captured_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Made these changes according to the [doc](https://docs.google.com/document/d/11CgVBu45aOENuBOTQOm2umocqk2Ae_jUbEYaFdRiTGA/edit?tab=t.0):

- Gate SPCS token reading on the SNOWFLAKE_RUNNING_INSIDE_SPCS environment variable; skip entirely when not running inside SPCS
- Remove the SF_SPCS_TOKEN_PATH environment variable override; the token path is now fixed at /snowflake/session/spcs_token
- Remove os.path.isfile pre-check; open the file directly and handle failures gracefully
- Log at warning level instead of debug on read failure

4. (Optional) PR for stored-proc connector:
