### PR TITLE
SNOW-2875919 Use metadata.google.internal for GCP WIF to support IPv6-only instances

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
   - Removed dynamic class deserialization from the OCSP response validation cache to prevent arbitrary code execution via crafted cache files (SNOW-2439940). The `SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS` environment variable is now a no-op.
   - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
+  - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address, so it works on IPv6-only GCP VMs.
 
 - v4.4.0(March 25,2026)
   - Bump the lower boundary of cryptography to 46.0.5 due to CVE-2026-26007.

--- a/src/snowflake/connector/aio/_wif_util.py
+++ b/src/snowflake/connector/aio/_wif_util.py
@@ -27,9 +27,7 @@ from ._session_manager import SessionManager, SessionManagerFactory
 
 logger = logging.getLogger(__name__)
 
-GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
-)
+GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 
 
 async def get_aws_region() -> str:

--- a/src/snowflake/connector/aio/_wif_util.py
+++ b/src/snowflake/connector/aio/_wif_util.py
@@ -28,7 +28,7 @@ from ._session_manager import SessionManager, SessionManagerFactory
 logger = logging.getLogger(__name__)
 
 GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default"
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 )
 
 

--- a/src/snowflake/connector/wif_util.py
+++ b/src/snowflake/connector/wif_util.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 SNOWFLAKE_AUDIENCE = "snowflakecomputing.com"
 DEFAULT_ENTRA_SNOWFLAKE_RESOURCE = "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
 GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default"
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 )
 
 

--- a/src/snowflake/connector/wif_util.py
+++ b/src/snowflake/connector/wif_util.py
@@ -23,9 +23,7 @@ from .session_manager import SessionManager, SessionManagerFactory
 logger = logging.getLogger(__name__)
 SNOWFLAKE_AUDIENCE = "snowflakecomputing.com"
 DEFAULT_ENTRA_SNOWFLAKE_RESOURCE = "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
-GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
-)
+GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 
 
 @unique

--- a/test/csp_helpers.py
+++ b/test/csp_helpers.py
@@ -263,7 +263,7 @@ class FakeGceMetadataService(FakeMetadataService):
 
     @property
     def expected_hostnames(self):
-        return ["169.254.169.254", "metadata.google.internal"]
+        return ["metadata.google.internal"]
 
     def handle_request(self, method, parsed_url, headers, timeout):
         query_string = parse_qs(parsed_url.query)

--- a/test/wif/test_wif.py
+++ b/test/wif/test_wif.py
@@ -125,7 +125,7 @@ def get_gcp_access_token() -> str:
     try:
         command = (
             'curl -H "Metadata-Flavor: Google" '
-            '"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
+            '"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
         )
 
         result = subprocess.run(

--- a/test/wif/test_wif.py
+++ b/test/wif/test_wif.py
@@ -105,7 +105,7 @@ def get_gcp_access_token() -> str:
     try:
         command = (
             'curl -H "Metadata-Flavor: Google" '
-            '"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
+            '"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
         )
 
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- Changed `GCP_METADATA_SERVICE_ACCOUNT_BASE_URL` in both `wif_util.py` and `aio/_wif_util.py` from `169.254.169.254` to `metadata.google.internal`
- GCP WIF attestation now uses the hostname that resolves to both IPv4 and IPv6 via DNS, enabling it to work on IPv6-only GCP VMs
- Updated integration test and test helpers to match

## Context
On IPv6-only cloud instances, the IPv4 link-local address `169.254.169.254` is unreachable. GCP platform detection (`platform_detection.py`) already uses `metadata.google.internal`, but WIF attestation was still using the hardcoded IPv4 address.

- **AWS**: No code change needed — boto3/botocore handle IPv6 IMDS natively via `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6`
- **Azure**: No change possible — Azure IMDS has no IPv6 endpoint. Azure URLs in `wif_util.py` and `platform_detection.py` unchanged.
- **GCP**: Fixed — switched from `169.254.169.254` to `metadata.google.internal`

## Test plan
- [ ] Existing WIF unit tests pass (they use mock session managers)
- [ ] Full test suite — no regressions
- [ ] On GCP IPv6-only VM: WIF integration test with GCP provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)