### PR TITLE
SNOW-1794102 Fix SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION

### DIFF
--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -45,9 +45,7 @@ def _should_skip_warning_for_read_permissions_on_config_file() -> bool:
     if SKIP_WARNING_ENV_VAR in os.environ:
         return os.getenv(SKIP_WARNING_ENV_VAR, "false").lower() == "true"
     if SPCS_INJECTED_SKIP_WARNING_ENV_VAR in os.environ:
-        return (
-            os.getenv(SPCS_INJECTED_SKIP_WARNING_ENV_VAR, "false").lower() == "true"
-        )
+        return os.getenv(SPCS_INJECTED_SKIP_WARNING_ENV_VAR, "false").lower() == "true"
     # Else fallback to old value
     if DEPRECATED_SKIP_WARNING_ENV_VAR in os.environ:
         warn(

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -29,7 +29,14 @@ LOGGER = logging.getLogger(__name__)
 READABLE_BY_OTHERS = stat.S_IRGRP | stat.S_IROTH
 WRITABLE_BY_OTHERS = stat.S_IWGRP | stat.S_IWOTH
 
+# NOTE: For historical and compatibility reasons, three environment variables are recognized:
+# - The skip warning mechanism was originally for internal use (only within SPCS containers).
+# - SPCS containers set SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION.
+# - SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION is the documented/public way to disable the warning.
+# - In the Universal driver, this warning will become unskippable and the message will clarify:
+#   "SNOWFLAKE_RUNNING_INSIDE_SPCS is detected, skipping permission checks."
 DEPRECATED_SKIP_WARNING_ENV_VAR = "SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE"
+SPCS_INJECTED_SKIP_WARNING_ENV_VAR = "SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION"
 SKIP_WARNING_ENV_VAR = "SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION"
 
 
@@ -37,6 +44,10 @@ def _should_skip_warning_for_read_permissions_on_config_file() -> bool:
     """Check if the warning should be skipped based on environment variable."""
     if SKIP_WARNING_ENV_VAR in os.environ:
         return os.getenv(SKIP_WARNING_ENV_VAR, "false").lower() == "true"
+    if SPCS_INJECTED_SKIP_WARNING_ENV_VAR in os.environ:
+        return (
+            os.getenv(SPCS_INJECTED_SKIP_WARNING_ENV_VAR, "false").lower() == "true"
+        )
     # Else fallback to old value
     if DEPRECATED_SKIP_WARNING_ENV_VAR in os.environ:
         warn(


### PR DESCRIPTION
## SNOW-1794102: Recognize SPCS-injected `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION`

Teaches `_should_skip_warning_for_read_permissions_on_config_file()` in `src/snowflake/connector/config_manager.py` to honor the `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` env var injected by SPCS (Snowpark Container Services) containers.

### Background

The skip-warning mechanism was originally meant as an internal, SPCS-only signal to silence the config-file permission warning for workloads where the token file's permissions are managed by the platform. SPCS injects `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION=true`, but the connector was never taught to read it — instead, a public `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` variant was introduced.

**Exposing `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` publicly was a mistake** — it was meant to be internal, not a user-facing toggle for a security-relevant warning. It now has to be kept for backward compatibility, but the SPCS-injected variable is the canonical source of truth going forward. In the Universal driver this warning will become unskippable.

### Resolution order (first match wins)

1. `SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` — kept for backward compatibility.
2. `SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION` — SPCS-injected, newly recognized.
3. `SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE` — deprecated, emits a `DeprecationWarning`.
4. Otherwise, do not skip.