### PR TITLE
SNOW-3526469: prune foreign-arch minicore binaries at build_py

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - v4.5.0(May 12,2026)
+  - Fixed sdist to only install the minicore binary matching the current platform (SNOW-3526469). Previous 4.x releases copied every platform's minicore `.so`/`.dylib`/`.dll` into the install prefix, breaking downstream packagers (e.g. Homebrew) whose audits reject foreign-arch binaries.
   - Fixed `write_pandas` temp stage name collisions (SNOW-3481510). The old PRNG could produce identical name sequences in forked processes (e.g. Notebook kernels), causing `CREATE TEMPORARY STAGE` to fail with "Object already exists".
   - Fixed a security bug in Okta SAML authentication where `_is_prefix_equal()` compared `url1`'s port against itself instead of `url2`'s port, allowing an attacker to redirect credentials to a different port on the same hostname. Also fixed the default port fallback to use `int` instead of `str` for correct comparison when one URL omits the port.
   - Fixed `executemany` with `paramstyle="pyformat"` to correctly locate the VALUES clause using a balanced-parentheses parser instead of a greedy regex. This fixes incorrect behaviour with nested function calls such as SQLAlchemy `@compiles VARIANT` patterns (e.g. `PARSE_JSON(%(col)s)`) and subquery-form INSERTs (SNOW-298756).

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 import os
+import platform
+import shutil
 import sys
 import warnings
 
 from setuptools import Extension, setup
+from setuptools.command.build_py import build_py
 from setuptools.command.egg_info import egg_info
 
 CONNECTOR_SRC_DIR = os.path.join("src", "snowflake", "connector")
@@ -192,8 +195,71 @@ class SetDefaultInstallationExtras(egg_info):
             self.distribution.install_requires += boto_extras
 
 
