### PR TITLE
Fix/underscore account hostname

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,6 +7,9 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
+- v4.6.1(TBD)
+  - Fixed SSL hostname mismatch when using the async connector with account names containing underscores (#1839).
+
 - v4.6.0(May 28,2026)
   - Dropped support for Python 3.9. The minimum supported version is now Python 3.10.
   - Fixed sdist to only install the minicore binary matching the current platform (SNOW-3526469). Previous 4.x releases copied every platform's minicore `.so`/`.dylib`/`.dll` into the install prefix, breaking downstream packagers (e.g. Homebrew) whose audits reject foreign-arch binaries.

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -306,6 +306,8 @@ def _concatenate_statements(
 
 def construct_hostname(region: str | None, account: str) -> str:
     """Constructs hostname from region and account."""
+    # RFC 952: underscores are not valid in hostnames
+    account = account.replace("_", "-")
 
     def _is_china_region(r: str) -> bool:
         # This is consistent with the Go driver:


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue
to your PR.

Fixes #1839 
The async connector fails with SSL hostname mismatch on Python 3.11+ when the account name contains underscores (e.g. `my_org_account`), because the resulting hostname is rejected during TLS verification.

I saw that it's already being discussed in #1839. @sfc-gh-dszmolka's test confirmed that both `_` and `-` resolve to the same account.
(I've seen that the official Snowflake docs also document this now in: https://docs.snowflake.com/en/user-guide/admin-account-identifier)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This one-liner in `construct_hostname()` normalizes underscores to hyphens before building the FQDN, same approach dbt-snowflake shipped in dbt-labs/dbt-snowflake#1068.

Note: this reopens #2897, which was closed for administrative reasons unrelated to the code.