### PR TITLE
Add native EmbeddedStreamlit helper to generate SiS embed URLs via OAuth token-exchange

### DIFF
--- a/src/snowflake/connector/__init__.py
+++ b/src/snowflake/connector/__init__.py
@@ -32,6 +32,7 @@ from .dbapi import (
     Timestamp,
     TimestampFromTicks,
 )
+from .embedded_streamlit import EmbeddedStreamlit
 from .errors import (
     DatabaseError,
     DataError,
@@ -103,4 +104,6 @@ __all__ = [
     "ROWID",
     # Extended data type (experimental)
     "EasyLoggingConfigPython",
+    # Streamlit embedding
+    "EmbeddedStreamlit",
 ]

--- a/src/snowflake/connector/embedded_streamlit.py
+++ b/src/snowflake/connector/embedded_streamlit.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+from .errorcode import ER_FAILED_TO_REQUEST, ER_INVALID_VALUE, ER_NO_HOSTNAME_FOUND
+from .errors import ProgrammingError
+from .session_manager import SessionManager, SessionManagerFactory
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+    from .connection import SnowflakeConnection
+
+logger = logging.getLogger(__name__)
+
+# OAuth 2.0 token-exchange grant (RFC 8693).
+_GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+# subject_token_type URNs, verified against GlobalServices SFOAuthTokenType.java
+# (modules/dbsec/authn-api), 2026-06-25.
+SUBJECT_TOKEN_TYPE_SESSION = "urn:snowflake:token-type:session"
+SUBJECT_TOKEN_TYPE_PAT = "programmatic_access_token"
+SUBJECT_TOKEN_TYPE_WIF = "urn:snowflake:token-type:wif"
+SUBJECT_TOKEN_TYPE_OAUTH_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+# PROVISIONAL: there is no key-pair-JWT subject_token_type in the GS enum today. This
+# default is used for the key_pair credential mode and is overridable via prepare(
+# subject_token_type=...) pending the GS keypair extension.
+SUBJECT_TOKEN_TYPE_JWT = "urn:ietf:params:oauth:token-type:jwt"
+
+# Embed URL query parameters reproduced from the GS system function
+# StreamlitGenerateEmbedUrl.java.
+_PARAM_PARENT_ORIGIN = "__parentOrigin"
+_PARAM_EMBEDDED_APP = "__embeddedApp"
+
+
+class EmbeddedStreamlit:
+    """Generate a Streamlit embed URL via the OAuth token-exchange endpoint.
+
+    This is the native equivalent of the ``SYSTEM$STREAMLIT_GENERATE_EMBED_URL``
+    SQL system function. It lets a customer backend mint a short-lived, single-use
+    embed URL for a Streamlit-in-Snowflake app from a service credential (PAT,
+    key-pair, or a live session) without issuing SQL.
+
+    Usage::
+
+        from snowflake.connector import EmbeddedStreamlit
+
+        url = (
+            EmbeddedStreamlit("MYDB.MYSCHEMA.MY_APP", "https://analytics.example.com")
+            .prepare(pat="<pat>", account="myaccount")
+            .get_embed_url()
+        )
+
+    Exactly one primary credential source must be supplied to :meth:`prepare`:
+    ``pat``, ``conn``, ``key_pair``, or an explicit ``subject_token``.
+    """
+
+    def __init__(self, streamlit_id: str, parent_origin: str) -> None:
+        """Init EmbeddedStreamlit.
+
+        Args:
+            streamlit_id: Fully-qualified name of the Streamlit app
+                (``db.schema.app``). Must not contain a ``:`` since it becomes
+                part of the token-exchange scope ``session:streamlit:<fqn>``.
+            parent_origin: The origin (scheme://host[:port]) of the 3rd-party page
+                that embeds the app. Carried back as the ``__parentOrigin`` query
+                parameter of the final embed URL.
+        """
+        if not streamlit_id:
+            raise ProgrammingError(
+                msg="streamlit_id must be a non-empty string",
+                errno=ER_INVALID_VALUE,
+            )
+        if ":" in streamlit_id:
+            raise ProgrammingError(
+                msg="streamlit_id (the db.schema.app FQN) must not contain ':'",
+                errno=ER_INVALID_VALUE,
+            )
+        if not parent_origin:
+            raise ProgrammingError(
+                msg="parent_origin must be a non-empty string",
+                errno=ER_INVALID_VALUE,
+            )
+
+        self._streamlit_id = streamlit_id
+        self._parent_origin = parent_origin
+
+        # Populated by prepare().
+        self._embed_url: str | None = None
+        self._expires_in: int | None = None
+
+    def prepare(
+        self,
+        *,
+        pat: str | None = None,
+        conn: SnowflakeConnection | None = None,
+        key_pair: bytes | str | RSAPrivateKey | EllipticCurvePrivateKey | None = None,
+        account: str | None = None,
+        host: str | None = None,
+        user: str | None = None,
+        subject_token: str | None = None,
+        subject_token_type: str | None = None,
+        token_endpoint: str | None = None,
+        session_manager: SessionManager | None = None,
+        timeout: int | None = 30,
+    ) -> EmbeddedStreamlit:
+        """Exchange the service credential for an authorization code and build the URL.
+
+        Exactly one primary credential source must be given: ``pat``, ``conn``,
+        ``key_pair``, or an explicit ``subject_token``.
+
+        Args:
+            pat: A Programmatic Access Token value. Requires ``account`` (or
+                ``host``) so the token endpoint can be resolved.
+            conn: A live :class:`SnowflakeConnection`. The session token and host
+                are pulled from it; no ``account``/``host`` needed.
+            key_pair: An unencrypted RSA/ECDSA private key (DER bytes, base64 str,
+                or a loaded key object). Requires ``account`` and ``user`` to mint
+                the key-pair JWT. May also be a pre-signed JWT string when paired
+                with an explicit ``subject_token_type``.
+            account: Snowflake account identifier; used to build the host when
+                ``host`` is not given, and to mint the key-pair JWT.
+            host: Explicit host (e.g. ``myaccount.snowflakecomputing.com``).
+                Overrides ``account`` for host resolution.
+            user: Snowflake user; required for the ``key_pair`` mode JWT.
+            subject_token: A pre-obtained credential value to send as-is. Pair with
+                ``subject_token_type`` for forward-compatibility / escape hatch.
+            subject_token_type: Override the ``subject_token_type`` URN. Defaults are
+                chosen per credential mode (session/PAT/JWT). Required when only
+                ``subject_token`` is given.
+            token_endpoint: Override the full token endpoint URL. Defaults to
+                ``https://<host>/oauth/token``. Injectable for tests.
+            session_manager: Override the HTTP session manager (injectable for
+                tests). Defaults to the connection's manager (``conn`` mode) or a
+                freshly created one.
+            timeout: Per-request timeout in seconds for the token exchange POST.
+
+        Returns:
+            self, so :meth:`get_embed_url` can be chained.
+        """
+        subject_token_value, token_type, resolved_host, resolved_manager = (
+            self._resolve_credential(
+                pat=pat,
+                conn=conn,
+                key_pair=key_pair,
+                account=account,
+                host=host,
+                user=user,
+                subject_token=subject_token,
+                subject_token_type=subject_token_type,
+                session_manager=session_manager,
+            )
+        )
+
+        endpoint = token_endpoint or self._default_token_endpoint(resolved_host)
+        if not endpoint:
+            raise ProgrammingError(
+                msg="Unable to resolve the token endpoint: provide one of "
+                "token_endpoint, host, account, or conn.",
+                errno=ER_NO_HOSTNAME_FOUND,
+            )
+
+        redirect_uri, expires_in = self._exchange_token(
+            endpoint=endpoint,
+            subject_token=subject_token_value,
+            subject_token_type=token_type,
+            session_manager=resolved_manager,
+            timeout=timeout,
+        )
+
+        self._embed_url = self._build_embed_url(redirect_uri)
+        self._expires_in = expires_in
+        return self
+
+    def _resolve_credential(
+        self,
+        *,
+        pat: str | None,
+        conn: SnowflakeConnection | None,
+        key_pair: bytes | str | RSAPrivateKey | EllipticCurvePrivateKey | None,
+        account: str | None,
+        host: str | None,
+        user: str | None,
+        subject_token: str | None,
+        subject_token_type: str | None,
+        session_manager: SessionManager | None,
+    ) -> tuple[str, str, str | None, SessionManager]:
+        """Validate inputs and produce (subject_token, subject_token_type, host, mgr).
+
+        Enforces exactly-one primary credential source and derives the matching
+        ``subject_token_type`` URN unless the caller overrides it.
+        """
+        sources = {
+            "pat": pat is not None,
+            "conn": conn is not None,
+            "key_pair": key_pair is not None,
+            "subject_token": subject_token is not None,
+        }
+        chosen = [name for name, present in sources.items() if present]
+        if len(chosen) == 0:
+            raise ProgrammingError(
+                msg="A credential is required: pass exactly one of pat, conn, "
+                "key_pair, or subject_token.",
+                errno=ER_INVALID_VALUE,
+            )
+        if len(chosen) > 1:
+            raise ProgrammingError(
+                msg="Exactly one credential source is allowed, got: "
+                + ", ".join(sorted(chosen)),
+                errno=ER_INVALID_VALUE,
+            )
+
+        resolved_host = host
+        resolved_manager = session_manager
+
+        if pat is not None:
+            token_value = pat
+            token_type = subject_token_type or SUBJECT_TOKEN_TYPE_PAT
+        elif conn is not None:
+            token_value = self._session_token_from_conn(conn)
+            token_type = subject_token_type or SUBJECT_TOKEN_TYPE_SESSION
+            if resolved_host is None:
+                resolved_host = getattr(conn, "host", None)
+            if resolved_manager is None:
+                # Reuse the connection's pooled session manager when available.
+                resolved_manager = getattr(conn, "_session_manager", None)
+        elif key_pair is not None:
+            token_value = self._jwt_from_key_pair(key_pair, account, user)
+            # PROVISIONAL default — overridable pending the GS keypair extension.
+            token_type = subject_token_type or SUBJECT_TOKEN_TYPE_JWT
+        else:
+            # Explicit subject_token escape hatch.
+            token_value = subject_token
+            if not subject_token_type:
+                raise ProgrammingError(
+                    msg="subject_token_type is required when passing an explicit "
+                    "subject_token.",
+                    errno=ER_INVALID_VALUE,
+                )
+            token_type = subject_token_type
+
+        if not token_value:
+            raise ProgrammingError(
+                msg="Resolved credential value is empty.",
+                errno=ER_INVALID_VALUE,
+            )
+
+        if resolved_host is None and host is None and account is not None:
+            resolved_host = self._host_from_account(account)
+
+        if resolved_manager is None:
+            resolved_manager = SessionManagerFactory.get_manager()
+
+        return token_value, token_type, resolved_host, resolved_manager
+
+    @staticmethod
+    def _session_token_from_conn(conn: SnowflakeConnection) -> str:
+        """Pull the live session token out of a SnowflakeConnection.
+
+        The session token lives on the REST layer (``conn.rest.token``). We never
+        log its value.
+        """
+        rest = getattr(conn, "rest", None)
+        token = getattr(rest, "token", None) if rest is not None else None
+        if not token:
+            raise ProgrammingError(
+                msg="The provided connection has no active session token; ensure it "
+                "is connected before calling prepare(conn=...).",
+                errno=ER_INVALID_VALUE,
+            )
+        return token
+
+    @staticmethod
+    def _jwt_from_key_pair(
+        key_pair: bytes | str | RSAPrivateKey | EllipticCurvePrivateKey,
+        account: str | None,
+        user: str | None,
+    ) -> str:
+        """Mint a key-pair JWT, or pass through a pre-signed JWT string.
+
+        When ``account`` and ``user`` are supplied, ``key_pair`` is treated as a
+        private key and signed via :class:`AuthByKeyPair`. When they are absent,
+        ``key_pair`` must already be a signed JWT string and is used verbatim.
+        """
+        if account and user:
+            # Local import to avoid pulling auth (and pyjwt) at module import time.
+            from .auth.keypair import AuthByKeyPair
+
+            auth = AuthByKeyPair(private_key=key_pair)
+            return auth.prepare(account=account, user=user)
+        if isinstance(key_pair, str):
+            # Pre-signed JWT passed directly.
+            return key_pair
+        raise ProgrammingError(
+            msg="key_pair mode requires both account and user to mint a JWT, or a "
+            "pre-signed JWT string.",
+            errno=ER_INVALID_VALUE,
+        )
+
+    @staticmethod
+    def _host_from_account(account: str) -> str:
+        # Local import keeps the module import lightweight.
+        from .util_text import construct_hostname
+
+        return construct_hostname(None, account)
+
+    @staticmethod
+    def _default_token_endpoint(host: str | None) -> str | None:
+        if not host:
+            return None
+        return f"https://{host}/oauth/token"
+
+    def _scope(self) -> str:
+        return f"session:streamlit:{self._streamlit_id}"
+
+    def _exchange_token(
+        self,
+        *,
+        endpoint: str,
+        subject_token: str,
+        subject_token_type: str,
+        session_manager: SessionManager,
+        timeout: int | None,
+    ) -> tuple[str, int | None]:
+        """POST the token-exchange request and return (redirect_uri, expires_in).
+
+        The request body is form-urlencoded per the wire contract. The credential
+        value (``subject_token``) is treated as a secret and never logged.
+        """
+        body = {
+            "grant_type": _GRANT_TYPE_TOKEN_EXCHANGE,
+            "subject_token": subject_token,
+            "subject_token_type": subject_token_type,
+            "scope": self._scope(),
+        }
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Accept": "application/json",
+        }
+
+        logger.debug(
+            "Requesting Streamlit embed token exchange: endpoint=%s, scope=%s, "
+            "subject_token_type=%s",
+            endpoint,
+            self._scope(),
+            subject_token_type,
+        )
+
+        response = session_manager.post(
+            endpoint,
+            headers=headers,
+            data=urlencode(body),
+            timeout=timeout,
+        )
+
+        if response.status_code != 200:
+            # Never echo the response body; it could contain sensitive material.
+            raise ProgrammingError(
+                msg="Streamlit embed token exchange failed with HTTP status "
+                f"{response.status_code}.",
+                errno=ER_FAILED_TO_REQUEST,
+            )
+
+        try:
+            payload = response.json()
+        except Exception as exc:
+            raise ProgrammingError(
+                msg=f"Streamlit embed token exchange returned a non-JSON response: {exc}",
+                errno=ER_FAILED_TO_REQUEST,
+            )
+
+        redirect_uri = (
+            payload.get("redirect_uri") if isinstance(payload, dict) else None
+        )
+        if not redirect_uri:
+            raise ProgrammingError(
+                msg="Streamlit embed token exchange response is missing 'redirect_uri'.",
+                errno=ER_FAILED_TO_REQUEST,
+            )
+
+        expires_in = payload.get("expires_in") if isinstance(payload, dict) else None
+        return redirect_uri, self._coerce_expires_in(expires_in)
+
+    @staticmethod
+    def _coerce_expires_in(value: object) -> int | None:
+        """Coerce the server's ``expires_in`` to ``int | None``.
+
+        The wire contract documents an integer, but defend against a server that
+        returns it as a JSON string (or any non-int) so the ``expires_in``
+        property keeps its declared ``int | None`` type for callers that do
+        ``ttl = es.expires_in``.
+        """
+        if isinstance(value, bool):
+            # bool is an int subclass; do not treat True/False as a TTL.
+            return None
+        if isinstance(value, int):
+            return value
+        try:
+            return int(value)  # handles int-like floats and numeric strings
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _extract_code(redirect_uri: str) -> str:
+        """Extract the single-use authorization code from the redirect URI.
+
+        Per the wire contract the code may be carried as a URL fragment
+        (``#code=...``) OR query (``?code=...`` / ``&code=...``). Fragment takes
+        precedence. The code value is treated as a secret and never logged.
+
+        The code is read VERBATIM and is NOT form-decoded: the GS system function
+        emits it via ``URIBuilder.setFragment("code=" + azCode)``, which does not
+        percent-encode the fragment, and authorization codes are commonly
+        base64/base64url and may contain ``+``, ``/``, and ``=``. Form-decoding
+        (e.g. ``urllib.parse.parse_qsl``) would turn a literal ``+`` into a space
+        and corrupt the single-use code, so we split on the literal ``code=``
+        delimiter and take the raw value up to the next ``&`` instead.
+        """
+        parts = urlsplit(redirect_uri)
+
+        # Fragment first, then query — read the raw value (no form-decoding).
+        for carrier in (parts.fragment, parts.query):
+            code = EmbeddedStreamlit._raw_code_value(carrier)
+            if code:
+                return code
+
+        raise ProgrammingError(
+            msg="Could not find authorization code in token-exchange redirect_uri.",
+            errno=ER_INVALID_VALUE,
+        )
+
+    @staticmethod
+    def _raw_code_value(carrier: str) -> str | None:
+        """Return the verbatim ``code`` value from a ``&``-separated carrier.
+
+        ``carrier`` is a raw fragment or query string. We split only on the
+        ``&`` separator and the first ``=`` of each segment, so the value is
+        returned byte-for-byte (no ``+`` -> space, no percent-decoding).
+        """
+        if not carrier:
+            return None
+        for segment in carrier.split("&"):
+            key, sep, value = segment.partition("=")
+            if key == "code" and sep and value:
+                return value
+        return None
+
+    def _build_embed_url(self, redirect_uri: str) -> str:
+        """Assemble the final embed URL from the token-exchange redirect_uri.
+
+        Reproduces StreamlitGenerateEmbedUrl.java: strips the code and any
+        pre-existing ``__embeddedApp`` / ``__parentOrigin`` params off the base,
+        re-adds ``__parentOrigin`` (url-encoded) and ``__embeddedApp=true`` as
+        query params, and appends the code as a ``#code=`` fragment.
+        """
+        code = self._extract_code(redirect_uri)
+        parts = urlsplit(redirect_uri)
+
+        # Drop the code carrier and our managed params from the base query, keep the rest.
+        preserved = [
+            (key, value)
+            for key, value in parse_qsl(parts.query, keep_blank_values=True)
+            if key not in ("code", _PARAM_PARENT_ORIGIN, _PARAM_EMBEDDED_APP)
+        ]
+
+        # Build the new query: preserved params first, then our two managed params,
+        # in the exact order the system function emits them.
+        query_pieces = []
+        if preserved:
+            query_pieces.append(urlencode(preserved))
+        query_pieces.append(
+            _PARAM_PARENT_ORIGIN + "=" + quote(self._parent_origin, safe="")
+        )
+        query_pieces.append(_PARAM_EMBEDDED_APP + "=true")
+        new_query = "&".join(query_pieces)
+
+        new_fragment = "code=" + code
+
+        return urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, new_query, new_fragment)
+        )
+
+    def get_embed_url(self) -> str:
+        """Return the generated embed URL.
+
+        Raises:
+            ProgrammingError: if :meth:`prepare` has not been called yet.
+        """
+        if self._embed_url is None:
+            raise ProgrammingError(
+                msg="get_embed_url() called before prepare(); call prepare(...) first."
+            )
+        return self._embed_url
+
+    @property
+    def expires_in(self) -> int | None:
+        """Seconds until the embed authorization code expires, if the server returned it."""
+        return self._expires_in

--- a/test/unit/test_embedded_streamlit.py
+++ b/test/unit/test_embedded_streamlit.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+from unittest import mock
+from urllib.parse import parse_qs, parse_qsl, urlsplit
+
+import pytest
+
+from snowflake.connector.embedded_streamlit import (
+    SUBJECT_TOKEN_TYPE_JWT,
+    SUBJECT_TOKEN_TYPE_PAT,
+    SUBJECT_TOKEN_TYPE_SESSION,
+    EmbeddedStreamlit,
+)
+from snowflake.connector.errors import ProgrammingError
+
+STREAMLIT_ID = "MYDB.MYSCHEMA.MY_APP"
+PARENT_ORIGIN = "https://analytics.example.com"
+ENDPOINT = "https://fake.example.com/oauth/token"
+
+
+class _FakeResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, status_code=200, payload=None, raise_on_json=False):
+        self.status_code = status_code
+        self._payload = payload
+        self._raise_on_json = raise_on_json
+
+    def json(self):
+        if self._raise_on_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+def _fake_manager(response):
+    """Return a mock SessionManager whose .post() returns *response*."""
+    manager = mock.MagicMock()
+    manager.post.return_value = response
+    return manager
+
+
+def _ok_manager(redirect_uri, expires_in=3600):
+    return _fake_manager(
+        _FakeResponse(
+            status_code=200,
+            payload={"redirect_uri": redirect_uri, "expires_in": expires_in},
+        )
+    )
+
+
+def _posted_body(manager):
+    """Parse the form-urlencoded body sent to manager.post() into a dict."""
+    _, kwargs = manager.post.call_args
+    return dict(parse_qsl(kwargs["data"], keep_blank_values=True))
+
+
+# ---------------------------------------------------------------------------
+# Credential modes + subject_token_type mapping + scope
+# ---------------------------------------------------------------------------
+
+
+def test_pat_mode_body_and_scope():
+    manager = _ok_manager("https://app.example.com/render#code=ABC123")
+    es = EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        pat="my-pat-value",
+        account="myaccount",
+        token_endpoint=ENDPOINT,
+        session_manager=manager,
+    )
+    body = _posted_body(manager)
+    assert body["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange"
+    assert body["subject_token"] == "my-pat-value"
+    assert body["subject_token_type"] == SUBJECT_TOKEN_TYPE_PAT
+    assert body["scope"] == f"session:streamlit:{STREAMLIT_ID}"
+    # The endpoint and headers are correct.
+    args, kwargs = manager.post.call_args
+    assert args[0] == ENDPOINT
+    assert kwargs["headers"]["Content-Type"].startswith(
+        "application/x-www-form-urlencoded"
+    )
+    assert kwargs["headers"]["Accept"] == "application/json"
+    # The streamlit embed token-exchange path has NO OAuth client identity, so the
+    # request must carry no Authorization (or any other auth) header. Guard against
+    # a regression that adds one.
+    assert "Authorization" not in kwargs["headers"]
+    assert set(kwargs["headers"]) == {"Content-Type", "Accept"}
+    assert es.expires_in == 3600
+
+
+def test_conn_mode_pulls_token_and_host():
+    manager = _ok_manager("https://app.example.com/render#code=XYZ")
+    conn = mock.MagicMock()
+    conn.rest.token = "session-token-secret"
+    conn.host = "acct.snowflakecomputing.com"
+    conn._session_manager = manager
+
+    EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(conn=conn)
+
+    body = _posted_body(manager)
+    assert body["subject_token"] == "session-token-secret"
+    assert body["subject_token_type"] == SUBJECT_TOKEN_TYPE_SESSION
+    # Default endpoint built from conn.host.
+    args, _ = manager.post.call_args
+    assert args[0] == "https://acct.snowflakecomputing.com/oauth/token"
+
+
+def test_key_pair_mode_default_jwt_type():
+    from test.unit.test_auth_keypair import generate_rsa_key_pair
+
+    private_key_der, _ = generate_rsa_key_pair(2048)
+    manager = _ok_manager("https://app.example.com/render#code=JWT1")
+
+    EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        key_pair=private_key_der,
+        account="myaccount",
+        user="myuser",
+        token_endpoint=ENDPOINT,
+        session_manager=manager,
+    )
+    body = _posted_body(manager)
+    # Provisional default subject_token_type for key-pair mode.
+    assert body["subject_token_type"] == SUBJECT_TOKEN_TYPE_JWT
+    # The minted JWT is a non-empty 3-part token, not the raw key.
+    assert body["subject_token"].count(".") == 2
+
+
+def test_key_pair_mode_subject_token_type_override():
+    from test.unit.test_auth_keypair import generate_rsa_key_pair
+
+    private_key_der, _ = generate_rsa_key_pair(2048)
+    manager = _ok_manager("https://app.example.com/render#code=JWT2")
+
+    EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        key_pair=private_key_der,
+        account="myaccount",
+        user="myuser",
+        subject_token_type="urn:custom:type",
+        token_endpoint=ENDPOINT,
+        session_manager=manager,
+    )
+    assert _posted_body(manager)["subject_token_type"] == "urn:custom:type"
+
+
+def test_explicit_subject_token_escape_hatch():
+    manager = _ok_manager("https://app.example.com/render#code=E1")
+    EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        subject_token="opaque-token",
+        subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+        token_endpoint=ENDPOINT,
+        session_manager=manager,
+    )
+    body = _posted_body(manager)
+    assert body["subject_token"] == "opaque-token"
+    assert body["subject_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+
+
+# ---------------------------------------------------------------------------
+# redirect_uri code extraction (fragment vs query) + URL assembly
+# ---------------------------------------------------------------------------
+
+
+def _assert_embed_url(url, *, expected_code, expected_base_path):
+    parts = urlsplit(url)
+    # Code is carried in the fragment.
+    assert parts.fragment == f"code={expected_code}"
+    assert parts.path == expected_base_path
+    qs = parse_qs(parts.query, keep_blank_values=True)
+    # parentOrigin is url-encoded and round-trips.
+    assert qs["__parentOrigin"] == [PARENT_ORIGIN]
+    assert qs["__embeddedApp"] == ["true"]
+    # The raw query must contain the encoded origin (":" and "/" escaped).
+    assert "__parentOrigin=https%3A%2F%2Fanalytics.example.com" in parts.query
+    # The code must not leak into the query.
+    assert "code=" not in parts.query
+
+
+def test_code_extracted_from_fragment():
+    manager = _ok_manager("https://app.example.com/render#code=FRAGCODE")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    _assert_embed_url(url, expected_code="FRAGCODE", expected_base_path="/render")
+
+
+def test_code_extracted_from_query():
+    manager = _ok_manager("https://app.example.com/render?code=QUERYCODE")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    _assert_embed_url(url, expected_code="QUERYCODE", expected_base_path="/render")
+
+
+def test_code_extracted_from_query_ampersand_form():
+    manager = _ok_manager("https://app.example.com/render?foo=bar&code=AMPCODE")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    parts = urlsplit(url)
+    qs = parse_qs(parts.query, keep_blank_values=True)
+    # Pre-existing non-managed query params are preserved.
+    assert qs["foo"] == ["bar"]
+    assert qs["__embeddedApp"] == ["true"]
+    assert parts.fragment == "code=AMPCODE"
+    assert "code=AMPCODE" not in parts.query
+
+
+def test_fragment_preferred_over_query():
+    # If both are present, fragment wins.
+    manager = _ok_manager("https://app.example.com/render?code=FROMQUERY#code=FROMFRAG")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    assert urlsplit(url).fragment == "code=FROMFRAG"
+
+
+def test_base_with_existing_query_appends_managed_params():
+    # redirect_uri already carries a query param AND the code in the fragment.
+    manager = _ok_manager("https://app.example.com/render?tab=2#code=C9")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    parts = urlsplit(url)
+    qs = parse_qs(parts.query, keep_blank_values=True)
+    assert qs["tab"] == ["2"]
+    assert qs["__parentOrigin"] == [PARENT_ORIGIN]
+    assert qs["__embeddedApp"] == ["true"]
+    assert parts.fragment == "code=C9"
+
+
+def test_preexisting_managed_params_are_stripped_and_rebuilt():
+    # If the server echoes __embeddedApp/__parentOrigin we must drop and re-add them
+    # (no duplicates).
+    manager = _ok_manager(
+        "https://app.example.com/render?__embeddedApp=false"
+        "&__parentOrigin=https%3A%2F%2Fevil.example.com#code=CC"
+    )
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    parts = urlsplit(url)
+    qs = parse_qs(parts.query, keep_blank_values=True)
+    # Exactly one value each, and the caller's parent_origin wins.
+    assert qs["__embeddedApp"] == ["true"]
+    assert qs["__parentOrigin"] == [PARENT_ORIGIN]
+    assert "evil.example.com" not in url
+
+
+# A base64/base64url authorization code may contain '+', '/', and '='. The code
+# carrier (fragment per the GS system function) is NOT form-encoded, so the
+# extractor must read it verbatim and must NOT turn '+' into a space.
+_BASE64_CODE = "aB+c/dEf12+/=="
+
+
+def test_code_with_base64_special_chars_from_fragment_roundtrips_verbatim():
+    manager = _ok_manager(f"https://app.example.com/render#code={_BASE64_CODE}")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    # The fragment must carry the code byte-for-byte: no '+' -> ' ' corruption.
+    assert urlsplit(url).fragment == f"code={_BASE64_CODE}"
+    assert " " not in urlsplit(url).fragment
+
+
+def test_code_with_base64_special_chars_from_query_roundtrips_verbatim():
+    # Same code, this time delivered via the query (after another param).
+    manager = _ok_manager(f"https://app.example.com/render?tab=2&code={_BASE64_CODE}")
+    url = (
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN)
+        .prepare(pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager)
+        .get_embed_url()
+    )
+    parts = urlsplit(url)
+    # Code moves to the fragment, verbatim; the unrelated query param is preserved.
+    assert parts.fragment == f"code={_BASE64_CODE}"
+    assert " " not in parts.fragment
+    assert parse_qs(parts.query, keep_blank_values=True)["tab"] == ["2"]
+
+
+# ---------------------------------------------------------------------------
+# expires_in coercion
+# ---------------------------------------------------------------------------
+
+
+def test_expires_in_string_is_coerced_to_int():
+    manager = _ok_manager("https://app.example.com/render#code=C", expires_in="900")
+    es = EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+    )
+    assert es.expires_in == 900
+    assert isinstance(es.expires_in, int)
+
+
+def test_expires_in_non_numeric_falls_back_to_none():
+    manager = _ok_manager("https://app.example.com/render#code=C", expires_in="soon")
+    es = EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+    )
+    assert es.expires_in is None
+
+
+def test_expires_in_missing_is_none():
+    manager = _fake_manager(
+        _FakeResponse(
+            status_code=200,
+            payload={"redirect_uri": "https://app.example.com/render#code=C"},
+        )
+    )
+    es = EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+    )
+    assert es.expires_in is None
+
+
+# ---------------------------------------------------------------------------
+# Error / validation cases
+# ---------------------------------------------------------------------------
+
+
+def test_missing_credential_raises():
+    with pytest.raises(ProgrammingError, match="A credential is required"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            account="a",
+            token_endpoint=ENDPOINT,
+            session_manager=_ok_manager("x#code=y"),
+        )
+
+
+def test_multiple_credentials_raises():
+    with pytest.raises(ProgrammingError, match="Exactly one credential source"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p",
+            subject_token="t",
+            subject_token_type="urn:x",
+            token_endpoint=ENDPOINT,
+            session_manager=_ok_manager("x#code=y"),
+        )
+
+
+def test_non_200_raises_without_leaking_body():
+    manager = _fake_manager(_FakeResponse(status_code=403, payload={"secret": "leak"}))
+    with pytest.raises(ProgrammingError) as ei:
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+        )
+    assert "403" in str(ei.value)
+    assert "leak" not in str(ei.value)
+
+
+def test_missing_redirect_uri_raises():
+    manager = _fake_manager(_FakeResponse(status_code=200, payload={"expires_in": 60}))
+    with pytest.raises(ProgrammingError, match="missing 'redirect_uri'"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+        )
+
+
+def test_non_json_response_raises():
+    manager = _fake_manager(_FakeResponse(status_code=200, raise_on_json=True))
+    with pytest.raises(ProgrammingError, match="non-JSON"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+        )
+
+
+def test_redirect_uri_without_code_raises():
+    manager = _ok_manager("https://app.example.com/render")
+    with pytest.raises(ProgrammingError, match="Could not find authorization code"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p", account="a", token_endpoint=ENDPOINT, session_manager=manager
+        )
+
+
+def test_streamlit_id_with_colon_rejected():
+    with pytest.raises(ProgrammingError, match="must not contain ':'"):
+        EmbeddedStreamlit("db.schema:app", PARENT_ORIGIN)
+
+
+def test_empty_streamlit_id_rejected():
+    with pytest.raises(ProgrammingError, match="streamlit_id"):
+        EmbeddedStreamlit("", PARENT_ORIGIN)
+
+
+def test_empty_parent_origin_rejected():
+    with pytest.raises(ProgrammingError, match="parent_origin"):
+        EmbeddedStreamlit(STREAMLIT_ID, "")
+
+
+def test_get_embed_url_before_prepare_raises():
+    with pytest.raises(ProgrammingError, match="before prepare"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).get_embed_url()
+
+
+def test_conn_without_token_raises():
+    conn = mock.MagicMock()
+    conn.rest.token = None
+    with pytest.raises(ProgrammingError, match="no active session token"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            conn=conn, token_endpoint=ENDPOINT, session_manager=_ok_manager("x#code=y")
+        )
+
+
+def test_no_endpoint_resolvable_raises():
+    # PAT mode with neither token_endpoint, host, nor account => cannot resolve endpoint.
+    with pytest.raises(ProgrammingError, match="resolve the token endpoint"):
+        EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+            pat="p", session_manager=_ok_manager("x#code=y")
+        )
+
+
+def test_pat_mode_host_builds_default_endpoint_from_account():
+    manager = _ok_manager("https://app.example.com/render#code=H1")
+    EmbeddedStreamlit(STREAMLIT_ID, PARENT_ORIGIN).prepare(
+        pat="p", account="myacct", session_manager=manager
+    )
+    args, _ = manager.post.call_args
+    # construct_hostname(None, "myacct") -> myacct.snowflakecomputing.com
+    assert args[0] == "https://myacct.snowflakecomputing.com/oauth/token"


### PR DESCRIPTION
## Summary

Adds a native `EmbeddedStreamlit` helper to the Python connector that generates a
Streamlit-in-Snowflake (SiS) embed URL by calling Snowflake's OAuth 2.0 token-exchange
endpoint (`POST /oauth/token`) with a service credential and assembling the final embed
URL. This is the native, session-free replacement for the
`SYSTEM$STREAMLIT_GENERATE_EMBED_URL` SQL system function.

> **DRAFT** — depends on the GlobalServices server-side token-exchange `session:streamlit:<fqn>`
> scope endpoint, which is **not yet in production**. All tests mock the HTTP layer.

## Motivation

Customer backends (e.g. `analytics.bmw.com`) embed SiS apps into 3rd-party pages and must
mint a short-lived, single-use embed URL from a **service credential** (PAT / key-pair /
session) **without** opening an interactive SQL session to call the system function. This
helper performs the token-exchange directly from the driver and never exposes the service
credential to the browser.

Design docs: [Streamlit Drivers](https://docs.google.com/document/d/1x4t63bbq7arzhBU5ZOyP2828hFuXk7quLzDOtNbDQZY)
and [Embedded Streamlit Authentication](https://docs.google.com/document/d/1HwA7gJGKJebDUuvMIRUoe14Tl4Q9X4Au02iakQTNkWc).

## What changed

- **`src/snowflake/connector/embedded_streamlit.py`** (new): `class EmbeddedStreamlit`.
- **`src/snowflake/connector/__init__.py`**: export `EmbeddedStreamlit` (added to `__all__`).
- **`test/unit/test_embedded_streamlit.py`** (new): 29 unit tests, HTTP layer fully mocked.

```python
from snowflake.connector import EmbeddedStreamlit

url = (
    EmbeddedStreamlit("MYDB.MYSCHEMA.MY_APP", "https://analytics.example.com")
    .prepare(pat="<pat>", account="myaccount")   # or conn=..., key_pair=..., or subject_token=...
    .get_embed_url()
)
```

`prepare()` takes exactly one primary credential source (`pat` | `conn` | `key_pair` |
explicit `subject_token`), plus `account`/`host`/`user` as needed for credential-only modes,
and an overridable `token_endpoint` / `session_manager` for tests. HTTP goes through the
connector's `SessionManager`; the key-pair JWT is minted via `AuthByKeyPair.prepare(account=, user=)`
(or a pre-signed JWT may be passed); `conn` mode pulls the session token and host from the live
`SnowflakeConnection` (`conn.rest.token`, `conn.host`).

## Wire contract

`POST https://<host>/oauth/token` — `Content-Type: application/x-www-form-urlencoded; charset=UTF-8`,
`Accept: application/json`, and crucially **no `Authorization` header** (the streamlit embed
token-exchange path has no OAuth client identity). Body:
`grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `subject_token=<credential>`,
`subject_token_type=<URN>`, `scope=session:streamlit:<db.schema.app>` (FQN contains no `:`).

`subject_token_type` mapping (verified against GS `SFOAuthTokenType.java`):

| Credential | `subject_token_type` |
|---|---|
| session | `urn:snowflake:token-type:session` |
| PAT | `programmatic_access_token` |
| WIF | `urn:snowflake:token-type:wif` |
| OAuth access token | `urn:ietf:params:oauth:token-type:access_token` |
| key-pair JWT | `urn:ietf:params:oauth:token-type:jwt` (**provisional, overridable**) |

Response `200 { "redirect_uri": "...", "expires_in": <int> }`; the single-use code may be a
fragment (`#code=`) or query (`?code=` / `&code=`).

URL assembly reproduces `StreamlitGenerateEmbedUrl.java`: extract the code (fragment first),
compute the base (`scheme://host[:port]/path`) minus the code and any echoed
`__embeddedApp`/`__parentOrigin`, then build
`base + "?__parentOrigin=" + urlencode(parentOrigin) + "&__embeddedApp=true" + "#code=" + code`
(joining with `&` when the base already has a query). The authorization code is read
**verbatim** (raw split on `code=`), **not** form-decoded — the GS system function emits it via
`URIBuilder.setFragment("code=" + azCode)` with no percent-encoding, and base64url codes can
contain `+`/`/`/`=`; form-decoding would turn `+` into a space and corrupt the single-use code.
The credential and the code are treated as secrets and never logged.

## Server dependency / open questions

1. GS must add `EntityType.STREAMLIT` and the `session:streamlit:<fqn>` scope handler to the
   token-exchange path before this works against a real account (not in prod yet).
2. The key-pair `subject_token_type` is **provisional** — there is no GS enum value for a
   key-pair JWT today; the default `urn:ietf:params:oauth:token-type:jwt` is overridable, and
   an explicit `(subject_token, subject_token_type)` escape hatch is provided.
3. To confirm with GS: the `/oauth/token` path and that the single-use azcode is delivered via
   `redirect_uri` (fragment or query) un-percent-encoded — the driver reads the code verbatim,
   matching the system function's fragment output.

## Testing

`test/unit/test_embedded_streamlit.py` — 29 tests, HTTP mocked via an injected fake
`SessionManager`: each credential mode + `subject_token_type`; scope string; endpoint, headers,
and **absence of any Authorization header**; default-endpoint-from-account; code extraction from
fragment, query, and `&code=` with fragment precedence; **regression tests that a code with
`+`/`/`/`=` round-trips verbatim** from both fragment and query; URL assembly (parentOrigin
url-encoding, `__embeddedApp=true`, base-with-query, stripping echoed managed params, evil-origin
negative check); `expires_in` coercion; and the full error matrix.

Commands run (observed):
```
PYTHONPATH=src python3 -m pytest test/unit/test_embedded_streamlit.py -q   => 29 passed
python3 -m black --safe --check ...                                        => unchanged
python3 -m isort --check-only ...                                          => exit 0
python3 -m flake8 ...                                                      => exit 0
```
Run with `PYTHONPATH=src` (package not pip-installed here); the benign `Failed to import
ArrowResult` warning is unrelated (Arrow C-ext not compiled). No live integration/e2e — the GS
endpoint is not in production yet.

## Out of scope

- Live integration / e2e tests (GS server endpoint not in production).
- Other drivers (Go / .NET / ODBC / JDBC / Node.js — JDBC and Node have sibling draft PRs).
- Removing the `SYSTEM$STREAMLIT_GENERATE_EMBED_URL` SQL system function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
