### PR TITLE
NO-SNOW: handle S3 307/308 redirects with re-signing

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,6 +12,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Improved URL validation reliability by replacing the hand-rolled regex in `is_valid_url()` with `urllib.parse.urlparse` (SNOW-3392651).
   - Fixed OAuth infinite loop when tokens expire by ensuring `reauthenticate()` calls `_request_tokens()` directly instead of looping through `prepare()`. Token cache is now read exactly once per connection, and `_store_tokens()` preserves macOS Keychain ACL by never calling `remove()`. The async OAuth `reauthenticate()` now runs the synchronous OAuth flow on a worker thread instead of blocking the event loop.
   - Fixed OAuth scope handling for Snowflake custom OAuth: when refresh tokens are enabled, the connector no longer appends the OIDC `offline_access` scope for token endpoints on `*.snowflakecomputing.com` or `*.snowflakecomputing.cn`, which caused `invalid_scope` errors. Snowflake custom OAuth expects `refresh_token` in scope instead. External IdP behavior is unchanged.
+  - Fixed S3 storage client to correctly handle 307/308 (method-preserving) and 301/302 (GET/HEAD only) redirects by disabling automatic redirect following and re-signing each request with AWS SigV4 credentials for the redirect target. The region is updated from the `x-amz-bucket-region` response header on each redirect. Redirects are capped at 5 hops.
 
 - v4.6.0(May 28,2026)
   - Dropped support for Python 3.9. The minimum supported version is now Python 3.10.

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -329,7 +329,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         if query_parts is None:
             query_parts = {}
 
