### PR TITLE
SNOW-3650888: fix prober image push failing due to ubuntu:26.04 multi-line label

### DIFF
--- a/prober/Dockerfile
+++ b/prober/Dockerfile
@@ -13,6 +13,11 @@ LABEL com.snowflake.owners.jira_component="Python Driver"
 # fake layers label to pass the validation
 LABEL com.snowflake.ugcbi.layers="sha256:850959b749c07b254308a4d1a84686fd7c09fcb94aeae33cc5748aa07e5cb232,sha256:b79d3c4628a989cbb8bc6f0bf0940ff33a68da2dca9c1ffbf8cfb2a27ac8d133,sha256:1cbcc0411a84fbce85e7ee2956c8c1e67b8e0edc81746a33d9da48c852037c3e,sha256:07e89b796f91d37255c6eec926b066d6818f3f2edc344a584d1b9566f77e1c27,sha256:84ff92691f909a05b224e1c56abb4864f01b4f8e3c854e4bb4c7baf1d3f6d652,sha256:3ab72684daee4eea64c3ae78a43ea332b86358446b6f2904dca4b634712e1537"
 
+# ubuntu:26.04 introduced a multi-line org.opencontainers.image.description label that
+# breaks jenkins_push.sh (empty line from \n\n in the value produces key="" → bad array
+# subscript in the bash associative array at line 42). Override it with a single-line value.
+LABEL org.opencontainers.image.description="Snowflake Python Connector prober image"
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # pyenv compiles CPython from source - these are the recommended build deps for


### PR DESCRIPTION
## Summary

- ubuntu:26.04 added `org.opencontainers.image.description` as a Docker label with a **multi-line value** (newline-separated paragraphs). ubuntu:25.10 did not have this label.
- `jenkins_push.sh` in `k8sc-jenkins_scripts` parses image labels by splitting on newlines to get `key=value` pairs. The `\n\n` in the description produces a blank line, which yields `key=""` — an invalid bash associative array subscript — causing `oci_annotations[$key]: bad array subscript` at line 42 and failing Build #99.
- Fix: override the inherited label in the Dockerfile with a single-line value so the push script never sees the blank line.

## Test plan

- [x] Trigger `BuildPyConnectorProber` Jenkins job and verify the Push Image stage succeeds: https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/view/PythonConnector/job/BuildPyConnectorProber/101/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