+def _minicore_native_subdir():
+    """Return the minicore/<platform> subdir matching the current interpreter.
+
+    Mirrors snowflake.connector._utils._CoreLoader._get_platform_subdir so the
+    build-time pruner and the runtime loader always agree on the layout.
+    Returns None when the platform is not recognised (leave tree untouched).
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "x86_64"
+    elif machine in ("aarch64", "arm64"):
+        arch = "aarch64"
+    elif machine == "ppc64":
+        arch = "ppc64"
+    else:
+        return None
+
+    if system == "linux":
+        libc, _ = platform.libc_ver()
+        libc_family = "glibc" if libc == "glibc" else "musl"
+        return f"linux_{arch}_{libc_family}"
+    if system == "darwin":
+        return f"macos_{arch}"
+    if system == "windows":
+        return f"windows_{arch}"
+    if system == "aix":
+        return f"aix_{arch}"
+    return None
+
+
+class PlatformBuildPy(build_py):
+    """Strip non-native minicore/<platform>/ dirs from the built distribution.
+
+    The sdist ships minicore binaries for every supported platform. At
+    build-time we keep only the one matching the current interpreter so wheels
+    and downstream sdist consumers (pip install, Homebrew, conda-forge,
+    nixpkgs) end up with a clean single-platform layout.
+    """
+
+    def run(self):
+        super().run()
+        self._prune_minicore()
+
+    def _prune_minicore(self):
+        minicore_build_dir = os.path.join(
+            self.build_lib, "snowflake", "connector", "minicore"
+        )
+        if not os.path.isdir(minicore_build_dir):
+            return
+        keep = _minicore_native_subdir()
+        if keep is None:
+            return
+        for entry in os.listdir(minicore_build_dir):
+            full = os.path.join(minicore_build_dir, entry)
+            if not os.path.isdir(full) or entry.startswith("__"):
+                continue
+            if entry == keep:
+                continue
+            shutil.rmtree(full)
+
+
 # Update command classes
 cmd_class["egg_info"] = SetDefaultInstallationExtras
+cmd_class["build_py"] = PlatformBuildPy
 
 setup(
     version=version,

--- a/test/unit/test_setup_minicore_pruner.py
+++ b/test/unit/test_setup_minicore_pruner.py
@@ -1,0 +1,149 @@
+"""Tests for the setup.py build-time minicore pruner.
+
+The sdist ships pre-built minicore binaries for every supported platform.
+`PlatformBuildPy._prune_minicore` strips the non-native subdirs from the built
+distribution so wheels and downstream sdist consumers (pip install, Homebrew,
+conda-forge, nixpkgs) end up with a clean single-platform layout that passes
+packaging audits which reject foreign-arch binaries.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytestmark = pytest.mark.skipolddriver
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_PY = REPO_ROOT / "setup.py"
+
+
+def _load_setup_module():
+    """Load setup.py as a module without executing the `setup()` call.
+
+    setup.py calls `setup(...)` at module scope, which is harmless to run but
+    noisy. We only need `_minicore_native_subdir` and `PlatformBuildPy`, so
+    stash `sys.argv` and rely on setuptools' no-op behaviour when no command
+    is given.
+    """
+    spec = importlib.util.spec_from_file_location("_setup_under_test", SETUP_PY)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch("sys.argv", ["setup.py", "--help-commands"]):
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def setup_module():
+    return _load_setup_module()
+
+
+MINICORE_PLATFORMS = (
+    "aix_ppc64",
+    "linux_aarch64_glibc",
+    "linux_aarch64_musl",
+    "linux_x86_64_glibc",
+    "linux_x86_64_musl",
+    "macos_aarch64",
+    "macos_x86_64",
+    "windows_x86_64",
+)
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "libc", "expected"),
+    [
+        ("Linux", "x86_64", ("glibc", "2.35"), "linux_x86_64_glibc"),
+        ("Linux", "aarch64", ("glibc", "2.35"), "linux_aarch64_glibc"),
+        ("Linux", "x86_64", ("musl", "1.2.3"), "linux_x86_64_musl"),
+        ("Linux", "aarch64", ("", ""), "linux_aarch64_musl"),
+        ("Darwin", "arm64", ("", ""), "macos_aarch64"),
+        ("Darwin", "x86_64", ("", ""), "macos_x86_64"),
+        ("Windows", "AMD64", ("", ""), "windows_x86_64"),
+        ("AIX", "ppc64", ("", ""), "aix_ppc64"),
+    ],
+)
+def test_native_subdir_matches_platform(setup_module, system, machine, libc, expected):
+    with mock.patch("platform.system", return_value=system), mock.patch(
+        "platform.machine", return_value=machine
+    ), mock.patch("platform.libc_ver", return_value=libc):
+        assert setup_module._minicore_native_subdir() == expected
+
+
+def test_native_subdir_returns_none_for_unknown_platform(setup_module):
+    with mock.patch("platform.system", return_value="Haiku"), mock.patch(
+        "platform.machine", return_value="x86_64"
+    ), mock.patch("platform.libc_ver", return_value=("", "")):
+        assert setup_module._minicore_native_subdir() is None
+
+
+def _populate_fake_minicore(root: Path) -> Path:
+    minicore = root / "snowflake" / "connector" / "minicore"
+    minicore.mkdir(parents=True)
+    (minicore / "__init__.py").write_text("")
+    (minicore / "__pycache__").mkdir()
+    for name in MINICORE_PLATFORMS:
+        platform_dir = minicore / name
+        platform_dir.mkdir()
+        (platform_dir / "libsf_mini_core.so").write_bytes(b"\x7fELF-stub")
+    return minicore
+
+
+def test_prune_minicore_keeps_only_native_dir(setup_module, tmp_path):
+    build_lib = tmp_path / "build" / "lib"
+    minicore = _populate_fake_minicore(build_lib)
+
+    cmd = setup_module.PlatformBuildPy.__new__(setup_module.PlatformBuildPy)
+    cmd.build_lib = str(build_lib)
+
+    with mock.patch.object(
+        setup_module, "_minicore_native_subdir", return_value="linux_x86_64_glibc"
+    ):
+        cmd._prune_minicore()
+
+    remaining = sorted(
+        entry for entry in os.listdir(minicore) if not entry.startswith("__")
+    )
+    assert remaining == ["linux_x86_64_glibc"]
+    assert (minicore / "__init__.py").exists()
+    assert (minicore / "__pycache__").is_dir()
+
+
+def test_prune_minicore_noop_when_platform_unknown(setup_module, tmp_path):
+    build_lib = tmp_path / "build" / "lib"
+    minicore = _populate_fake_minicore(build_lib)
+
+    cmd = setup_module.PlatformBuildPy.__new__(setup_module.PlatformBuildPy)
+    cmd.build_lib = str(build_lib)
+
+    with mock.patch.object(setup_module, "_minicore_native_subdir", return_value=None):
+        cmd._prune_minicore()
+
+    remaining = sorted(
+        entry for entry in os.listdir(minicore) if not entry.startswith("__")
+    )
+    assert remaining == list(MINICORE_PLATFORMS)
+
+
+def test_prune_minicore_noop_when_directory_missing(setup_module, tmp_path):
+    build_lib = tmp_path / "build" / "lib"
+    build_lib.mkdir(parents=True)
+
+    cmd = setup_module.PlatformBuildPy.__new__(setup_module.PlatformBuildPy)
+    cmd.build_lib = str(build_lib)
+
+    cmd._prune_minicore()
+
+
+def test_pruner_agrees_with_runtime_loader(setup_module):
+    from snowflake.connector._utils import _CoreLoader
+
+    try:
+        runtime = _CoreLoader._get_platform_subdir()
+    except OSError:
+        pytest.skip("runtime loader does not support this platform")
+    assert setup_module._minicore_native_subdir() == runtime

