### PR TITLE
SNOW-3665226: fix FQN DDL cache test to assert unchanged instead of None

### DIFF
--- a/test/integ/test_connection.py
+++ b/test/integ/test_connection.py
@@ -2696,20 +2696,14 @@ def test_fqn_ddl_does_not_pollute_schema_cache(conn_cnx, db_parameters):
     schema = db_parameters["schema"].upper()
     view_name = f'"{database}"."{schema}"."SNOW_3665226_REPRO_VIEW"'
 
-    # Open a session with NO database and NO schema so both caches start as None.
-    # The FQN object below lives in `database`.`schema`; without the guard the
-    # connector would overwrite the None caches with the object's namespace. We
-    # start _database as None too (not just _schema) so its "None is not
-    # overridden" path is actually exercised rather than a tautology.
-    with conn_cnx(database=None, schema=None) as cnx:
+    # Open a session with NO schema so the cache starts as None.
+    with conn_cnx(schema=None) as cnx:
         with cnx.cursor() as cur:
-            # Sanity-check: cache and server agree (both empty) before the test.
-            assert cnx._database is None
+            # Sanity-check: cache and server agree before the test.
             assert cnx._schema is None
-            server_db_before, server_schema_before = cur.execute(
-                "SELECT CURRENT_DATABASE(), CURRENT_SCHEMA()"
-            ).fetchone()
-            assert server_db_before is None
+            db_before = cnx._database
+            assert db_before is not None  # database was set at connect time
+            server_schema_before = cur.execute("SELECT CURRENT_SCHEMA()").fetchone()[0]
             assert server_schema_before is None
 
             # Touch a fully-qualified object — this must not change the session context.
@@ -2718,23 +2712,18 @@ def test_fqn_ddl_does_not_pollute_schema_cache(conn_cnx, db_parameters):
             finally:
                 cur.execute(f"DROP VIEW IF EXISTS {view_name}")
 
-            # Caches must still be None — the session context never changed.
-            assert cnx._database is None, (
-                f"connector cache was polluted: _database={cnx._database!r}, "
-                "but no USE DATABASE was issued"
-            )
+            # Cache must still be None / unchanged — the session context never changed.
             assert cnx._schema is None, (
                 f"connector cache was polluted: _schema={cnx._schema!r}, "
                 "but no USE SCHEMA was issued"
             )
+            assert cnx._database == db_before, (
+                f"connector _database was polluted: got {cnx._database!r}, "
+                f"expected {db_before!r}"
+            )
 
-            # Server must also still return NULL for the current namespace.
-            server_db_after, server_schema_after = cur.execute(
-                "SELECT CURRENT_DATABASE(), CURRENT_SCHEMA()"
-            ).fetchone()
-            assert (
-                server_db_after is None
-            ), f"unexpected server database: {server_db_after!r}"
+            # Server must also still return NULL for CURRENT_SCHEMA().
+            server_schema_after = cur.execute("SELECT CURRENT_SCHEMA()").fetchone()[0]
             assert (
                 server_schema_after is None
             ), f"unexpected server schema: {server_schema_after!r}"

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -5,6 +5,7 @@ import json
 import logging
 import stat
 import sys
+import uuid
 from pathlib import Path
 from secrets import token_urlsafe
 from textwrap import dedent
@@ -1021,3 +1022,76 @@ def test_server_session_keep_alive_false_calls_async_check(mock_post_requests):
 
     # Verify delete_session WAS called (since async queries are finished and keep_alive=False)
     delete_session_mock.assert_called_once()
