### PR TITLE
fix: avoid duplicating trailing semicolons in executemany

### DIFF
--- a/src/snowflake/connector/aio/_cursor.py
+++ b/src/snowflake/connector/aio/_cursor.py
@@ -836,7 +836,7 @@ class SnowflakeCursorBase(SnowflakeCursorBaseSync, abc.ABC, typing.Generic[Fetch
             for param in seqparams:
                 await self.execute(command, params=param, _do_reset=False, **kwargs)
         else:
-            if re.search(";/s*$", command) is None:
+            if not command.endswith(";"):
                 command = command + "; "
             if self._connection.is_pyformat and not kwargs.get(
                 "_force_qmark_paramstyle", False

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1541,7 +1541,7 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
             for param in seqparams:
                 self.execute(command, params=param, _do_reset=False, **kwargs)
         else:
-            if re.search(";/s*$", command) is None:
+            if not command.endswith(";"):
                 command = command + "; "
             if self._connection.is_pyformat and not kwargs.get(
                 "_force_qmark_paramstyle", False

--- a/test/unit/aio/test_cursor_async_unit.py
+++ b/test/unit/aio/test_cursor_async_unit.py
@@ -107,6 +107,31 @@ async def test_cursor_execute_timeout(mockCancelQuery):
     assert mockCancelQuery.called
 
 
+async def test_executemany_with_num_statements_does_not_duplicate_trailing_semicolon():
+    fake_conn = FakeConnection()
+    fake_conn._paramstyle = "pyformat"
+
+    cursor = SnowflakeCursor(fake_conn)
+    cursor.reset = MagicMock()
+    cursor._preprocess_pyformat_query = AsyncMock(
+        side_effect=lambda command, params=None: command
+    )
+    cursor.execute = AsyncMock()
+
+    await cursor.executemany(
+        "select %(value)s;",
+        [{"value": 1}, {"value": 2}],
+        num_statements=1,
+    )
+
+    cursor.execute.assert_awaited_once_with(
+        "select %(value)s;select %(value)s;",
+        None,
+        _do_reset=False,
+        num_statements=2,
+    )
+
+
 # The _upload/_download/_upload_stream/_download_stream are newly introduced
 # and therefore should not be tested in old drivers.
 @pytest.mark.skipolddriver

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -102,6 +102,31 @@ def test_cursor_execute_timeout(mockCancelQuery):
     assert mockCancelQuery.called
 
 
+def test_executemany_with_num_statements_does_not_duplicate_trailing_semicolon():
+    fake_conn = FakeConnection()
+    fake_conn._paramstyle = "pyformat"
+
+    cursor = SnowflakeCursor(fake_conn)
+    cursor.reset = MagicMock()
+    cursor._preprocess_pyformat_query = MagicMock(
+        side_effect=lambda command, params=None: command
+    )
+    cursor.execute = MagicMock()
+
+    cursor.executemany(
+        "select %(value)s;",
+        [{"value": 1}, {"value": 2}],
+        num_statements=1,
+    )
+
+    cursor.execute.assert_called_once_with(
+        "select %(value)s;select %(value)s;",
+        None,
+        _do_reset=False,
+        num_statements=2,
+    )
+
+
 # The _upload/_download/_upload_stream/_download_stream are newly introduced
 # and therefore should not be tested in old drivers.
 @pytest.mark.skipolddriver


### PR DESCRIPTION
Fixes #2853

## Pre-review checklist

- [x] I am adding a new automated test(s) to verify correctness of my new code
- [ ] I am adding new logging messages
- [ ] I am adding a new telemetry message
- [ ] I am modifying authorization mechanisms
- [ ] I am adding new credentials
- [ ] I am modifying OCSP code
- [ ] I am adding a new dependency

## Summary

This fixes the `executemany(..., num_statements=...)` semicolon handling in both sync and async cursors.

The current code uses `re.search(";/s*$", command)`, which never matches trailing whitespace after a semicolon because `/s` is treated literally instead of as `\\s`. As a result, commands that already end with `;` can still receive an extra `; ` during multi-statement concatenation.

This change replaces that check with `not command.endswith(";")`. `executemany` already normalizes the command with `command.strip(" \\t\\n\\r")` before this branch, so `endswith(";")` correctly handles the intended trailing-whitespace cases without regex.

## Tests

- `python3 -m pytest test/unit/test_cursor.py test/unit/aio/test_cursor_async_unit.py -k trailing_semicolon -q`
