### PR TITLE
SNOW-3526469: move minicore pruning note to Upcoming Release

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,8 +7,10 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
-- v4.5.0(May 12,2026)
+- Upcoming Release
   - Fixed sdist to only install the minicore binary matching the current platform (SNOW-3526469). Previous 4.x releases copied every platform's minicore `.so`/`.dylib`/`.dll` into the install prefix, breaking downstream packagers (e.g. Homebrew) whose audits reject foreign-arch binaries.
+
+- v4.5.0(May 12,2026)
   - Fixed `write_pandas` temp stage name collisions (SNOW-3481510). The old PRNG could produce identical name sequences in forked processes (e.g. Notebook kernels), causing `CREATE TEMPORARY STAGE` to fail with "Object already exists".
   - Fixed a security bug in Okta SAML authentication where `_is_prefix_equal()` compared `url1`'s port against itself instead of `url2`'s port, allowing an attacker to redirect credentials to a different port on the same hostname. Also fixed the default port fallback to use `int` instead of `str` for correct comparison when one URL omits the port.
   - Fixed `executemany` with `paramstyle="pyformat"` to correctly locate the VALUES clause using a balanced-parentheses parser instead of a greedy regex. This fixes incorrect behaviour with nested function calls such as SQLAlchemy `@compiles VARIANT` patterns (e.g. `PARSE_JSON(%(col)s)`) and subquery-form INSERTs (SNOW-298756).


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Follow-up to #2871 / #2870.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Problem.** #2871 was based on `c2b2ba7b` (the "Bump up version to 4.5.0" commit) and added its changelog entry under the `v4.5.0(May 12,2026)` heading. That PR merged after the `v4.5.0` tag was already cut, so the minicore-pruning fix is **not** part of the v4.5.0 release — it currently mis-advertises itself as such in `DESCRIPTION.md`.

   **Fix.** Move the entry out of `v4.5.0` and into a new `Upcoming Release` section above it. This matches the convention already used in this repo for between-release changelog additions (see commits `e0cefafd` "Add changelog entry for permissions env var rename" and `44d8c376` "Move 3.14t changelog to Upcoming Release"), where an `Upcoming Release` header floats above the latest tagged version until the next version bump rolls those entries into a dated release.

   No code changes — `DESCRIPTION.md` only.