+
+
+def _run_cmd_query_with_final_names(
+    conn: SnowflakeConnection, sql: str, final_db: str | None, final_schema: str | None
+) -> None:
+    """Drive ``cmd_query`` with a mocked server response carrying
+    finalDatabaseName / finalSchemaName so the cache-update guard runs against a
+    controlled response. Caches are mutated in place per the guard logic."""
+    conn._rest.request = mock.MagicMock(
+        return_value={
+            "success": True,
+            "data": {
+                "finalDatabaseName": final_db,
+                "finalSchemaName": final_schema,
+            },
+        }
+    )
+    # _no_results=True skips query-context plumbing; the cache-update logic under
+    # test runs regardless of that flag.
+    conn.cmd_query(sql, 0, uuid.uuid4(), _no_results=True)
+
+
+@pytest.mark.skipolddriver
+def test_fqn_ddl_does_not_pollute_none_database_cache(mock_post_requests):
+    """SNOW-3665226: when the session has no current database (e.g. the user has
+    no default namespace), a fully-qualified DDL's finalDatabaseName /
+    finalSchemaName reflect the *referenced* object, not the session context, and
+    must NOT overwrite the connector's ``None`` cache.
+
+    This is the mocked counterpart to the integ test: the integ test exercises
+    the schema side on real accounts (which have no default schema), while this
+    unit test locks in the database side, which can't be driven end-to-end on
+    accounts that carry a default database.
+    """
+    conn = fake_connector()
+    try:
+        # Simulate a session with no current namespace at all.
+        conn._database = None
+        conn._schema = None
+
+        # A fully-qualified DDL returns the referenced object's namespace in
+        # final*Name — this must be ignored while the cache is None.
+        _run_cmd_query_with_final_names(
+            conn,
+            'CREATE OR REPLACE VIEW "OTHER_DB"."OTHER_SCHEMA"."V" AS SELECT 1',
+            final_db="OTHER_DB",
+            final_schema="OTHER_SCHEMA",
+        )
+        assert conn._database is None
+        assert conn._schema is None
+
+        # A genuine context switch (USE ...) must still update the None caches,
+        # otherwise the guard would wrongly suppress real changes.
+        _run_cmd_query_with_final_names(
+            conn,
+            "USE SCHEMA OTHER_DB.OTHER_SCHEMA",
+            final_db="OTHER_DB",
+            final_schema="OTHER_SCHEMA",
+        )
+        assert conn._database == "OTHER_DB"
+        assert conn._schema == "OTHER_SCHEMA"
+
+        # Once a context is set, subsequent final*Name values refresh the cache
+        # as before (pre-existing behaviour is unchanged).
+        _run_cmd_query_with_final_names(
+            conn,
+            "SELECT 1",
+            final_db="OTHER_DB",
+            final_schema="NEW_SCHEMA",
+        )
+        assert conn._schema == "NEW_SCHEMA"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Description

Post-merge CI on `main` is failing on the newly-added test `test/integ/test_connection.py::test_fqn_ddl_does_not_pollute_schema_cache` across **all** integ jobs (aws/azure/gcp × py3.10–3.14):

```
test/integ/test_connection.py:2707: in test_fqn_ddl_does_not_pollute_schema_cache
    assert cnx._database is None
E   AssertionError: assert 'TESTDB_PYTHON' is None
```

### Root cause

The failing assertion is the **first sanity check**, before any feature logic runs. It was introduced by commit `7150c5b` ("make FQN DDL test assert None cache is not overridden") in #2909, which changed the test to connect with `database=None` and assert `cnx._database is None`.

That assumption only holds when the connecting user has **no server-side default namespace**. All CI test accounts have a database-only default namespace (`TESTDB_PYTHON`), so during authentication the login response's `sessionInfo.databaseName` is `TESTDB_PYTHON` and the connector caches it (`auth/_auth.py`), making `cnx._database` non-`None` at connect time — regardless of the connector fix.

The connector fix in #2909 itself is fine; only the test's precondition is wrong.

### Fix

Revert the test to the environment-agnostic **"unchanged"** style (effectively reverting `7150c5b`):

- connect with `schema=None` only,
- capture the connect-time `_database` (`db_before`),
- run the fully-qualified DDL,
- assert `_schema` stays `None` and `_database == db_before`.

This still exercises the regression — a fully-qualified DDL must not pollute the schema/database cache — without depending on the account having no default namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)