-        for redirect_count in range(MAX_S3_REDIRECTS):
+        for _ in range(MAX_S3_REDIRECTS):
             response = self._send_single_request_with_authentication(
                 url=url,
                 verb=verb,
@@ -345,44 +345,49 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             if response.status_code not in ALL_REDIRECT_STATUS_CODES:
                 return response
 
-            # Handle redirect
-            if response.status_code in METHOD_CHANGING_REDIRECTS:
-                if verb not in ("GET", "HEAD"):
-                    raise OperationalError(
-                        msg=f"S3 returned {response.status_code} for {verb} request. "
-                        f"Expected 307/308 for method-preserving redirect.",
-                        errno=253003,
-                    )
-
-            location = response.headers.get("Location")
-            if not location:
-                raise OperationalError(
-                    msg=f"S3 returned {response.status_code} without Location header",
-                    errno=253003,
-                )
-
-            bucket_region = response.headers.get("x-amz-bucket-region")
-            if not bucket_region:
-                raise OperationalError(
-                    msg=f"S3 returned {response.status_code} without x-amz-bucket-region header",
-                    errno=253003,
-                )
-
-            logger.debug(
-                "S3 redirect: %d from %s to %s (region: %s)",
-                response.status_code,
-                url,
-                location,
-                bucket_region,
-            )
-
-            url = location
-            self.region_name = bucket_region
+            url = self._handle_s3_redirect(response, verb, url)
 
         raise OperationalError(
             msg=f"Too many S3 redirects (max {MAX_S3_REDIRECTS})",
             errno=253003,
         )
+
+    def _handle_s3_redirect(
+        self, response: requests.Response, verb: str, original_url: str
+    ) -> str:
+        """Handle S3 redirect response, update region, and return new URL."""
+        if response.status_code in METHOD_CHANGING_REDIRECTS:
+            if verb not in ("GET", "HEAD"):
+                raise OperationalError(
+                    msg=f"S3 returned {response.status_code} for {verb} request. "
+                    f"Expected 307/308 for method-preserving redirect.",
+                    errno=253003,
+                )
+
+        location = response.headers.get("Location")
+        if not location:
+            raise OperationalError(
+                msg=f"S3 returned {response.status_code} without Location header",
+                errno=253003,
+            )
+
+        bucket_region = response.headers.get("x-amz-bucket-region")
+        if not bucket_region:
+            raise OperationalError(
+                msg=f"S3 returned {response.status_code} without x-amz-bucket-region header",
+                errno=253003,
+            )
+
+        logger.debug(
+            "S3 redirect: %d from %s to %s (region: %s)",
+            response.status_code,
+            original_url,
+            location,
+            bucket_region,
+        )
+
+        self.region_name = bucket_region
+        return location
 
     def _send_single_request_with_authentication(
         self,

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from cryptography.hazmat.primitives import hashes, hmac
 
 from .compat import quote, urlparse
-from .errors import OperationalError
 from .constants import (
     HTTP_HEADER_CONTENT_TYPE,
     HTTP_HEADER_VALUE_OCTET_STREAM,
@@ -20,6 +19,7 @@ from .constants import (
     ResultStatus,
 )
 from .encryption_util import EncryptionMetadata
+from .errors import OperationalError
 from .storage_client import SnowflakeStorageClient, remove_content_encoding
 from .vendored import requests
 
@@ -659,7 +659,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
         else:
             chunk_size = self.chunk_size
             if chunk_id < self.num_of_chunks - 1:
-                _range = f"{chunk_id * chunk_size}-{(chunk_id+1)*chunk_size-1}"
+                _range = f"{chunk_id * chunk_size}-{(chunk_id + 1) * chunk_size - 1}"
             else:
                 _range = f"{chunk_id * chunk_size}-"
 

--- a/src/snowflake/connector/s3_storage_client.py
+++ b/src/snowflake/connector/s3_storage_client.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from cryptography.hazmat.primitives import hashes, hmac
 
 from .compat import quote, urlparse
+from .errors import OperationalError
 from .constants import (
     HTTP_HEADER_CONTENT_TYPE,
     HTTP_HEADER_VALUE_OCTET_STREAM,
@@ -37,6 +38,12 @@ AMZ_IV = "x-amz-iv"
 ERRORNO_WSAECONNABORTED = 10053  # network connection was aborted
 
 EXPIRED_TOKEN = "ExpiredToken"
+
+# S3 redirect handling
+MAX_S3_REDIRECTS = 5
+METHOD_PRESERVING_REDIRECTS = (307, 308)
+METHOD_CHANGING_REDIRECTS = (301, 302)
+ALL_REDIRECT_STATUS_CODES = METHOD_PRESERVING_REDIRECTS + METHOD_CHANGING_REDIRECTS
 ADDRESSING_STYLE = "virtual"  # explicit force to use virtual addressing style
 UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
 
@@ -321,6 +328,75 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             payload = b""
         if query_parts is None:
             query_parts = {}
+
+        for redirect_count in range(MAX_S3_REDIRECTS):
+            response = self._send_single_request_with_authentication(
+                url=url,
+                verb=verb,
+                retry_id=retry_id,
+                query_parts=query_parts,
+                x_amz_headers=x_amz_headers.copy(),
+                headers=headers.copy(),
+                payload=payload,
+                unsigned_payload=unsigned_payload,
+                ignore_content_encoding=ignore_content_encoding,
+            )
+
+            if response.status_code not in ALL_REDIRECT_STATUS_CODES:
+                return response
+
+            # Handle redirect
+            if response.status_code in METHOD_CHANGING_REDIRECTS:
+                if verb not in ("GET", "HEAD"):
+                    raise OperationalError(
+                        msg=f"S3 returned {response.status_code} for {verb} request. "
+                        f"Expected 307/308 for method-preserving redirect.",
+                        errno=253003,
+                    )
+
+            location = response.headers.get("Location")
+            if not location:
+                raise OperationalError(
+                    msg=f"S3 returned {response.status_code} without Location header",
+                    errno=253003,
+                )
+
+            bucket_region = response.headers.get("x-amz-bucket-region")
+            if not bucket_region:
+                raise OperationalError(
+                    msg=f"S3 returned {response.status_code} without x-amz-bucket-region header",
+                    errno=253003,
+                )
+
+            logger.debug(
+                "S3 redirect: %d from %s to %s (region: %s)",
+                response.status_code,
+                url,
+                location,
+                bucket_region,
+            )
+
+            url = location
+            self.region_name = bucket_region
+
+        raise OperationalError(
+            msg=f"Too many S3 redirects (max {MAX_S3_REDIRECTS})",
+            errno=253003,
+        )
+
+    def _send_single_request_with_authentication(
+        self,
+        url: str,
+        verb: str,
+        retry_id: int | str,
+        query_parts: dict[str, str],
+        x_amz_headers: dict[str, str],
+        headers: dict[str, str],
+        payload: bytes | bytearray | IOBase,
+        unsigned_payload: bool,
+        ignore_content_encoding: bool,
+    ) -> requests.Response:
+        """Send a single authenticated request to S3 with retry logic."""
         parsed_url = urlparse(url)
         x_amz_headers["x-amz-security-token"] = self.credentials.creds.get(
             "AWS_TOKEN", ""
@@ -377,7 +453,7 @@ class SnowflakeS3RestClient(SnowflakeStorageClient):
             )
             headers.update(x_amz_headers)
             headers["Authorization"] = authorization_header
-            rest_args = {"headers": headers}
+            rest_args = {"headers": headers, "allow_redirects": False}
 
             if payload:
                 rest_args["data"] = payload

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -549,7 +549,7 @@ def test_s3_redirect_307_success_with_resign():
         return success_resp
 
     with mock.patch.dict(METHODS, HEAD=mock_head):
-        result = rest_client.get_file_header("file.txt")
+        rest_client.get_file_header("file.txt")
         assert call_count[0] == 2
         assert rest_client.region_name == "us-west-2"
 
@@ -742,7 +742,7 @@ def test_s3_redirect_301_allowed_for_head():
         return success_resp
 
     with mock.patch.dict(METHODS, HEAD=mock_head):
-        result = rest_client.get_file_header("file.txt")
+        rest_client.get_file_header("file.txt")
         assert call_count[0] == 2
         assert rest_client.region_name == "us-west-2"
 

--- a/test/unit/test_s3_util.py
+++ b/test/unit/test_s3_util.py
@@ -18,7 +18,7 @@ from ..helpers import verify_log_tuple
 
 try:
     from snowflake.connector.constants import megabyte
-    from snowflake.connector.errors import RequestExceedMaxRetryError
+    from snowflake.connector.errors import OperationalError, RequestExceedMaxRetryError
     from snowflake.connector.file_transfer_agent import (
         SnowflakeFileMeta,
         StorageCredential,
@@ -38,6 +38,7 @@ except ImportError:
     SnowflakeFileMeta = dict
     SnowflakeS3RestClient = None
     RequestExceedMaxRetryError = None
+    OperationalError = None
     StorageCredential = None
     megabytes = 1024 * 1024
     DEFAULT_MAX_RETRY = 5
@@ -495,3 +496,297 @@ def test_accelerate_in_china_endpoint():
         8 * megabyte,
     )
     assert not rest_client.transfer_accelerate_config()
+
+
+def test_s3_redirect_307_success_with_resign():
+    """Tests that 307 redirect is handled by re-signing with new region."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=307)
+    redirect_resp.headers = {
+        "Location": "https://bucket.s3.us-west-2.amazonaws.com/path/file.txt",
+        "x-amz-bucket-region": "us-west-2",
+    }
+    success_resp = MagicMock(autospec=Response, status_code=200)
+    success_resp.headers = {"Content-Length": "100"}
+
+    from snowflake.connector.storage_client import METHODS
+
+    call_count = [0]
+
+    def mock_head(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return redirect_resp
+        return success_resp
+
+    with mock.patch.dict(METHODS, HEAD=mock_head):
+        result = rest_client.get_file_header("file.txt")
+        assert call_count[0] == 2
+        assert rest_client.region_name == "us-west-2"
+
+
+def test_s3_redirect_missing_location_header():
+    """Tests that 307 redirect without Location header raises OperationalError."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=307)
+    redirect_resp.headers = {"x-amz-bucket-region": "us-west-2"}  # No Location
+
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, HEAD=MagicMock(return_value=redirect_resp)):
+        with pytest.raises(OperationalError, match="without Location header"):
+            rest_client.get_file_header("file.txt")
+
+
+def test_s3_redirect_missing_region_header():
+    """Tests that 307 redirect without x-amz-bucket-region header raises OperationalError."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=307)
+    redirect_resp.headers = {
+        "Location": "https://bucket.s3.us-west-2.amazonaws.com/path/file.txt"
+    }  # No x-amz-bucket-region
+
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, HEAD=MagicMock(return_value=redirect_resp)):
+        with pytest.raises(OperationalError, match="without x-amz-bucket-region"):
+            rest_client.get_file_header("file.txt")
+
+
+def test_s3_redirect_301_fails_for_put():
+    """Tests that 301 redirect fails fast for PUT requests."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=301)
+    redirect_resp.headers = {
+        "Location": "https://bucket.s3.us-west-2.amazonaws.com/path/file.txt",
+        "x-amz-bucket-region": "us-west-2",
+    }
+
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, PUT=MagicMock(return_value=redirect_resp)):
+        with mock.patch(
+            "snowflake.connector.storage_client.SnowflakeStorageClient.preprocess"
+        ):
+            rest_client.prepare_upload()
+        with pytest.raises(
+            OperationalError, match="Expected 307/308 for method-preserving redirect"
+        ):
+            rest_client.upload_chunk(0)
+
+
+def test_s3_redirect_301_allowed_for_head():
+    """Tests that 301 redirect is allowed for HEAD requests."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=301)
+    redirect_resp.headers = {
+        "Location": "https://bucket.s3.us-west-2.amazonaws.com/path/file.txt",
+        "x-amz-bucket-region": "us-west-2",
+    }
+    success_resp = MagicMock(autospec=Response, status_code=200)
+    success_resp.headers = {"Content-Length": "100"}
+
+    from snowflake.connector.storage_client import METHODS
+
+    call_count = [0]
+
+    def mock_head(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return redirect_resp
+        return success_resp
+
+    with mock.patch.dict(METHODS, HEAD=mock_head):
+        result = rest_client.get_file_header("file.txt")
+        assert call_count[0] == 2
+        assert rest_client.region_name == "us-west-2"
+
+
+def test_s3_redirect_max_redirects_exceeded():
+    """Tests that too many redirects raises OperationalError."""
+    meta_info = {
+        "name": "data1.txt.gz",
+        "stage_location_type": "S3",
+        "no_sleeping_time": True,
+        "put_callback": None,
+        "put_callback_output_stream": None,
+        SHA256_DIGEST: "123456789abcdef",
+        "dst_file_name": "data1.txt.gz",
+        "src_file_name": path.join(THIS_DIR, "../data", "put_get_1.txt"),
+        "overwrite": True,
+    }
+    meta = SnowflakeFileMeta(**meta_info)
+    creds = {"AWS_SECRET_KEY": "secret", "AWS_KEY_ID": "keyid", "AWS_TOKEN": "token"}
+    rest_client = SnowflakeS3RestClient(
+        meta,
+        StorageCredential(
+            creds,
+            MagicMock(autospec=SnowflakeConnection),
+            "PUT file:/tmp/file.txt @~",
+        ),
+        {
+            "locationType": "AWS",
+            "location": "bucket/path",
+            "creds": creds,
+            "region": "us-east-1",
+            "endPoint": None,
+        },
+        8 * megabyte,
+    )
+
+    redirect_resp = MagicMock(autospec=Response, status_code=307)
+    redirect_resp.headers = {
+        "Location": "https://bucket.s3.us-west-2.amazonaws.com/path/file.txt",
+        "x-amz-bucket-region": "us-west-2",
+    }
+
+    from snowflake.connector.storage_client import METHODS
+
+    with mock.patch.dict(METHODS, HEAD=MagicMock(return_value=redirect_resp)):
+        with pytest.raises(OperationalError, match="Too many S3 redirects"):
+            rest_client.get_file_header("file.txt")


### PR DESCRIPTION
## Summary
- Fix S3 307/308 redirect handling by disabling auto-redirect and re-signing requests with the correct region
- Extract `Location` and `x-amz-bucket-region` headers from redirect response
- Fail fast for 301/302 on non-GET/HEAD methods (which may change HTTP verb)
- Limit redirects to 5 to prevent infinite loops

## Problem
When S3 returns a 307/308 redirect to a different region, the `requests` library auto-follows but strips the Authorization header on cross-host redirects. This causes 403 Forbidden errors.

## Solution
1. Disable auto-redirect following (`allow_redirects=False`)
2. Detect redirect status codes (307, 308, 301, 302)
3. Extract `Location` and `x-amz-bucket-region` headers
4. Re-sign the request with the correct region
5. Retry to the new endpoint

## Test plan
- [x] Added unit tests for 307 redirect with re-signing
- [x] Added unit tests for missing Location header
- [x] Added unit tests for missing x-amz-bucket-region header
- [x] Added unit tests for 301/302 failing on PUT
- [x] Added unit tests for 301/302 succeeding on HEAD
- [x] Added unit tests for max redirects exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)