### PR TITLE
Fix OAuth authorization code refresh-token caching and Snowflake-as-IdP scope

### DIFF
--- a/src/snowflake/connector/auth/_oauth_base.py
+++ b/src/snowflake/connector/auth/_oauth_base.py
@@ -152,6 +152,7 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
         scope: str,
         token_cache: TokenCache | None,
         refresh_token_enabled: bool,
+        is_snowflake_as_idp: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -167,7 +168,12 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
         self._scope = scope
         if refresh_token_enabled:
             logger.debug("oauth refresh token is going to be used if needed")
-            self._scope += (" " if self._scope else "") + "offline_access"
+            # Snowflake's OAuth IdP issues refresh tokens based on the security
+            # integration's OAUTH_ISSUE_REFRESH_TOKENS setting, not via the
+            # offline_access scope. Appending it would cause "invalid_scope"
+            # errors. Only append for external IdPs (Okta, Azure AD, etc.).
+            if not is_snowflake_as_idp:
+                self._scope += (" " if self._scope else "") + "offline_access"
 
     @abstractmethod
     def _request_tokens(
@@ -268,6 +274,13 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
                 "OAuth access token is already available in cache, no need to authenticate."
             )
             return
+        if self._pop_cached_refresh_token():
+            logger.debug(
+                "OAuth refresh token is available in cache, try to use it to obtain a new access token"
+            )
+            self._do_refresh_token(conn=conn)
+            if self._access_token:
+                return
         access_token, refresh_token = self._request_tokens(
             conn=conn,
             authenticator=authenticator,

--- a/src/snowflake/connector/auth/oauth_code.py
+++ b/src/snowflake/connector/auth/oauth_code.py
@@ -92,6 +92,9 @@ class AuthByOauthCode(AuthByOAuthBase):
             scope=scope,
             token_cache=token_cache,
             refresh_token_enabled=refresh_token_enabled,
+            is_snowflake_as_idp=self._is_snowflake_as_idp(
+                authentication_url, token_request_url, host
+            ),
             **kwargs,
         )
         self._application = application

--- a/test/unit/test_auth_oauth_auth_code.py
+++ b/test/unit/test_auth_oauth_auth_code.py
@@ -5,13 +5,14 @@
 
 import unittest.mock as mock
 from test.helpers import apply_auth_class_update_body, create_mock_auth_body
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
 from snowflake.connector.auth import AuthByOauthCode
 from snowflake.connector.errors import ProgrammingError
 from snowflake.connector.network import OAUTH_AUTHORIZATION_CODE
+from snowflake.connector.token_cache import TokenKey, TokenType
 
 
 @pytest.fixture()
@@ -111,6 +112,145 @@ def test_auth_oauth_auth_code_single_use_refresh_tokens(
                 account="acc",
                 user="user",
             )
