### PR TITLE
SNOW-3526469: prune foreign minicore binaries at sdist build, not install

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - v4.5.0(May 12,2026)
+  - Fixed sdist to ship only the host platform's minicore binary (SNOW-3526469). Previous 4.x sdists bundled every supported platform's `.so`/`.dylib`/`.dll`, breaking downstream packagers (e.g. Homebrew) whose audits reject foreign-arch binaries. Wheels are unaffected — they were already single-platform.
   - Fixed `write_pandas` temp stage name collisions (SNOW-3481510). The old PRNG could produce identical name sequences in forked processes (e.g. Notebook kernels), causing `CREATE TEMPORARY STAGE` to fail with "Object already exists".
   - Fixed a security bug in Okta SAML authentication where `_is_prefix_equal()` compared `url1`'s port against itself instead of `url2`'s port, allowing an attacker to redirect credentials to a different port on the same hostname. Also fixed the default port fallback to use `int` instead of `str` for correct comparison when one URL omits the port.
   - Fixed `executemany` with `paramstyle="pyformat"` to correctly locate the VALUES clause using a balanced-parentheses parser instead of a greedy regex. This fixes incorrect behaviour with nested function calls such as SQLAlchemy `@compiles VARIANT` patterns (e.g. `PARSE_JSON(%(col)s)`) and subquery-form INSERTs (SNOW-298756).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,9 @@ repair-wheel-command = ""
 archs = ["AMD64"]
 
 [tool.check-manifest]
+# Prebuilt minicore binaries live in git for every supported platform so
+# wheel CI can consume them directly. setup.py's HostOnlyMinicoreSdist
+# strips foreign-arch subdirs from the sdist. Tell check-manifest not to
+# flag the resulting asymmetry between the git tree and the sdist tarball.
+ignore = ["src/snowflake/connector/minicore/**"]
 ignore-bad-ideas = ["src/snowflake/connector/minicore/**"]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
 import os
+import platform
+import shutil
 import sys
 import warnings
 
 from setuptools import Extension, setup
 from setuptools.command.egg_info import egg_info
+from setuptools.command.sdist import sdist
 
 CONNECTOR_SRC_DIR = os.path.join("src", "snowflake", "connector")
 NANOARROW_SRC_DIR = os.path.join(CONNECTOR_SRC_DIR, "nanoarrow_cpp", "ArrowIterator")
@@ -192,8 +195,69 @@ class SetDefaultInstallationExtras(egg_info):
             self.distribution.install_requires += boto_extras
 
 