--- a/test/unit/test_setup_minicore_pruner.py
+++ b/test/unit/test_setup_minicore_pruner.py
@@ -18,6 +18,11 @@ import pytest
 
 pytestmark = pytest.mark.skipolddriver
 
+pytest.importorskip(
+    "setuptools",
+    reason="setup.py imports setuptools at module scope; Python 3.14+ envs may not bundle it",
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_PY = REPO_ROOT / "setup.py"
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2870

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Problem.** Since 4.0.0 the sdist ships pre-built minicore binaries for every supported platform under `src/snowflake/connector/minicore/`. `_CoreLoader._get_platform_subdir` only ever loads the native one, so the other 7 platforms' binaries are dead weight inside every install. Packaging audits that reject foreign-arch binaries (e.g. `brew audit`) fail, blocking the Homebrew release of `snowflake-cli` 3.17.0 ([Homebrew/homebrew-core#282333](https://github.com/Homebrew/homebrew-core/pull/282333)) — the first CLI release to pull `snowflake-connector-python >= 4.0.0`. Same class of problem will hit conda-forge, nixpkgs, distro maintainers, and internal packagers.

   **Fix.** Hook setuptools' `build_py` command to strip non-matching `minicore/<platform>/` subdirs from the built distribution. This mirrors the platform-specific cleanup that `ci/build_linux.sh` already runs before wheel builds, but runs for every `build_py` invocation — so wheels, `pip install sdist`, `python -m build`, and downstream packager builds all produce a clean single-platform layout.

   The sdist itself keeps all 8 platforms (single source of truth). The `_minicore_native_subdir` helper in `setup.py` mirrors `_CoreLoader._get_platform_subdir` so build-time and runtime detection always agree (enforced by `test_pruner_agrees_with_runtime_loader`).

   **Verified locally** by building the sdist, `pip install`-ing it, and confirming only the native `linux_aarch64_glibc/` remains in the installed tree (and the sdist still ships all 8 platforms).

   Tracked internally as SNOW-3526469.