+
+
+def test_auth_oauth_auth_code_offline_access_omitted_for_snowflake_idp():
+    """When Snowflake is the OAuth IdP, the offline_access scope must not be appended:
+    Snowflake issues refresh tokens via the security integration's
+    OAUTH_ISSUE_REFRESH_TOKENS setting, and adding offline_access causes the IdP to
+    return an invalid_scope error.
+    """
+    auth = AuthByOauthCode(
+        application="app",
+        client_id="",
+        client_secret="",
+        authentication_url="https://example.snowflakecomputing.com/oauth/authorize",
+        token_request_url="https://example.snowflakecomputing.com/oauth/token",
+        redirect_uri="http://127.0.0.1:8080",
+        scope="session:role:ENGINEER",
+        host="example.snowflakecomputing.com",
+        refresh_token_enabled=True,
+    )
+    assert auth._scope == "session:role:ENGINEER"
+
+
+def test_auth_oauth_auth_code_offline_access_appended_for_external_idp(
+    omit_oauth_urls_check,
+):
+    """For external IdPs (Okta, Azure AD, etc.) the connector must continue to append
+    offline_access so the IdP issues a refresh token alongside the access token.
+    """
+    auth = AuthByOauthCode(
+        application="app",
+        client_id="clientId",
+        client_secret="clientSecret",
+        authentication_url="https://idp.example.com/oauth/authorize",
+        token_request_url="https://idp.example.com/oauth/token",
+        redirect_uri="http://127.0.0.1:8080",
+        scope="session:role:ENGINEER",
+        host="example.snowflakecomputing.com",
+        refresh_token_enabled=True,
+    )
+    assert auth._scope == "session:role:ENGINEER offline_access"
+
+
+def test_auth_oauth_auth_code_prepare_uses_cached_refresh_token(omit_oauth_urls_check):
+    """When the access token cache misses but a refresh token is cached, prepare() should
+    exchange the refresh token for a new access token instead of launching the browser flow.
+    """
+    token_cache = MagicMock()
+    refresh_token_value = "cached-refresh-token"
+
+    def retrieve(key: TokenKey) -> str | None:
+        if key.tokenType == TokenType.OAUTH_REFRESH_TOKEN:
+            return refresh_token_value
+        return None
+
+    token_cache.retrieve.side_effect = retrieve
+
+    auth = AuthByOauthCode(
+        "app",
+        "clientId",
+        "clientSecret",
+        "https://idp.example.com/oauth/authorize",
+        "https://idp.example.com/oauth/token",
+        "http://127.0.0.1:8080",
+        "scope",
+        "host",
+        pkce_enabled=False,
+        token_cache=token_cache,
+        refresh_token_enabled=True,
+    )
+
+    refresh_response = MagicMock()
+    refresh_response.data = b'{"access_token": "new-access-token"}'
+
+    with patch(
+        "snowflake.connector.auth.AuthByOauthCode._get_refresh_token_response",
+        return_value=refresh_response,
+    ) as mock_refresh, patch(
+        "snowflake.connector.auth.AuthByOauthCode._request_tokens",
+    ) as mock_request_tokens:
+        auth.prepare(
+            conn=None,
+            authenticator=OAUTH_AUTHORIZATION_CODE,
+            service_name=None,
+            account="acc",
+            user="user",
+        )
+
+    mock_refresh.assert_called_once()
+    mock_request_tokens.assert_not_called()
+    assert auth._access_token == "new-access-token"
+
+
+def test_auth_oauth_auth_code_prepare_falls_back_to_browser_when_refresh_fails(
+    omit_oauth_urls_check,
+):
+    """When the cached refresh token exchange fails, prepare() should fall back to the
+    full browser-based token request flow.
+    """
+    token_cache = MagicMock()
+
+    def retrieve(key: TokenKey) -> str | None:
+        if key.tokenType == TokenType.OAUTH_REFRESH_TOKEN:
+            return "stale-refresh-token"
+        return None
+
+    token_cache.retrieve.side_effect = retrieve
+
+    auth = AuthByOauthCode(
+        "app",
+        "clientId",
+        "clientSecret",
+        "https://idp.example.com/oauth/authorize",
+        "https://idp.example.com/oauth/token",
+        "http://127.0.0.1:8080",
+        "scope",
+        "host",
+        pkce_enabled=False,
+        token_cache=token_cache,
+        refresh_token_enabled=True,
+    )
+
+    with patch(
+        "snowflake.connector.auth.AuthByOauthCode._get_refresh_token_response",
+        return_value=None,
+    ) as mock_refresh, patch(
+        "snowflake.connector.auth.AuthByOauthCode._request_tokens",
+        return_value=("browser-access-token", "browser-refresh-token"),
+    ) as mock_request_tokens:
+        auth.prepare(
+            conn=None,
+            authenticator=OAUTH_AUTHORIZATION_CODE,
+            service_name=None,
+            account="acc",
+            user="user",
+        )
+
+    mock_refresh.assert_called_once()
+    mock_request_tokens.assert_called_once()
+    assert auth._access_token == "browser-access-token"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Two fixes for `OAUTH_AUTHORIZATION_CODE` that together stop the browser popup on every script invocation when `client_store_temporary_credential=True` and `oauth_enable_refresh_tokens=True` are set:

- **`AuthByOAuthBase.prepare()` now consults the cached refresh token before launching the browser.** Previously the cached RT was only consumed from `reauthenticate()`, which is not invoked for `OAUTH_AUTHORIZATION_CODE` from `network.py` — so the cached RT was ignored across processes and every AT expiry (~10 min) re-launched the browser.
- **Do not append `offline_access` when Snowflake itself is the OAuth IdP.** Snowflake issues refresh tokens based on the security integration's `OAUTH_ISSUE_REFRESH_TOKENS` parameter, not via the OIDC `offline_access` scope. Appending it caused the IdP to render an `invalid_scope` page in the browser flow. External IdPs (Okta, Azure AD, etc.) continue to receive `offline_access` as before.

## Reproducer

```python
import snowflake.connector

conn = snowflake.connector.connect(
    account="acc",
    user="jdoe",
    authenticator="OAUTH_AUTHORIZATION_CODE",
    role="ENGINEER",
    warehouse="xs",
    client_store_temporary_credential=True,
    oauth_enable_refresh_tokens=True,
)
with conn.cursor() as cur:
    cur.execute("SELECT 1")
    print(cur.fetchone()[0])
conn.close()
```

Before: every ~10 minutes (AT lifetime) the browser pops; for Snowflake-as-IdP the browser shows `invalid_scope`.
After: first run does the browser flow once; subsequent runs silently exchange the cached RT for a new AT.

## Test plan

- [x] `test_auth_oauth_auth_code_offline_access_omitted_for_snowflake_idp` — scope stays `session:role:ENGINEER` for Snowflake IdP
- [x] `test_auth_oauth_auth_code_offline_access_appended_for_external_idp` — scope becomes `session:role:ENGINEER offline_access` for external IdP
- [x] `test_auth_oauth_auth_code_prepare_uses_cached_refresh_token` — verifies the silent-refresh path skips the browser
- [x] `test_auth_oauth_auth_code_prepare_falls_back_to_browser_when_refresh_fails` — verifies stale RT gracefully falls back to the browser flow
- [ ] Manual repro against Snowhouse with the script above — confirm browser pops once, then silent for the duration of the RT lifetime
- [ ] Manual repro against an external IdP (Okta) — confirm `offline_access` is still requested and refresh works

🤖 Generated with [Claude Code](https://claude.com/claude-code)