+def _host_minicore_subdir():
+    """Return the minicore/<platform> name matching the host, or None."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "x86_64"
+    elif machine in ("aarch64", "arm64"):
+        arch = "aarch64"
+    elif machine == "ppc64":
+        arch = "ppc64"
+    else:
+        return None
+
+    if system == "linux":
+        libc, _ = platform.libc_ver()
+        return f"linux_{arch}_{'glibc' if libc == 'glibc' else 'musl'}"
+    if system == "darwin":
+        return f"macos_{arch}"
+    if system == "windows":
+        return f"windows_{arch}"
+    if system == "aix":
+        return f"aix_{arch}"
+    return None
+
+
+class HostOnlyMinicoreSdist(sdist):
+    # The sdist only ever needs the host's minicore binary — the runtime loader
+    # opens one, and downstream packaging audits (Homebrew, conda-forge,
+    # nixpkgs) reject foreign-arch binaries. Wheels are built from the git
+    # tree, not the sdist, so keeping all platforms in git is fine.
+
+    def make_release_tree(self, base_dir, files):
+        super().make_release_tree(base_dir, files)
+        minicore_dir = os.path.join(
+            base_dir, "src", "snowflake", "connector", "minicore"
+        )
+        if not os.path.isdir(minicore_dir):
+            return
+        keep = _host_minicore_subdir()
+        if keep is None:
+            raise RuntimeError(
+                "Cannot build sdist: host platform "
+                f"({platform.system()}/{platform.machine()}) has no matching "
+                "minicore subdir. Build the sdist on a supported platform."
+            )
+        keep_path = os.path.join(minicore_dir, keep)
+        if not os.path.isdir(keep_path):
+            raise RuntimeError(
+                f"Cannot build sdist: expected {keep_path} to exist. Run "
+                "ci/download_minicore.py (or the normal wheel-build pipeline) "
+                "to populate it before building the sdist."
+            )
+        for entry in os.listdir(minicore_dir):
+            if entry == keep or entry.startswith("__"):
+                continue
+            full = os.path.join(minicore_dir, entry)
+            if os.path.isdir(full):
+                shutil.rmtree(full)
+
+
 # Update command classes
 cmd_class["egg_info"] = SetDefaultInstallationExtras
+cmd_class["sdist"] = HostOnlyMinicoreSdist
 
 setup(
     version=version,

--- a/test/unit/test_sdist_minicore_pruner.py
+++ b/test/unit/test_sdist_minicore_pruner.py
@@ -1,0 +1,172 @@
+"""Tests for HostOnlyMinicoreSdist in setup.py.
+
+The sdist is expected to ship only the host platform's minicore binary.
+Keeping foreign-arch binaries in the sdist failed downstream packaging audits
+(Homebrew, conda-forge). Wheels come from the git tree directly and are
+unaffected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytestmark = pytest.mark.skipolddriver
+
+pytest.importorskip(
+    "setuptools",
+    reason="setup.py imports setuptools at module scope",
+)
+# Some Python 3.14+ test envs ship without setuptools.command.sdist even when
+# the top-level `setuptools` package is importable; guard both.
+pytest.importorskip("setuptools.command.sdist")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_PY = REPO_ROOT / "setup.py"
+
+MINICORE_PLATFORMS = (
+    "aix_ppc64",
+    "linux_aarch64_glibc",
+    "linux_aarch64_musl",
+    "linux_x86_64_glibc",
+    "linux_x86_64_musl",
+    "macos_aarch64",
+    "macos_x86_64",
+    "windows_x86_64",
+)
+
+
+def _load_setup_module():
+    spec = importlib.util.spec_from_file_location("_setup_under_test", SETUP_PY)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch("sys.argv", ["setup.py", "--help-commands"]):
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def setup_module():
+    try:
+        return _load_setup_module()
+    except ModuleNotFoundError as exc:
+        pytest.skip(f"setup.py cannot be loaded in this env: {exc}")
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "libc", "expected"),
+    [
+        ("Linux", "x86_64", ("glibc", "2.35"), "linux_x86_64_glibc"),
+        ("Linux", "aarch64", ("glibc", "2.35"), "linux_aarch64_glibc"),
+        ("Linux", "x86_64", ("musl", "1.2.3"), "linux_x86_64_musl"),
+        ("Linux", "aarch64", ("", ""), "linux_aarch64_musl"),
+        ("Darwin", "arm64", ("", ""), "macos_aarch64"),
+        ("Darwin", "x86_64", ("", ""), "macos_x86_64"),
+        ("Windows", "AMD64", ("", ""), "windows_x86_64"),
+        ("AIX", "ppc64", ("", ""), "aix_ppc64"),
+    ],
+)
+def test_host_subdir_resolves(setup_module, system, machine, libc, expected):
+    with mock.patch("platform.system", return_value=system), mock.patch(
+        "platform.machine", return_value=machine
+    ), mock.patch("platform.libc_ver", return_value=libc):
+        assert setup_module._host_minicore_subdir() == expected
+
+
+def test_host_subdir_returns_none_for_unknown_arch(setup_module):
+    with mock.patch("platform.system", return_value="Linux"), mock.patch(
+        "platform.machine", return_value="riscv64"
+    ), mock.patch("platform.libc_ver", return_value=("glibc", "2.35")):
+        assert setup_module._host_minicore_subdir() is None
+
+
+def _populate_fake_tree(base_dir: Path) -> Path:
+    minicore = base_dir / "src" / "snowflake" / "connector" / "minicore"
+    minicore.mkdir(parents=True)
+    (minicore / "__init__.py").write_text("")
+    for name in MINICORE_PLATFORMS:
+        platform_dir = minicore / name
+        platform_dir.mkdir()
+        (platform_dir / "libsf_mini_core.so").write_bytes(b"\x7fELF-stub")
+    return minicore
+
+
+def _make_sdist_cmd(setup_module):
+    """Construct the sdist command without running its real init."""
+    return setup_module.HostOnlyMinicoreSdist.__new__(
+        setup_module.HostOnlyMinicoreSdist
+    )
+
+
+def test_make_release_tree_keeps_only_host_dir(setup_module, tmp_path):
+    base_dir = tmp_path / "sdist_tree"
+    minicore = _populate_fake_tree(base_dir)
+
+    cmd = _make_sdist_cmd(setup_module)
+
+    with mock.patch.object(
+        setup_module.sdist, "make_release_tree", lambda self, b, f: None
+    ), mock.patch.object(
+        setup_module, "_host_minicore_subdir", return_value="linux_x86_64_glibc"
+    ):
+        cmd.make_release_tree(str(base_dir), [])
+
+    remaining = sorted(entry for entry in os.listdir(minicore))
+    assert remaining == ["__init__.py", "linux_x86_64_glibc"]
+
+
+def test_make_release_tree_raises_for_unknown_host(setup_module, tmp_path):
+    base_dir = tmp_path / "sdist_tree"
+    _populate_fake_tree(base_dir)
+
+    cmd = _make_sdist_cmd(setup_module)
+
+    with mock.patch.object(
+        setup_module.sdist, "make_release_tree", lambda self, b, f: None
+    ), mock.patch.object(setup_module, "_host_minicore_subdir", return_value=None):
+        with pytest.raises(RuntimeError, match="no matching"):
+            cmd.make_release_tree(str(base_dir), [])
+
+
+def test_make_release_tree_raises_when_host_subdir_missing(setup_module, tmp_path):
+    base_dir = tmp_path / "sdist_tree"
+    minicore = _populate_fake_tree(base_dir)
+    # Simulate a git tree where the host dir was never populated.
+    import shutil
+
+    shutil.rmtree(minicore / "linux_x86_64_glibc")
+
+    cmd = _make_sdist_cmd(setup_module)
+
+    with mock.patch.object(
+        setup_module.sdist, "make_release_tree", lambda self, b, f: None
+    ), mock.patch.object(
+        setup_module, "_host_minicore_subdir", return_value="linux_x86_64_glibc"
+    ):
+        with pytest.raises(RuntimeError, match="expected .* to exist"):
+            cmd.make_release_tree(str(base_dir), [])
+
+
+def test_make_release_tree_noop_without_minicore_dir(setup_module, tmp_path):
+    base_dir = tmp_path / "sdist_tree"
+    base_dir.mkdir()
+
+    cmd = _make_sdist_cmd(setup_module)
+
+    with mock.patch.object(
+        setup_module.sdist, "make_release_tree", lambda self, b, f: None
+    ):
+        cmd.make_release_tree(str(base_dir), [])
+
+
+def test_host_subdir_agrees_with_runtime_loader(setup_module):
+    from snowflake.connector._utils import _CoreLoader
+
+    try:
+        runtime = _CoreLoader._get_platform_subdir()
+    except OSError:
+        pytest.skip("runtime loader does not support this platform")
+    assert setup_module._host_minicore_subdir() == runtime


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2870. Alternative to #2871.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Problem.** Since 4.0.0 the sdist ships prebuilt minicore binaries for every supported platform under `src/snowflake/connector/minicore/`. The runtime loader (`_CoreLoader._get_platform_subdir`) only ever opens one, so the other 7 are dead weight. Downstream packaging audits that reject foreign-arch binaries (e.g. `brew audit`) fail — this blocked the Homebrew release of `snowflake-cli` 3.17.0 ([Homebrew/homebrew-core#282333](https://github.com/Homebrew/homebrew-core/pull/282333)), the first CLI release pulling `snowflake-connector-python >= 4.0.0`. Same class of problem will hit conda-forge, nixpkgs, and distro maintainers.

   **Why this PR, not #2871.** #2871 treated the symptom: a `build_py` hook pruned non-native subdirs on every install. That copy of `_CoreLoader._get_platform_subdir` had to be kept in sync with the runtime via a test, and it ran on every wheel build and end-user install. This PR tracks the root cause — the binaries should never have been in the sdist in the first place — and fixes it at the single source: the `sdist` command.

   **Fix.** Override `setuptools.command.sdist.make_release_tree` to remove foreign-arch subdirs from the staged sdist tree before the tarball is written. The git tree keeps all 8 binaries (wheel CI consumes them directly via `ci/build_linux.sh`, unchanged). Install-time is untouched for wheels and sdists alike.

   The command fails fast if the host platform is unrecognised or its minicore subdir is missing, so a silently-broken sdist never ships. `check-manifest` is configured with an `ignore` rule for `src/snowflake/connector/minicore/**` because the intentional asymmetry between git and the sdist would otherwise trip the pre-commit hook.

   **Verified locally** by running `python setup.py sdist`, confirming only the native `linux_aarch64_glibc/libsf_mini_core.so` ended up in the tarball (git tree still has all 8), then `pip install`-ing the tarball into a clean venv and confirming the installed tree contains only the host binary.

   Tracked internally as SNOW-3526469.

4. (Optional) PR for stored-proc connector: