### PR TITLE
NO-SNOW: skip CLA Assistant on internal "-private" repos

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
+    # The CLA only applies to external contributions on the public repos. Skip it
+    # on internal "-private" repos.
+    if: ${{ !endsWith(github.repository, '-private') }}
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Mirror of snowflake-connector-python-private#36.

Guards the CLAssistant job with `if: !endsWith(github.repository, '-private')`. On this public repo the condition is true, so the CLA job runs exactly as before (external contributors stay gated); on the internal "-private" mirror it evaluates false and the job is skipped (a skipped required check is treated as passing). Keeping the workflow identical across both repos so future mirrors stay clean.
