### PR TITLE
fix async AuthByKeyPair missing private_key_passphrase parameter

### DIFF
--- a/src/snowflake/connector/aio/auth/_keypair.py
+++ b/src/snowflake/connector/aio/auth/_keypair.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import Any
 
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 
 from ...auth.keypair import AuthByKeyPair as AuthByKeyPairSync
@@ -16,11 +17,14 @@ logger = getLogger(__name__)
 class AuthByKeyPair(AuthByPluginAsync, AuthByKeyPairSync):
     def __init__(
         self,
-        private_key: bytes | str | RSAPrivateKey,
+        private_key: bytes | str | RSAPrivateKey | EllipticCurvePrivateKey,
+        private_key_passphrase: bytes | None = None,
         lifetime_in_seconds: int = AuthByKeyPairSync.LIFETIME,
         **kwargs,
     ) -> None:
-        AuthByKeyPairSync.__init__(self, private_key, lifetime_in_seconds, **kwargs)
+        AuthByKeyPairSync.__init__(
+            self, private_key, private_key_passphrase, lifetime_in_seconds, **kwargs
+        )
 
     async def reset_secrets(self) -> None:
         AuthByKeyPairSync.reset_secrets(self)

--- a/test/unit/aio/test_auth_keypair_async.py
+++ b/test/unit/aio/test_auth_keypair_async.py
@@ -151,6 +151,38 @@ async def test_renew_token(mockPrepare):
     assert mockPrepare.called
 
 
+def test_async_keypair_init_with_passphrase_no_multiple_values_error():
+    """Regression test for GH #2896.
+
+    Before the fix, passing private_key_passphrase to the async AuthByKeyPair raised:
+      TypeError: __init__() got multiple values for argument 'private_key_passphrase'
+    because the async __init__ was missing the parameter and forwarded it through
+    **kwargs while also passing lifetime_in_seconds into the passphrase slot positionally.
+    """
+    private_key = rsa.generate_private_key(
+        backend=default_backend(), public_exponent=65537, key_size=2048
+    )
+    passphrase = b"test-passphrase"
+    private_key_der_encrypted = private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(passphrase),
+    )
+    # must not raise "got multiple values for argument 'private_key_passphrase'"
+    auth_instance = AuthByKeyPair(
+        private_key=private_key_der_encrypted,
+        private_key_passphrase=passphrase,
+    )
+    assert auth_instance is not None
+
+
+def test_async_keypair_init_without_passphrase():
+    """AuthByKeyPair without passphrase must still work after the param reorder fix."""
+    private_key_der, _ = generate_key_pair(2048)
+    auth_instance = AuthByKeyPair(private_key=private_key_der)
+    assert auth_instance is not None
+
+
 def test_mro():
     """Ensure that methods from AuthByPluginAsync override those from AuthByPlugin."""
     from snowflake.connector.aio.auth import AuthByPlugin as AuthByPluginAsync


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2896

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

pr #2736 inserted `private_key_passphrase` as the second positional parameter of the **sync** `AuthByKeyPair.__init__`, but the **async** subclass in `aio/auth/_keypair.py` was not updated. its `__init__` had no `private_key_passphrase` parameter and forwarded calls as:

```python
AuthByKeyPairSync.__init__(self, private_key, lifetime_in_seconds, **kwargs)
```

when the async connection code calls `AuthByKeyPair(private_key=..., private_key_passphrase=..., ...)`, the passphrase lands in `**kwargs`. the call to the sync init then passes `lifetime_in_seconds` positionally into the passphrase slot, and `private_key_passphrase` is *also* in `**kwargs` — causing:

```
TypeError: AuthByKeyPair.__init__() got multiple values for argument 'private_key_passphrase'
```

this broke **all** async key-pair authentication in v4.5.0+.

the fix adds `private_key_passphrase: bytes | None = None` to the async `__init__` signature and passes it explicitly to the sync `__init__`, matching the parameter order. also aligns the `private_key` type hint to include `EllipticCurvePrivateKey` as in the sync class.

two unit tests are added: one that reproduces the exact failure (encrypted key + passphrase) and one that verifies unencrypted keys still work.