### PR TITLE
Fix write_pandas temp stage name collisions in forked processes (SNOW-3481510)

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - Upcoming Release
+  - Fixed `write_pandas` temp stage name collisions (SNOW-3481510). The old PRNG could produce identical name sequences in forked processes (e.g. Notebook kernels), causing `CREATE TEMPORARY STAGE` to fail with "Object already exists".
   - Fixed a security bug in Okta SAML authentication where `_is_prefix_equal()` compared `url1`'s port against itself instead of `url2`'s port, allowing an attacker to redirect credentials to a different port on the same hostname. Also fixed the default port fallback to use `int` instead of `str` for correct comparison when one URL omits the port.
   - Fixed `executemany` with `paramstyle="pyformat"` to correctly locate the VALUES clause using a balanced-parentheses parser instead of a greedy regex. This fixes incorrect behaviour with nested function calls such as SQLAlchemy `@compiles VARIANT` patterns (e.g. `PARSE_JSON(%(col)s)`) and subquery-form INSERTs (SNOW-298756).
   - Added ECDSA key support (ES256, ES384, ES512) for key-pair authentication.

--- a/src/snowflake/connector/_utils.py
+++ b/src/snowflake/connector/_utils.py
@@ -10,7 +10,7 @@ import threading
 import time
 from enum import Enum
 from inspect import stack
-from random import choice
+from secrets import choice
 from threading import Timer
 from uuid import UUID
 

--- a/test/unit/test_pandas_tools.py
+++ b/test/unit/test_pandas_tools.py
@@ -132,3 +132,51 @@ class TestWritePandasOverwriteWithoutAutoCreate:
         assert not any(
             "TRUNCATE" in sql for sql in executed_sqls
         ), "Should not TRUNCATE when overwrite=False"
+
+
+@pytest.mark.pandas
+@pytest.mark.unit
+class TestTempObjectNameUniqueness:
+    """Tests for SNOW-3481510: random_name_for_temp_object must use
+    cryptographically secure randomness to prevent collisions in forked
+    processes and high-frequency usage."""
+
+    def test_random_names_are_unique_across_many_calls(self):
+        """Generate a large batch of names and verify no collisions."""
+        from snowflake.connector._utils import (
+            TempObjectType,
+            random_name_for_temp_object,
+        )
+
+        names = [
+            random_name_for_temp_object(TempObjectType.STAGE) for _ in range(10_000)
+        ]
+        assert len(set(names)) == len(names), "Detected duplicate temp object names"
+
+    def test_random_names_unique_for_all_object_types(self):
+        """Verify uniqueness holds across different temp object types."""
+        from snowflake.connector._utils import (
+            TempObjectType,
+            random_name_for_temp_object,
+        )
+
+        names = []
+        for obj_type in [
+            TempObjectType.STAGE,
+            TempObjectType.FILE_FORMAT,
+            TempObjectType.TABLE,
+        ]:
+            names.extend(random_name_for_temp_object(obj_type) for _ in range(1_000))
+        assert len(set(names)) == len(names)
+
+    def test_random_name_format_preserved(self):
+        """Ensure the name format is still SNOWPARK_TEMP_<TYPE>_<ALPHANUMERIC>."""
+        import re
+
+        from snowflake.connector._utils import (
+            TempObjectType,
+            random_name_for_temp_object,
+        )
+
+        name = random_name_for_temp_object(TempObjectType.STAGE)
+        assert re.match(r"^SNOWPARK_TEMP_STAGE_[A-Z0-9]{10}$", name)


### PR DESCRIPTION
## Summary
Fixed write_pandas / create_dataframe failures caused by temp stage name collisions (002002 (42710): Object 'SNOWPARK_TEMP_STAGE_<X>' already exists) by switching the random name generator from random.choice (Mersenne Twister) to secrets.choice (CSPRNG).
The Mersenne Twister PRNG shares state across fork(), so forked processes (e.g. Notebook kernels) produce identical "random" name sequences, making collisions deterministic rather than probabilistic.
This is a single-line change in _utils.py (from random import choice → from secrets import choice) with no API or format changes.
## Context
In Notebooks, every time a user displays a pandas DataFrame the kernel calls session.create_dataframe(pandas_df) which triggers write_pandas → _create_temp_stage. A single session may invoke this path many times, and Notebook kernels commonly fork from a shared parent process. Because random.choice uses the Mersenne Twister PRNG (which inherits state across fork), child processes generate the exact same sequence of stage names, causing CREATE TEMPORARY STAGE to fail when the name already exists.