### PR TITLE
Revert "Remove upper bound on pandas optional dependency (#2904)"

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,6 +7,9 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
+- v4.7.1
+  - Reverting support for pandas 3.
+
 - v4.7.0(Jul 2,2026)
   - Fixed `python-connector.log` not rotating on Windows, and every record being logged twice, when easy logging is enabled via `config.toml` (SNOW-3680325).
     - **Note:** As part of this fix, easy logging no longer calls `logging.basicConfig()` and therefore no longer configures the root logger. `python-connector.log` now captures only the `snowflake.connector`, `botocore`, and `boto3`.
@@ -14,7 +17,6 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Fixed OAuth infinite loop when tokens expire by ensuring `reauthenticate()` calls `_request_tokens()` directly instead of looping through `prepare()`. Token cache is now read exactly once per connection, and `_store_tokens()` preserves macOS Keychain ACL by never calling `remove()`. The async OAuth `reauthenticate()` now runs the synchronous OAuth flow on a worker thread instead of blocking the event loop.
   - Fixed OAuth scope handling for Snowflake custom OAuth: when refresh tokens are enabled, the connector no longer appends the OIDC `offline_access` scope for token endpoints on `*.snowflakecomputing.com` or `*.snowflakecomputing.cn`, which caused `invalid_scope` errors. Snowflake custom OAuth expects `refresh_token` in scope instead. External IdP behavior is unchanged.
   - Fixed input validation for `scale` metadata in Arrow result set processing for `TIME`, `TIMESTAMP_NTZ`, `TIMESTAMP_LTZ`, and `TIMESTAMP_TZ` columns (SNOW-3388299).
-  - Removed pandas upper bound dependency constraint on the `[pandas]` extra to allow installation of pandas 3.0.0 and later.
   - Fixed S3 storage client to correctly handle 307/308 (method-preserving) and 301/302 (GET/HEAD only) redirects by disabling automatic redirect following and re-signing each request with AWS SigV4 credentials for the redirect target. The region is updated from the `x-amz-bucket-region` response header on each redirect. Redirects are capped at 5 hops.
   - Added native AKS (Azure Kubernetes Service) workload identity support. When running on AKS with workload identity configured, the connector automatically uses `WorkloadIdentityCredential` to authenticate via the injected service account credentials. OIDC backward compatibility is also supported.
   - Added the `workload_identity_aws_use_outbound_token` connection option (default `false`) to opt into AWS WIF JWT attestation via STS `GetWebIdentityToken` instead of the default SigV4 `GetCallerIdentity` method.

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,8 +108,8 @@ development =
     pytzdata
     responses
 pandas =
-    pandas>=1.0.0; python_version < '3.13'
-    pandas>=2.1.2; python_version >= '3.13'
+    pandas>=1.0.0,<3.0.0; python_version < '3.13'
+    pandas>=2.1.2,<3.0.0; python_version >= '3.13'
     pyarrow>=14.0.1
 secure-local-storage =
     keyring>=23.1.0,<26.0.0

--- a/test/integ/pandas_it/test_arrow_pandas.py
+++ b/test/integ/pandas_it/test_arrow_pandas.py
@@ -1521,13 +1521,10 @@ def assert_pandas_batch_types(
     assert batch.dtypes is not None
 
     pandas_dtypes = batch.dtypes
+    # pd.string is represented as an np.object
+    # np.dtype string is not the same as pd.string (python)
     for pandas_dtype, expected_type in zip(pandas_dtypes, expected_types):
-        actual_type = pandas_dtype.type
-        expected_numpy_type = numpy.dtype(expected_type).type
-        # pandas 3+ uses native str (not numpy.object_) as the type for string dtype
-        if actual_type is str and expected_numpy_type is numpy.object_:
-            continue
-        assert_dtype_equal(actual_type, expected_numpy_type)
+        assert_dtype_equal(pandas_dtype.type, numpy.dtype(expected_type).type)
 
 
 def test_pandas_dtypes(conn_cnx):
@@ -1629,13 +1626,7 @@ def test_fetch_with_pandas_nullable_types(conn_cnx):
         [pandas.Float64Dtype(), pandas.Float64Dtype(), pandas.Float64Dtype()],
         index=["1.0::FLOAT", "'NAN'::FLOAT", "NULL::FLOAT"],
     )
-    # pandas 3+ coerces NaN to pd.NA in nullable Float64Dtype, so NaN and NULL both show as <NA>
-    _pandas_major = int(pandas.__version__.split(".")[0])
-    if _pandas_major >= 3:
-        expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
-0         1.0          <NA>         <NA>"""
-    else:
-        expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
+    expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
 0         1.0           NaN         <NA>"""
     with conn_cnx() as cnx_table:
         # fetch dataframe with new arrow support

--- a/test/integ/pandas_it/test_arrow_pandas.py
+++ b/test/integ/pandas_it/test_arrow_pandas.py
@@ -1521,10 +1521,13 @@ def assert_pandas_batch_types(
     assert batch.dtypes is not None
 
     pandas_dtypes = batch.dtypes
-    # pd.string is represented as an np.object
-    # np.dtype string is not the same as pd.string (python)
     for pandas_dtype, expected_type in zip(pandas_dtypes, expected_types):
-        assert_dtype_equal(pandas_dtype.type, numpy.dtype(expected_type).type)
+        actual_type = pandas_dtype.type
+        expected_numpy_type = numpy.dtype(expected_type).type
+        # pandas 3+ uses native str (not numpy.object_) as the type for string dtype
+        if actual_type is str and expected_numpy_type is numpy.object_:
+            continue
+        assert_dtype_equal(actual_type, expected_numpy_type)
 
 
 def test_pandas_dtypes(conn_cnx):
@@ -1626,7 +1629,13 @@ def test_fetch_with_pandas_nullable_types(conn_cnx):
         [pandas.Float64Dtype(), pandas.Float64Dtype(), pandas.Float64Dtype()],
         index=["1.0::FLOAT", "'NAN'::FLOAT", "NULL::FLOAT"],
     )
-    expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
+    # pandas 3+ coerces NaN to pd.NA in nullable Float64Dtype, so NaN and NULL both show as <NA>
+    _pandas_major = int(pandas.__version__.split(".")[0])
+    if _pandas_major >= 3:
+        expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
+0         1.0          <NA>         <NA>"""
+    else:
+        expected_df_to_string = """   1.0::FLOAT  'NAN'::FLOAT  NULL::FLOAT
 0         1.0           NaN         <NA>"""
     with conn_cnx() as cnx_table:
         # fetch dataframe with new arrow support


### PR DESCRIPTION
Reverts commit a804148c — removes pandas 3 support by restoring the `<3.0.0` upper bound on the pandas optional dependency.

## Summary
- Restores `pandas>=1.0.0,<3.0.0` and `pandas>=2.1.2,<3.0.0` constraints in `setup.cfg`
- Reverts test adjustments for pandas 3 behaviour in `test_arrow_pandas.py`
- Adds release note under `v4.7.1` in `DESCRIPTION.md`