### PR TITLE
Removed dynamic class deserialization from the OCSP response validati…

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -13,6 +13,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added HTTP 307/308 redirect status codes to the retryable set as defense-in-depth, with redirect-aware logging in both sync and async paths.
   - Consolidated keyring token cache to use a single service name with hashed account keys, reducing macOS Keychain password prompts. Legacy entries are auto-migrated on first read.
   - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
+  - Removed dynamic class deserialization from the OCSP response validation cache to prevent arbitrary code execution via crafted cache files (SNOW-2439940). The `SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS` environment variable is now a no-op.
   - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
 
 - v4.4.0(March 25,2026)

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import codecs
-import importlib
 import json
 import os
 import platform
@@ -10,7 +9,6 @@ import re
 import sys
 import tempfile
 import time
-import warnings
 from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from logging import getLogger
@@ -29,10 +27,7 @@ from OpenSSL.SSL import Connection
 
 from snowflake.connector import SNOWFLAKE_CONNECTOR_VERSION
 from snowflake.connector.compat import OK, urlsplit, urlunparse
-from snowflake.connector.constants import (
-    ENV_VAR_ENABLE_CUSTOM_REVOCATION_ERRORS,
-    HTTP_HEADER_USER_AGENT,
-)
+from snowflake.connector.constants import HTTP_HEADER_USER_AGENT
 from snowflake.connector.errorcode import (
     ER_INVALID_OCSP_RESPONSE_SSD,
     ER_INVALID_SSD,
@@ -137,40 +132,19 @@ class OCSPResponseValidationResult(NamedTuple):
                     errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
                 )
 
-            # For non-RevocationCheckError, always try to deserialize to detect failures
-            try:
-                module = importlib.import_module(exc_module)
-                exc_cls = getattr(module, exc_class)
-                custom_exc = exc_cls(exception_dict["msg"])
-
-                # If env var is set, return the custom exception with deprecation warning
-                if os.getenv(ENV_VAR_ENABLE_CUSTOM_REVOCATION_ERRORS, "").lower() in (
-                    "true",
-                    "1",
-                ):
-                    warnings.warn(
-                        "Support for custom revocation error classes will be removed in a future release.",
-                        DeprecationWarning,
-                        stacklevel=3,
-                    )
-                    return custom_exc
-
-                # Otherwise, convert to RevocationCheckError
-                return RevocationCheckError(
-                    msg=exception_dict["msg"],
-                    errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
-                )
-            except Exception as deserialize_exc:
-                logger.debug(
-                    f"hitting error {str(deserialize_exc)} while deserializing exception,"
-                    f" the original error error class and message are {exc_class} and {exception_dict['msg']}"
-                )
-                return RevocationCheckError(
-                    msg=f"Got error {str(deserialize_exc)} while deserializing ocsp cache, please try "
-                    f"cleaning up the "
-                    f"OCSP cache under directory {OCSP_RESPONSE_VALIDATION_CACHE.file_path}",
-                    errno=ER_OCSP_RESPONSE_LOAD_FAILURE,
-                )
+            # SECURITY: Do not dynamically import or instantiate classes from
+            # cache data.  All non-RevocationCheckError exceptions are wrapped
+            # in a RevocationCheckError to avoid arbitrary code execution via
+            # crafted cache files (CWE-470 / CWE-502).
+            logger.debug(
+                "Converting cached %s.%s exception to RevocationCheckError",
+                exc_module,
+                exc_class,
+            )
+            return RevocationCheckError(
+                msg=exception_dict.get("msg", "Cached OCSP exception"),
+                errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
+            )
 
         return OCSPResponseValidationResult(
             exception=deserialize_exception(json_obj.get("exception")),

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -862,8 +862,8 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
         ):
             assert key1 == key2 and value1 == value2
 
-    def verify_exception_default(_, loaded_cache):
-        """Test default behavior: custom exceptions are converted to RevocationCheckError"""
+    def verify_exception(_, loaded_cache):
+        """All cached exceptions are deserialized as RevocationCheckError (no dynamic import)."""
         exc_1 = loaded_cache[(b"key1", b"key2", b"key3")].exception
         exc_2 = loaded_cache[(b"key4", b"key5", b"key6")].exception
         exc_3 = loaded_cache[(b"key7", b"key8", b"key9")].exception
@@ -872,31 +872,10 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
             and exc_1.raw_msg == "error"
             and exc_1.errno == 1
         )
-        # By default, custom exceptions (ValueError) are converted to RevocationCheckError
         assert isinstance(exc_2, RevocationCheckError)
-        assert (
-            isinstance(exc_3, RevocationCheckError)
-            and "while deserializing ocsp cache, please try cleaning up the OCSP cache under directory"
-            in exc_3.msg
-        )
-
-    def verify_exception_deprecated(_, loaded_cache):
-        """Test deprecated behavior with env var: custom exceptions are preserved"""
-        exc_1 = loaded_cache[(b"key1", b"key2", b"key3")].exception
-        exc_2 = loaded_cache[(b"key4", b"key5", b"key6")].exception
-        exc_3 = loaded_cache[(b"key7", b"key8", b"key9")].exception
-        assert (
-            isinstance(exc_1, RevocationCheckError)
-            and exc_1.raw_msg == "error"
-            and exc_1.errno == 1
-        )
-        # With env var set, custom exceptions are preserved
-        assert isinstance(exc_2, ValueError) and str(exc_2) == "value error"
-        assert (
-            isinstance(exc_3, RevocationCheckError)
-            and "while deserializing ocsp cache, please try cleaning up the OCSP cache under directory"
-            in exc_3.msg
-        )
+        assert exc_2.raw_msg == "value error"
+        assert isinstance(exc_3, RevocationCheckError)
+        assert exc_3.raw_msg == "json error: line 1 column 1 (char 0)"
 
     verify(verify_happy_path, copy.deepcopy(test_cache))
 
@@ -906,7 +885,6 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
     )
     verify(verify_none, origin_cache)
 
-    # Test default behavior (no env var)
     origin_cache = copy.deepcopy(test_cache)
     origin_cache.update(
         {
@@ -921,27 +899,4 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
             ),
         }
     )
-    verify(verify_exception_default, origin_cache)
-
-    # Test deprecated behavior (with env var set)
-    with mock.patch.dict(
-        os.environ, {"SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS": "true"}
-    ):
-        origin_cache = copy.deepcopy(test_cache)
-        origin_cache.update(
-            {
-                (b"key1", b"key2", b"key3"): OCSPResponseValidationResult(
-                    exception=RevocationCheckError(msg="error", errno=1),
-                ),
-                (b"key4", b"key5", b"key6"): OCSPResponseValidationResult(
-                    exception=ValueError("value error"),
-                ),
-                (b"key7", b"key8", b"key9"): OCSPResponseValidationResult(
-                    exception=json.JSONDecodeError("json error", "doc", 0)
-                ),
-            }
-        )
-        with pytest.warns(
-            DeprecationWarning, match="Support for custom revocation error classes"
-        ):
-            verify(verify_exception_deprecated, origin_cache)
+    verify(verify_exception, origin_cache)


### PR DESCRIPTION
…on cache

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-3383311

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Removed dynamic deserialization - the only exception type that needs faithful reconstruction is RevocationCheckError (which has its own fast-path at lines 126-133 that doesn't use importlib). All other exceptions were already being converted to RevocationCheckError in the default code path (when ENV_VAR_ENABLE_CUSTOM_REVOCATION_ERRORS was not set). The env var was already deprecated. Removing the dynamic import is functionally equivalent for the default case.
