### PR TITLE
SNOW-3296990: Support jwt in aws wif

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Display Python version
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -174,7 +174,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -259,7 +259,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -305,7 +305,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -462,7 +462,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -535,7 +535,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -631,7 +631,7 @@ jobs:
         with:
           path: artifacts
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Display Python version

--- a/.github/workflows/check_installation.yml
+++ b/.github/workflows/check_installation.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/create_req_files.yml
+++ b/.github/workflows/create_req_files.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We require our contributors to sign a CLA, available at https://github.com/snowf
 What is a development environment? It's a [virtualenv](https://virtualenv.pypa.io) that has all of necessary
 dependencies installed with `snowflake-connector-python` installed as an editable package.
 
-Setting up a development environment is super easy with this [one simple tox command](https://tox.wiki/en/latest/example/devenv.html).
+Setting up a development environment is super easy with this [one simple tox command](https://tox.wiki/en/legacy/example/devenv.html).
 
 ```shell
 tox --devenv venv39 -e py39

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,8 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - Upcoming Release
   - Added HTTP 307/308 redirect status codes to the retryable set as defense-in-depth, with redirect-aware logging in both sync and async paths.
   - Consolidated keyring token cache to use a single service name with hashed account keys, reducing macOS Keychain password prompts. Legacy entries are auto-migrated on first read.
+  - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
+  - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
 
 - v4.4.0(March 25,2026)
   - Bump the lower boundary of cryptography to 46.0.5 due to CVE-2026-26007.
@@ -78,6 +80,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 - v3.18.0(October 03,2025)
   - Added support for pandas conversion for Day-time and Year-Month Interval types
+* Fixed the return type of iterating over a cursor
 
 - v3.17.4(September 22,2025)
   - Added support for intermediate certificates as roots when they are stored in the trust store

--- a/src/snowflake/connector/_utils.py
+++ b/src/snowflake/connector/_utils.py
@@ -109,30 +109,29 @@ def get_application_path() -> str:
         return "unknown"
 
 
-_SPCS_TOKEN_ENV_VAR_NAME = "SF_SPCS_TOKEN_PATH"
-_SPCS_TOKEN_DEFAULT_PATH = "/snowflake/session/spcs_token"
+_SPCS_ENV_VAR = "SNOWFLAKE_RUNNING_INSIDE_SPCS"
+_SPCS_TOKEN_PATH = "/snowflake/session/spcs_token"
 
 
 def get_spcs_token() -> str | None:
-    """Return the SPCS token read from the configured path, or None.
+    """Return the SPCS token if running inside an SPCS container, or None.
 
-    The path is determined by the SF_SPCS_TOKEN_PATH environment variable,
-    falling back to ``/snowflake/session/spcs_token`` when unset.
+    The token is only read when the SNOWFLAKE_RUNNING_INSIDE_SPCS environment
+    variable is set.  The file at /snowflake/session/spcs_token is read as
+    UTF-8 text and leading/trailing whitespace is stripped.
 
-    Any I/O errors or missing/empty files are treated as \"no token\" and
-    will not cause authentication to fail.
+    Any read failure is logged as a warning and None is returned.
     """
-    path = os.getenv(_SPCS_TOKEN_ENV_VAR_NAME) or _SPCS_TOKEN_DEFAULT_PATH
+    if not os.environ.get(_SPCS_ENV_VAR):
+        return None
     try:
-        if not os.path.isfile(path):
-            return None
-        with open(path, encoding="utf-8") as f:
+        with open(_SPCS_TOKEN_PATH, encoding="utf-8") as f:
             token = f.read().strip()
         if not token:
             return None
         return token
-    except Exception as exc:  # pragma: no cover - best-effort logging only
-        logger.debug("Failed to read SPCS token from %s: %s", path, exc)
+    except Exception as exc:
+        logger.warning("Failed to read SPCS token from %s: %s", _SPCS_TOKEN_PATH, exc)
         return None
 
 

--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -105,8 +105,8 @@ class Auth:
     def _add_spcs_token_to_body(self, body: dict[Any, Any]) -> None:
         """Inject SPCS_TOKEN into the login request body when available.
 
-        This reads the SPCS token from the path specified by SF_SPCS_TOKEN_PATH,
-        or from ``/snowflake/session/spcs_token`` when the env var is unset.
+        The token is read from /snowflake/session/spcs_token when
+        SNOWFLAKE_RUNNING_INSIDE_SPCS is set.
         """
         spcs_token = get_spcs_token()
         if spcs_token is not None:

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -1695,7 +1695,7 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
         if not self.connection._reuse_results:
             self._result_set = None
 
-    def __iter__(self) -> Iterator[dict] | Iterator[tuple]:
+    def __iter__(self) -> Iterator[FetchRow]:
         """Iteration over the result set."""
         while True:
             _next = self.fetchone()

--- a/src/snowflake/connector/platform_detection.py
+++ b/src/snowflake/connector/platform_detection.py
@@ -429,6 +429,22 @@ def is_github_action():
     )
 
 
+def is_aws_wif_outbound_token_enabled():
+    """
+    Check if AWS WIF outbound token is enabled via environment variable.
+
+    Returns:
+        _DetectionState: DETECTED if SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN env var is true,
+                        NOT_DETECTED otherwise.
+    """
+    return (
+        _DetectionState.DETECTED
+        if os.environ.get("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "false").lower()
+        == "true"
+        else _DetectionState.NOT_DETECTED
+    )
+
+
 @cache
 def detect_platforms(
     platform_detection_timeout_seconds: float | None,
@@ -490,6 +506,7 @@ def detect_platforms(
                 "is_gce_cloud_run_service": is_gcp_cloud_run_service(),
                 "is_gce_cloud_run_job": is_gcp_cloud_run_job(),
                 "is_github_action": is_github_action(),
+                "is_aws_wif_outbound_token_enabled": is_aws_wif_outbound_token_enabled(),
             }
 
             # Run network-calling functions in parallel

--- a/src/snowflake/connector/wif_util.py
+++ b/src/snowflake/connector/wif_util.py
@@ -195,29 +195,51 @@ def create_aws_attestation(
         )
     region = get_aws_region()
     partition = session.get_partition_for_region(region)
-    sts_hostname = get_aws_sts_hostname(region, partition)
-    request = AWSRequest(
-        method="POST",
-        url=f"https://{sts_hostname}/?Action=GetCallerIdentity&Version=2011-06-15",
-        headers={
-            "Host": sts_hostname,
-            "X-Snowflake-Audience": SNOWFLAKE_AUDIENCE,
-        },
-    )
+    # TODO: Remove this environment variable check once AWS WIF outbound token is fully released
+    # and make it the default behavior (SNOW-2919437)
+    if (
+        os.environ.get("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", "false").lower()
+        == "true"
+    ):
+        sts_client = session.client("sts", region_name=region)
+        response = sts_client.get_web_identity_token(
+            Audience=[SNOWFLAKE_AUDIENCE], SigningAlgorithm="ES384"
+        )
+        jwt_token = response["WebIdentityToken"]
+        logger.debug("AWS outbound token prefix: %s", jwt_token[:10])
+        return WorkloadIdentityAttestation(
+            AttestationProvider.AWS,
+            jwt_token,
+            {"region": region, "partition": partition},
+        )
+    else:
+        sts_hostname = get_aws_sts_hostname(region, partition)
+        request = AWSRequest(
+            method="POST",
+            url=f"https://{sts_hostname}/?Action=GetCallerIdentity&Version=2011-06-15",
+            headers={
+                "Host": sts_hostname,
+                "X-Snowflake-Audience": SNOWFLAKE_AUDIENCE,
+            },
+        )
 
-    SigV4Auth(aws_creds, "sts", region).add_auth(request)
+        SigV4Auth(aws_creds, "sts", region).add_auth(request)
 
-    assertion_dict = {
-        "url": request.url,
-        "method": request.method,
-        "headers": dict(request.headers.items()),
-    }
-    credential = b64encode(json.dumps(assertion_dict).encode("utf-8")).decode("utf-8")
-    # Unlike other providers, for AWS, we only include general identifiers (region and partition)
-    # rather than specific user identifiers, since we don't actually execute a GetCallerIdentity call.
-    return WorkloadIdentityAttestation(
-        AttestationProvider.AWS, credential, {"region": region, "partition": partition}
-    )
+        assertion_dict = {
+            "url": request.url,
+            "method": request.method,
+            "headers": dict(request.headers.items()),
+        }
+        credential = b64encode(json.dumps(assertion_dict).encode("utf-8")).decode(
+            "utf-8"
+        )
+        # Unlike other providers, for AWS, we only include general identifiers (region and partition)
+        # rather than specific user identifiers, since we don't actually execute a GetCallerIdentity call.
+        return WorkloadIdentityAttestation(
+            AttestationProvider.AWS,
+            credential,
+            {"region": region, "partition": partition},
+        )
 
 
 def get_gcp_access_token(session_manager: SessionManager) -> str:

--- a/test/csp_helpers.py
+++ b/test/csp_helpers.py
@@ -379,6 +379,7 @@ class FakeAwsEnvironment:
             b'{"region": "us-east-1", "instanceId": "i-1234567890abcdef0"}'
         )
         self.metadata_token = "test-token"
+        self.web_identity_token = "fake.jwt.token-for-testing-only"
 
     def assume_role(self, **kwargs):
         if (
@@ -423,6 +424,9 @@ class FakeAwsEnvironment:
         mock_client = mock.Mock()
         mock_client.get_caller_identity.return_value = self.caller_identity
         mock_client.assume_role = self.assume_role
+        mock_client.get_web_identity_token.return_value = {
+            "WebIdentityToken": self.web_identity_token
+        }
         return mock_client
 
     def __enter__(self):

--- a/test/unit/aio/test_spcs_token_async.py
+++ b/test/unit/aio/test_spcs_token_async.py
@@ -8,143 +8,95 @@ import pytest
 import snowflake.connector.aio
 
 
-@pytest.mark.skipolddriver
-async def test_spcs_token_included_in_login_request_async(monkeypatch):
-    """Verify that SPCS_TOKEN is injected into async login request body when present."""
+async def _mock_post_factory(captured_requests):
+    async def mock_post_request(url, headers, body, **kwargs):
+        captured_requests.append((url, json.loads(body)))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN_ASYNC",
+                "masterToken": "MASTER_TOKEN_ASYNC",
+            },
+        }
 
-    custom_path = "/custom/path/to/spcs_token"
-    monkeypatch.setenv("SF_SPCS_TOKEN_PATH", custom_path)
-    monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == custom_path,
-        raising=False,
-    )
+    return mock_post_request
+
+
+async def _connect_and_capture(captured_requests):
+    mock_post = await _mock_post_factory(captured_requests)
+    with mock.patch(
+        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
+        side_effect=mock_post,
+    ):
+        conn = snowflake.connector.aio.SnowflakeConnection(
+            account="testaccount",
+            user="testuser",
+            password="testpwd",
+            host="testaccount.snowflakecomputing.com",
+        )
+        await conn.connect()
+        assert conn._rest.token == "TOKEN_ASYNC"
+        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
+        await conn.close()
+
+    return [body for (url, body) in captured_requests if "login-request" in url]
+
+
+@pytest.mark.skipolddriver
+async def test_spcs_token_present_async(monkeypatch):
+    """SPCS_TOKEN is injected into async login request when env var is set and file exists."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN_ASYNC")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
 
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
     assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"
+    assert login_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"
 
 
 @pytest.mark.skipolddriver
-async def test_spcs_token_not_included_when_file_missing_async(monkeypatch):
-    """Verify that SPCS_TOKEN is not added to async login request when file does not exist."""
-
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    captured_requests: list[tuple[str, dict]] = []
-
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
-    assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert "SPCS_TOKEN" not in body["data"]
-
-
-@pytest.mark.skipolddriver
-async def test_spcs_token_default_path_used_when_env_unset_async(
-    monkeypatch,
-):
-    """When SF_SPCS_TOKEN_PATH is not set, default path should be used (async)."""
-
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    default_path = "/snowflake/session/spcs_token"
+async def test_spcs_token_absent_async(monkeypatch):
+    """SPCS_TOKEN is not added to async login request when file does not exist."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == default_path,
+        "snowflake.connector._utils.open",
+        mock.Mock(side_effect=FileNotFoundError("No such file")),
         raising=False,
     )
-    mock_open = mock.mock_open(read_data="DEFAULT_PATH_SPCS_TOKEN_ASYNC")
+
+    captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
+
+    assert len(login_bodies) == 1
+    assert "SPCS_TOKEN" not in login_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+async def test_not_in_spcs_async(monkeypatch):
+    """SPCS_TOKEN is not added when SNOWFLAKE_RUNNING_INSIDE_SPCS is not set (async)."""
+    monkeypatch.delenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", raising=False)
+    mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN_ASYNC")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
 
-    async def mock_post_request(url, headers, body, **kwargs):
-        captured_requests.append((url, json.loads(body)))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN_ASYNC",
-                "masterToken": "MASTER_TOKEN_ASYNC",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.aio._network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.aio.SnowflakeConnection(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        await conn.connect()
-        assert conn._rest.token == "TOKEN_ASYNC"
-        assert conn._rest.master_token == "MASTER_TOKEN_ASYNC"
-        await conn.close()
-
-    # Exactly one login-request should have been sent for this simple flow
-    login_bodies = [body for (url, body) in captured_requests if "login-request" in url]
     assert len(login_bodies) == 1
-    body = login_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "DEFAULT_PATH_SPCS_TOKEN_ASYNC"
+    assert "SPCS_TOKEN" not in login_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+async def test_spcs_token_with_whitespace_async(monkeypatch):
+    """SPCS_TOKEN value has leading/trailing whitespace stripped (async)."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
+    mock_open = mock.mock_open(read_data="  \n TEST_SPCS_TOKEN_ASYNC \n  ")
+    monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
+
+    captured_requests: list[tuple[str, dict]] = []
+    login_bodies = await _connect_and_capture(captured_requests)
+
+    assert len(login_bodies) == 1
+    assert login_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN_ASYNC"

--- a/test/unit/test_auth_workload_identity.py
+++ b/test/unit/test_auth_workload_identity.py
@@ -333,6 +333,38 @@ def test_aws_impersonation_calls_correct_apis_for_each_role_in_impersonation_pat
     assert fake_aws_environment.assume_role_call_count == 2
 
 
+@pytest.mark.parametrize(
+    "env_value,expected_format",
+    [
+        ("true", "jwt"),
+        ("false", "old"),
+        (None, "old"),
+    ],
+)
+def test_aws_token_format_based_on_env_variable(
+    fake_aws_environment: FakeAwsEnvironment,
+    monkeypatch,
+    env_value,
+    expected_format,
+):
+    """Test that AWS uses correct token format based on SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN environment variable."""
+    if env_value is not None:
+        monkeypatch.setenv("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", env_value)
+
+    auth_class = AuthByWorkloadIdentity(provider=AttestationProvider.AWS)
+    auth_class.prepare(conn=None)
+
+    data = extract_api_data(auth_class)
+
+    assert data["AUTHENTICATOR"] == "WORKLOAD_IDENTITY"
+    assert data["PROVIDER"] == "AWS"
+
+    if expected_format == "jwt":
+        assert data["TOKEN"] == fake_aws_environment.web_identity_token
+    else:
+        verify_aws_token(data["TOKEN"], fake_aws_environment.region)
+
+
 # -- GCP Tests --
 
 

--- a/test/unit/test_spcs_token.py
+++ b/test/unit/test_spcs_token.py
@@ -8,137 +8,90 @@ import pytest
 import snowflake.connector
 
 
-@pytest.mark.skipolddriver
-def test_spcs_token_included_in_login_request(monkeypatch):
-    """Verify that SPCS_TOKEN is injected into the login request body when present."""
+def _mock_post_factory(captured_bodies):
+    def mock_post_request(url, headers, body, **kwargs):
+        captured_bodies.append(json.loads(body))
+        return {
+            "success": True,
+            "message": None,
+            "data": {
+                "token": "TOKEN",
+                "masterToken": "MASTER_TOKEN",
+            },
+        }
 
-    # Use a custom SPCS token path and mock its existence and contents
-    custom_path = "/custom/path/to/spcs_token"
-    monkeypatch.setenv("SF_SPCS_TOKEN_PATH", custom_path)
-    monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == custom_path,
-        raising=False,
-    )
+    return mock_post_request
+
+
+def _connect_and_capture(captured_bodies):
+    with mock.patch(
+        "snowflake.connector.network.SnowflakeRestful._post_request",
+        side_effect=_mock_post_factory(captured_bodies),
+    ):
+        conn = snowflake.connector.connect(
+            account="testaccount",
+            user="testuser",
+            password="testpwd",
+            host="testaccount.snowflakecomputing.com",
+        )
+        assert conn._rest.token == "TOKEN"
+        assert conn._rest.master_token == "MASTER_TOKEN"
+
+
+@pytest.mark.skipolddriver
+def test_spcs_token_present(monkeypatch):
+    """SPCS_TOKEN is injected into the login request when env var is set and file exists."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
 
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        # Return a minimal successful login response
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
     assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"
+    assert captured_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"
 
 
 @pytest.mark.skipolddriver
-def test_spcs_token_not_included_when_file_missing(monkeypatch):
-    """Verify that SPCS_TOKEN is not added when the token file does not exist."""
-
-    # Ensure env var is unset so default path is used, but not created
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    captured_bodies: list[dict] = []
-
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
-    assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert "SPCS_TOKEN" not in body["data"]
-
-
-@pytest.mark.skipolddriver
-def test_spcs_token_default_path_used_when_env_unset(monkeypatch):
-    """When SF_SPCS_TOKEN_PATH is not set, default path should be used."""
-
-    # Ensure env var is unset so default path logic is exercised
-    monkeypatch.delenv("SF_SPCS_TOKEN_PATH", raising=False)
-
-    # Default SPCS path inside SPCS container
-    default_path = "/snowflake/session/spcs_token"
+def test_spcs_token_absent(monkeypatch):
+    """SPCS_TOKEN is not added when env var is set but token file does not exist."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
     monkeypatch.setattr(
-        "snowflake.connector._utils.os.path.isfile",
-        lambda path: path == default_path,
+        "snowflake.connector._utils.open",
+        mock.Mock(side_effect=FileNotFoundError("No such file")),
         raising=False,
     )
-    mock_open = mock.mock_open(read_data="DEFAULT_PATH_SPCS_TOKEN")
+
+    captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
+
+    assert len(captured_bodies) == 1
+    assert "SPCS_TOKEN" not in captured_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+def test_not_in_spcs(monkeypatch):
+    """SPCS_TOKEN is not added when SNOWFLAKE_RUNNING_INSIDE_SPCS is not set."""
+    monkeypatch.delenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", raising=False)
+    mock_open = mock.mock_open(read_data="TEST_SPCS_TOKEN")
     monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
 
     captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
 
-    def mock_post_request(url, headers, body, **kwargs):
-        captured_bodies.append(json.loads(body))
-        return {
-            "success": True,
-            "message": None,
-            "data": {
-                "token": "TOKEN",
-                "masterToken": "MASTER_TOKEN",
-            },
-        }
-
-    with mock.patch(
-        "snowflake.connector.network.SnowflakeRestful._post_request",
-        side_effect=mock_post_request,
-    ):
-        conn = snowflake.connector.connect(
-            account="testaccount",
-            user="testuser",
-            password="testpwd",
-            host="testaccount.snowflakecomputing.com",
-        )
-        assert conn._rest.token == "TOKEN"
-        assert conn._rest.master_token == "MASTER_TOKEN"
-
-    # Exactly one login-request should have been sent for this simple flow
     assert len(captured_bodies) == 1
-    body = captured_bodies[0]
-    assert body["data"]["SPCS_TOKEN"] == "DEFAULT_PATH_SPCS_TOKEN"
+    assert "SPCS_TOKEN" not in captured_bodies[0]["data"]
+
+
+@pytest.mark.skipolddriver
+def test_spcs_token_with_whitespace(monkeypatch):
+    """SPCS_TOKEN value has leading/trailing whitespace stripped."""
+    monkeypatch.setenv("SNOWFLAKE_RUNNING_INSIDE_SPCS", "true")
+    mock_open = mock.mock_open(read_data="  \n TEST_SPCS_TOKEN \n  ")
+    monkeypatch.setattr("snowflake.connector._utils.open", mock_open, raising=False)
+
+    captured_bodies: list[dict] = []
+    _connect_and_capture(captured_bodies)
+
+    assert len(captured_bodies) == 1
+    assert captured_bodies[0]["data"]["SPCS_TOKEN"] == "TEST_SPCS_TOKEN"

--- a/test/wif/test_wif.py
+++ b/test/wif/test_wif.py
@@ -79,6 +79,26 @@ def test_should_authenticate_with_impersonation():
     ), f"Failed to connect using WIF with provider {PROVIDER}"
 
 
+@pytest.mark.wif
+def test_should_authenticate_using_aws_outbound_token():
+    if PROVIDER != "AWS":
+        pytest.skip("Skipping test - not running on AWS")
+
+    os.environ["SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN"] = "true"
+    try:
+        connection_params = {
+            "host": HOST,
+            "account": ACCOUNT,
+            "authenticator": "WORKLOAD_IDENTITY",
+            "workload_identity_provider": "AWS",
+        }
+        assert connect_and_execute_simple_query(
+            connection_params, EXPECTED_USERNAME
+        ), "Failed to connect using WIF with AWS outbound token"
+    finally:
+        os.environ.pop("SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN", None)
+
+
 def is_provider_gcp() -> bool:
     return PROVIDER == "GCP"
 


### PR DESCRIPTION
## Summary
Fix async: Support jwt in aws wif

## Squashed commits (5)
- 1aa9f4c support jwt in aws wif (#2766)
- e48118d [SNOW-3296990] fix spcs token related flow for python driver (#2847)
- bbe49cc docs: Update tox devenv docs link in setup documentation (#1979)
- da1000c Fix type of SnowflakeCursorBase.__iter__ (#2603)
- ba60d56 Upgrade actions/setup-python from v4 to v5 (#2849)

🤖 Created by stack_create.py

[SNOW-3296990]: https://snowflakecomputing.atlassian.net/browse/SNOW-3296990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