### PR TITLE
SNOW-298756: Add ECDSA key support for key-pair authentication

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,9 +8,13 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - Upcoming Release
+  - Fixed a security bug in Okta SAML authentication where `_is_prefix_equal()` compared `url1`'s port against itself instead of `url2`'s port, allowing an attacker to redirect credentials to a different port on the same hostname. Also fixed the default port fallback to use `int` instead of `str` for correct comparison when one URL omits the port.
+  - Fixed `executemany` with `paramstyle="pyformat"` to correctly locate the VALUES clause using a balanced-parentheses parser instead of a greedy regex. This fixes incorrect behaviour with nested function calls such as SQLAlchemy `@compiles VARIANT` patterns (e.g. `PARSE_JSON(%(col)s)`) and subquery-form INSERTs (SNOW-298756).
+  - Added ECDSA key support (ES256, ES384, ES512) for key-pair authentication.
   - Added HTTP 307/308 redirect status codes to the retryable set as defense-in-depth, with redirect-aware logging in both sync and async paths.
   - Consolidated keyring token cache to use a single service name with hashed account keys, reducing macOS Keychain password prompts. Legacy entries are auto-migrated on first read.
   - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
+  - Removed dynamic class deserialization from the OCSP response validation cache to prevent arbitrary code execution via crafted cache files (SNOW-2439940). The `SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS` environment variable is now a no-op.
   - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
 
 - v4.4.0(March 25,2026)

--- a/src/snowflake/connector/aio/_cursor.py
+++ b/src/snowflake/connector/aio/_cursor.py
@@ -57,6 +57,7 @@ from snowflake.connector.errors import BindUploadError, DatabaseError
 from snowflake.connector.file_transfer_agent import SnowflakeProgressPercentage
 from snowflake.connector.telemetry import TelemetryData, TelemetryField
 from snowflake.connector.time_util import get_time_millis
+from snowflake.connector.util_text import extract_values_clause
 
 from .._utils import REQUEST_ID_STATEMENT_PARAM_NAME, is_uuid4
 
@@ -765,8 +766,8 @@ class SnowflakeCursorBase(SnowflakeCursorBaseSync, abc.ABC, typing.Generic[Fetch
                 #  accumulate results to mock the result from a single insert statement as formatted below
                 logger.debug("rewriting INSERT query")
                 command_wo_comments = re.sub(self.COMMENT_SQL_RE, "", command)
-                m = self.INSERT_SQL_VALUES_RE.match(command_wo_comments)
-                if not m:
+                fmt = extract_values_clause(command_wo_comments)
+                if fmt is None:
                     Error.errorhandler_wrapper(
                         self.connection,
                         self,
@@ -776,8 +777,6 @@ class SnowflakeCursorBase(SnowflakeCursorBaseSync, abc.ABC, typing.Generic[Fetch
                             "errno": ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
                         },
                     )
-
-                fmt = m.group(1)
                 values = []
                 for param in seqparams:
                     logger.debug(f"parameter: {param}")

--- a/src/snowflake/connector/auth/keypair.py
+++ b/src/snowflake/connector/auth/keypair.py
@@ -10,6 +10,12 @@ from typing import Any
 
 import jwt
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    SECP256R1,
+    SECP384R1,
+    SECP521R1,
+    EllipticCurvePrivateKey,
+)
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -28,7 +34,12 @@ logger = getLogger(__name__)
 class AuthByKeyPair(AuthByPlugin):
     """Key pair based authentication."""
 
-    ALGORITHM = "RS256"
+    ALG_RS256 = "RS256"
+    ALG_ES256 = "ES256"
+    ALG_ES384 = "ES384"
+    ALG_ES512 = "ES512"
+    ALGORITHM = ALG_RS256  # deprecated, kept for backward compatibility
+
     ISSUER = "iss"
     SUBJECT = "sub"
     EXPIRE_TIME = "exp"
@@ -39,7 +50,7 @@ class AuthByKeyPair(AuthByPlugin):
 
     def __init__(
         self,
-        private_key: bytes | str | RSAPrivateKey,
+        private_key: bytes | str | RSAPrivateKey | EllipticCurvePrivateKey,
         private_key_passphrase: bytes | None = None,
         lifetime_in_seconds: int = LIFETIME,
         **kwargs,
@@ -48,7 +59,7 @@ class AuthByKeyPair(AuthByPlugin):
 
         Args:
             private_key: a byte array of der formats of private key, or an
-                object that implements the `RSAPrivateKey` interface.
+                object that implements the `RSAPrivateKey` or `EllipticCurvePrivateKey` interface.
             lifetime_in_seconds: number of seconds the JWT token will be valid
         """
         super().__init__(
@@ -72,7 +83,9 @@ class AuthByKeyPair(AuthByPlugin):
             ).total_seconds()
         )
 
-        self._private_key: bytes | str | RSAPrivateKey | None = private_key
+        self._private_key: (
+            bytes | str | RSAPrivateKey | EllipticCurvePrivateKey | None
+        ) = private_key
         self._private_key_passphrase: bytes | None = private_key_passphrase
         self._jwt_token = ""
         self._jwt_token_exp = 0
@@ -109,7 +122,7 @@ class AuthByKeyPair(AuthByPlugin):
             except Exception as e:
                 raise ProgrammingError(
                     msg=f"Failed to decode private key: {e}\nPlease provide a valid "
-                    "unencrypted rsa private key in base64-encoded DER format as a "
+                    "unencrypted RSA or ECDSA private key in base64-encoded DER format as a "
                     "str object",
                     errno=ER_INVALID_PRIVATE_KEY,
                 )
@@ -124,23 +137,23 @@ class AuthByKeyPair(AuthByPlugin):
             except Exception as e:
                 raise ProgrammingError(
                     msg=f"Failed to load private key: {e}\nPlease provide a valid "
-                    "rsa private key in DER format as bytes object. If the key is "
+                    "RSA or ECDSA private key in DER format as bytes object. If the key is "
                     "encrypted, provide the passphrase via private_key_passphrase",
                     errno=ER_INVALID_PRIVATE_KEY,
                 )
 
-            if not isinstance(private_key, RSAPrivateKey):
+            if not isinstance(private_key, (RSAPrivateKey, EllipticCurvePrivateKey)):
                 raise ProgrammingError(
                     msg=f"Private key type ({private_key.__class__.__name__}) not supported."
-                    "\nPlease provide a valid rsa private key in DER format as bytes "
+                    "\nPlease provide a valid RSA or ECDSA private key in DER format as bytes "
                     "object",
                     errno=ER_INVALID_PRIVATE_KEY,
                 )
-        elif isinstance(self._private_key, RSAPrivateKey):
+        elif isinstance(self._private_key, (RSAPrivateKey, EllipticCurvePrivateKey)):
             private_key = self._private_key
         else:
             raise TypeError(
-                f"Expected bytes or RSAPrivateKey, got {type(self._private_key)}"
+                f"Expected bytes, RSAPrivateKey, or EllipticCurvePrivateKey, got {type(self._private_key)}"
             )
 
         public_key_fp = self.calculate_public_key_fingerprint(private_key)
@@ -153,7 +166,24 @@ class AuthByKeyPair(AuthByPlugin):
             self.EXPIRE_TIME: self._jwt_token_exp,
         }
 
-        _jwt_token = jwt.encode(payload, private_key, algorithm=self.ALGORITHM)
+        # select algorithm based on key type and curve
+        if isinstance(private_key, EllipticCurvePrivateKey):
+            curve = private_key.curve
+            if isinstance(curve, SECP256R1):
+                algorithm = self.ALG_ES256
+            elif isinstance(curve, SECP384R1):
+                algorithm = self.ALG_ES384
+            elif isinstance(curve, SECP521R1):
+                algorithm = self.ALG_ES512
+            else:
+                raise ProgrammingError(
+                    msg=f"Unsupported EC curve: {curve.name}. Supported: SECP256R1, SECP384R1, SECP521R1",
+                    errno=ER_INVALID_PRIVATE_KEY,
+                )
+        else:
+            algorithm = self.ALG_RS256
+
+        _jwt_token = jwt.encode(payload, private_key, algorithm=algorithm)
 
         # jwt.encode() returns bytes in pyjwt 1.x and a string
         # in pyjwt 2.x

--- a/src/snowflake/connector/auth/okta.py
+++ b/src/snowflake/connector/auth/okta.py
@@ -38,10 +38,10 @@ def _is_prefix_equal(url1, url2):
 
     port1 = parsed_url1.port
     if not port1 and parsed_url1.scheme == "https":
-        port1 = "443"
-    port2 = parsed_url1.port
+        port1 = 443
+    port2 = parsed_url2.port
     if not port2 and parsed_url2.scheme == "https":
-        port2 = "443"
+        port2 = 443
 
     return (
         parsed_url1.hostname == parsed_url2.hostname

--- a/src/snowflake/connector/cursor.py
+++ b/src/snowflake/connector/cursor.py
@@ -79,6 +79,7 @@ from .options import installed_pandas
 from .sqlstate import SQLSTATE_FEATURE_NOT_SUPPORTED
 from .telemetry import TelemetryData, TelemetryField
 from .time_util import get_time_millis
+from .util_text import extract_values_clause
 
 if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
@@ -348,9 +349,6 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
 
     INSERT_SQL_RE = re.compile(r"^insert\s+into", flags=re.IGNORECASE)
     COMMENT_SQL_RE = re.compile(r"/\*.*\*/")
-    INSERT_SQL_VALUES_RE = re.compile(
-        r".*VALUES\s*(\(.*\)).*", re.IGNORECASE | re.MULTILINE | re.DOTALL
-    )
     ALTER_SESSION_RE = re.compile(
         r"alter\s+session\s+set\s+(\w*?)\s*=\s*\'?([^\']+?)\'?\s*(?:;|$)",
         flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
@@ -1473,8 +1471,8 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
                 #  accumulate results to mock the result from a single insert statement as formatted below
                 logger.debug("rewriting INSERT query")
                 command_wo_comments = re.sub(self.COMMENT_SQL_RE, "", command)
-                m = self.INSERT_SQL_VALUES_RE.match(command_wo_comments)
-                if not m:
+                fmt = extract_values_clause(command_wo_comments)
+                if fmt is None:
                     Error.errorhandler_wrapper(
                         self.connection,
                         self,
@@ -1484,8 +1482,6 @@ class SnowflakeCursorBase(abc.ABC, Generic[FetchRow]):
                             "errno": ER_FAILED_TO_REWRITE_MULTI_ROW_INSERT,
                         },
                     )
-
-                fmt = m.group(1)
                 values = []
                 for param in seqparams:
                     logger.debug(f"parameter: {param}")

--- a/src/snowflake/connector/ocsp_snowflake.py
+++ b/src/snowflake/connector/ocsp_snowflake.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import codecs
-import importlib
 import json
 import os
 import platform
@@ -10,7 +9,6 @@ import re
 import sys
 import tempfile
 import time
-import warnings
 from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from logging import getLogger
@@ -29,10 +27,7 @@ from OpenSSL.SSL import Connection
 
 from snowflake.connector import SNOWFLAKE_CONNECTOR_VERSION
 from snowflake.connector.compat import OK, urlsplit, urlunparse
-from snowflake.connector.constants import (
-    ENV_VAR_ENABLE_CUSTOM_REVOCATION_ERRORS,
-    HTTP_HEADER_USER_AGENT,
-)
+from snowflake.connector.constants import HTTP_HEADER_USER_AGENT
 from snowflake.connector.errorcode import (
     ER_INVALID_OCSP_RESPONSE_SSD,
     ER_INVALID_SSD,
@@ -137,40 +132,19 @@ class OCSPResponseValidationResult(NamedTuple):
                     errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
                 )
 
-            # For non-RevocationCheckError, always try to deserialize to detect failures
-            try:
-                module = importlib.import_module(exc_module)
-                exc_cls = getattr(module, exc_class)
-                custom_exc = exc_cls(exception_dict["msg"])
-
-                # If env var is set, return the custom exception with deprecation warning
-                if os.getenv(ENV_VAR_ENABLE_CUSTOM_REVOCATION_ERRORS, "").lower() in (
-                    "true",
-                    "1",
-                ):
-                    warnings.warn(
-                        "Support for custom revocation error classes will be removed in a future release.",
-                        DeprecationWarning,
-                        stacklevel=3,
-                    )
-                    return custom_exc
-
-                # Otherwise, convert to RevocationCheckError
-                return RevocationCheckError(
-                    msg=exception_dict["msg"],
-                    errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
-                )
-            except Exception as deserialize_exc:
-                logger.debug(
-                    f"hitting error {str(deserialize_exc)} while deserializing exception,"
-                    f" the original error error class and message are {exc_class} and {exception_dict['msg']}"
-                )
-                return RevocationCheckError(
-                    msg=f"Got error {str(deserialize_exc)} while deserializing ocsp cache, please try "
-                    f"cleaning up the "
-                    f"OCSP cache under directory {OCSP_RESPONSE_VALIDATION_CACHE.file_path}",
-                    errno=ER_OCSP_RESPONSE_LOAD_FAILURE,
-                )
+            # SECURITY: Do not dynamically import or instantiate classes from
+            # cache data.  All non-RevocationCheckError exceptions are wrapped
+            # in a RevocationCheckError to avoid arbitrary code execution via
+            # crafted cache files (CWE-470 / CWE-502).
+            logger.debug(
+                "Converting cached %s.%s exception to RevocationCheckError",
+                exc_module,
+                exc_class,
+            )
+            return RevocationCheckError(
+                msg=exception_dict.get("msg", "Cached OCSP exception"),
+                errno=exception_dict.get("errno", ER_OCSP_RESPONSE_LOAD_FAILURE),
+            )
 
         return OCSPResponseValidationResult(
             exception=deserialize_exception(json_obj.get("exception")),

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -11,6 +11,78 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Sequence
 
+_VALUES_CLAUSE_RE = re.compile(r"\bVALUES\s*\(", re.IGNORECASE)
+
+# Matches only the tokens that affect parser state.  Two-char tokens are
+# listed first so the alternation is greedy and consumes them whole:
+#   $$   — dollar-quote delimiter
+#   ''   — escaped single-quote inside a single-quoted string
+#   ""   — escaped double-quote inside a double-quoted string
+#   ( ) ' "  — individual state-change characters
+# Everything between tokens is skipped at C speed by the regex engine,
+# avoiding a Python-level loop over every character.
+_SQL_TOKENS_RE = re.compile(r"\$\$|''|\"\"|[()'\"]")
+
+
+def extract_values_clause(sql: str) -> str | None:
+    """Extract the VALUES clause from an INSERT SQL statement.
+
+    Uses a balanced-parentheses parser rather than a greedy regex so that
+    nested function calls (e.g. ``PARSE_JSON(%(col)s)``) and string literals
+    that contain parentheses are handled correctly.
+
+    Examples that the greedy regex gets wrong but this function handles:
+
+    * ``INSERT INTO t (raw) (SELECT PARSE_JSON(c) as raw FROM VALUES (%(raw)s))``
+      → returns ``(%(raw)s)``  (greedy regex returns ``(%(raw)s))``)
+    * ``INSERT INTO t (col) VALUES (PARSE_JSON(%(col)s))``
+      → returns ``(PARSE_JSON(%(col)s))``
+
+    Returns:
+        The VALUES clause including its outer parentheses, e.g. ``(%(col)s)``,
+        or ``None`` when no balanced VALUES clause can be found.
+    """
+    m = _VALUES_CLAUSE_RE.search(sql)
+    if not m:
+        return None
+
+    start = m.end() - 1  # position of the opening '('
+    depth = 0
+    in_single_quote = False
+    in_double_quote = False
+    in_dollar_quote = False
+
+    for tok in _SQL_TOKENS_RE.finditer(sql, start):
+        t = tok.group()
+
+        if in_dollar_quote:
+            if t == "$$":
+                in_dollar_quote = False
+        elif in_single_quote:
+            if t == "'":
+                in_single_quote = False
+            # t == "''" → escaped quote, stay in string (fall through, do nothing)
+        elif in_double_quote:
+            if t == '"':
+                in_double_quote = False
+            # t == '""' → escaped quote, stay in string (fall through, do nothing)
+        else:
+            if t == "(":
+                depth += 1
+            elif t == ")":
+                depth -= 1
+                if depth == 0:
+                    return sql[start : tok.end()]
+            elif t == "'":
+                in_single_quote = True
+            elif t == '"':
+                in_double_quote = True
+            elif t == "$$":
+                in_dollar_quote = True
+
+    return None  # unbalanced or no VALUES clause found
+
+
 COMMENT_PATTERN_RE = re.compile(r"^\s*\-\-")
 EMPTY_LINE_RE = re.compile(r"^\s*$")
 

--- a/src/snowflake/connector/version.py
+++ b/src/snowflake/connector/version.py
@@ -1,3 +1,3 @@
 # Update this for the versions
-# Don't change the forth version number from None
+# Don't change the fourth version number from None
 VERSION = (4, 4, 0, None)

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -20,6 +20,154 @@ except ImportError:
     from snowflake.connector.auth_okta import AuthByOkta
 
 
+@pytest.mark.parametrize(
+    "url1,url2,expected",
+    [
+        # same prefix, no explicit port
+        ("https://company.okta.com/path", "https://company.okta.com/other", True),
+        # same prefix, explicit matching port
+        (
+            "https://company.okta.com:443/path",
+            "https://company.okta.com:443/other",
+            True,
+        ),
+        # implicit 443 matches explicit 443
+        ("https://company.okta.com/path", "https://company.okta.com:443/other", True),
+        ("https://company.okta.com:443/path", "https://company.okta.com/other", True),
+        # different hostname
+        ("https://company.okta.com/path", "https://evil.okta.com/path", False),
+        # different scheme
+        ("https://company.okta.com/path", "http://company.okta.com/path", False),
+        # different port — the core case this bug was about
+        ("https://company.okta.com/path", "https://company.okta.com:8443/path", False),
+        (
+            "https://company.okta.com:443/path",
+            "https://company.okta.com:8443/path",
+            False,
+        ),
+        ("https://company.okta.com:8443/path", "https://company.okta.com/path", False),
+        (
+            "https://company.okta.com:8443/path",
+            "https://company.okta.com:443/path",
+            False,
+        ),
+        # http scheme, different ports
+        ("http://host/a", "http://host:8080/a", False),
+    ],
+)
+def test_is_prefix_equal(url1, url2, expected):
+    """Verify _is_prefix_equal correctly compares scheme, host, AND port of both URLs."""
+    from snowflake.connector.auth.okta import _is_prefix_equal
+
+    assert _is_prefix_equal(url1, url2) is expected
+
+
+def test_step2_rejects_token_url_with_different_port():
+    """_step2 must reject a tokenUrl whose port differs from the authenticator.
+
+    This is the primary credential-theft vector: a rogue Snowflake server returns
+    a tokenUrl on the same Okta hostname but on an attacker-controlled port.
+    """
+    authenticator = "https://company.okta.com/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://company.okta.com/sso"
+    ref_token_url = "https://company.okta.com:8443/api/v1/authn"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert (
+        rest._connection.errorhandler.called
+    ), "_step2 should reject tokenUrl with a different port"
+
+
+def test_step2_rejects_sso_url_with_different_port():
+    """_step2 must reject an ssoUrl whose port differs from the authenticator."""
+    authenticator = "https://company.okta.com/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://company.okta.com:8443/app/snowflake/sso"
+    ref_token_url = "https://company.okta.com/api/v1/authn"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert (
+        rest._connection.errorhandler.called
+    ), "_step2 should reject ssoUrl with a different port"
+
+
+def test_step5_rejects_post_back_url_with_different_port():
+    """_step5 must reject a SAML post-back URL whose port differs from Snowflake's."""
+    application = "testapplication"
+    account = "testaccount"
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+
+    rest._protocol = "https"
+    rest._host = f"{account}.snowflakecomputing.com"
+    rest._port = 443
+
+    response_html = (
+        "<html><body>"
+        '<form action="https://testaccount.snowflakecomputing.com:8443/post_back"></form>'
+        "</body></html>"
+    )
+    auth._step5(rest._connection, response_html)
+    assert (
+        rest._connection.errorhandler.called
+    ), "_step5 should reject post_back_url with a different port"
+
+
+def test_step5_accepts_implicit_port_matching_explicit_port():
+    """Implicit https port (no :443 in URL) must match explicit :443 in full_url.
+
+    _step5 constructs full_url with an explicit port (e.g. :443) from
+    conn._rest._port. The post-back URL from the SAML response typically
+    omits the port for standard https. These must compare as equal —
+    regression test for the int-vs-string port default mismatch.
+    """
+    application = "testapplication"
+    account = "testaccount"
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+
+    rest._protocol = "https"
+    rest._host = f"{account}.snowflakecomputing.com"
+    rest._port = 443
+
+    response_html = (
+        "<html><body>"
+        '<form action="https://testaccount.snowflakecomputing.com/post_back"></form>'
+        "</body></html>"
+    )
+    auth._step5(rest._connection, response_html)
+    assert (
+        not rest._connection.errorhandler.called
+    ), "_step5 should accept post_back_url when implicit port 443 matches explicit :443"
+
+
 def test_auth_prepare_body_does_not_overwrite_client_environment_fields():
     application = "testapplication"
     auth_class = AuthByOkta(application)

--- a/test/unit/test_ocsp.py
+++ b/test/unit/test_ocsp.py
@@ -862,8 +862,8 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
         ):
             assert key1 == key2 and value1 == value2
 
-    def verify_exception_default(_, loaded_cache):
-        """Test default behavior: custom exceptions are converted to RevocationCheckError"""
+    def verify_exception(_, loaded_cache):
+        """All cached exceptions are deserialized as RevocationCheckError (no dynamic import)."""
         exc_1 = loaded_cache[(b"key1", b"key2", b"key3")].exception
         exc_2 = loaded_cache[(b"key4", b"key5", b"key6")].exception
         exc_3 = loaded_cache[(b"key7", b"key8", b"key9")].exception
@@ -872,31 +872,10 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
             and exc_1.raw_msg == "error"
             and exc_1.errno == 1
         )
-        # By default, custom exceptions (ValueError) are converted to RevocationCheckError
         assert isinstance(exc_2, RevocationCheckError)
-        assert (
-            isinstance(exc_3, RevocationCheckError)
-            and "while deserializing ocsp cache, please try cleaning up the OCSP cache under directory"
-            in exc_3.msg
-        )
-
-    def verify_exception_deprecated(_, loaded_cache):
-        """Test deprecated behavior with env var: custom exceptions are preserved"""
-        exc_1 = loaded_cache[(b"key1", b"key2", b"key3")].exception
-        exc_2 = loaded_cache[(b"key4", b"key5", b"key6")].exception
-        exc_3 = loaded_cache[(b"key7", b"key8", b"key9")].exception
-        assert (
-            isinstance(exc_1, RevocationCheckError)
-            and exc_1.raw_msg == "error"
-            and exc_1.errno == 1
-        )
-        # With env var set, custom exceptions are preserved
-        assert isinstance(exc_2, ValueError) and str(exc_2) == "value error"
-        assert (
-            isinstance(exc_3, RevocationCheckError)
-            and "while deserializing ocsp cache, please try cleaning up the OCSP cache under directory"
-            in exc_3.msg
-        )
+        assert exc_2.raw_msg == "value error"
+        assert isinstance(exc_3, RevocationCheckError)
+        assert exc_3.raw_msg == "json error: line 1 column 1 (char 0)"
 
     verify(verify_happy_path, copy.deepcopy(test_cache))
 
@@ -906,7 +885,6 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
     )
     verify(verify_none, origin_cache)
 
-    # Test default behavior (no env var)
     origin_cache = copy.deepcopy(test_cache)
     origin_cache.update(
         {
@@ -921,27 +899,4 @@ def test_json_cache_serialization_and_deserialization(tmpdir):
             ),
         }
     )
-    verify(verify_exception_default, origin_cache)
-
-    # Test deprecated behavior (with env var set)
-    with mock.patch.dict(
-        os.environ, {"SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS": "true"}
-    ):
-        origin_cache = copy.deepcopy(test_cache)
-        origin_cache.update(
-            {
-                (b"key1", b"key2", b"key3"): OCSPResponseValidationResult(
-                    exception=RevocationCheckError(msg="error", errno=1),
-                ),
-                (b"key4", b"key5", b"key6"): OCSPResponseValidationResult(
-                    exception=ValueError("value error"),
-                ),
-                (b"key7", b"key8", b"key9"): OCSPResponseValidationResult(
-                    exception=json.JSONDecodeError("json error", "doc", 0)
-                ),
-            }
-        )
-        with pytest.warns(
-            DeprecationWarning, match="Support for custom revocation error classes"
-        ):
-            verify(verify_exception_deprecated, origin_cache)
+    verify(verify_exception, origin_cache)

--- a/test/unit/test_text_util.py
+++ b/test/unit/test_text_util.py
@@ -4,7 +4,7 @@ import random
 import pytest
 
 try:
-    from snowflake.connector.util_text import random_string
+    from snowflake.connector.util_text import extract_values_clause, random_string
 except ImportError:
     pass
 
@@ -31,3 +31,73 @@ def test_random_string_generation_with_same_global_seed():
         futures = [executor.submit(get_random_string) for _ in range(5)]
         res = [f.result() for f in futures]
         assert len(set(res)) == 5  # no duplicate string
+
+
+# ---------------------------------------------------------------------------
+# extract_values_clause tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        # Simple pyformat single column
+        (
+            "INSERT INTO t (col) VALUES (%(col)s)",
+            "(%(col)s)",
+        ),
+        # printf-style %s / %d
+        (
+            "INSERT INTO t (a, b) VALUES (%s, %d)",
+            "(%s, %d)",
+        ),
+        # Nested function call — the bug case for @compiles VARIANT (PARSE_JSON)
+        (
+            "INSERT INTO t (col) VALUES (PARSE_JSON(%(col)s))",
+            "(PARSE_JSON(%(col)s))",
+        ),
+        # VARIANT cast via :: — another common @compiles pattern
+        (
+            "INSERT INTO t (col) VALUES (%(col)s::VARIANT)",
+            "(%(col)s::VARIANT)",
+        ),
+        # PARSE_JSON + VARIANT cast combined
+        (
+            "INSERT INTO t (col) VALUES (PARSE_JSON(%(col)s)::VARIANT)",
+            "(PARSE_JSON(%(col)s)::VARIANT)",
+        ),
+        # Multiple columns, one with nested function
+        (
+            "INSERT INTO t (a, b) VALUES (%(a)s, PARSE_JSON(%(b)s))",
+            "(%(a)s, PARSE_JSON(%(b)s))",
+        ),
+        # String literal with parens inside — must not confuse depth counter
+        (
+            "INSERT INTO t (col) VALUES (%s, '))((' )()",
+            "(%s, '))((' )",
+        ),
+        # Subquery form that used to return an extra ')' with the greedy regex
+        # (SNOW-298756 / PR #657 bug case)
+        (
+            'INSERT INTO "MESSAGES" (raw) (SELECT PARSE_JSON(column1) as raw from values (%(raw)s))',
+            "(%(raw)s)",
+        ),
+        # VALUES keyword is case-insensitive
+        (
+            "INSERT INTO t (col) values (%(col)s)",
+            "(%(col)s)",
+        ),
+        # No VALUES clause → None
+        (
+            "INSERT INTO t SELECT col FROM src",
+            None,
+        ),
+        # Dollar-quoted string containing parens — depth must not be affected
+        (
+            "INSERT INTO t (col) VALUES ($$)$$)",
+            "($$)$$)",
+        ),
+    ],
+)
+def test_extract_values_clause(sql, expected):
+    assert extract_values_clause(sql) == expected


### PR DESCRIPTION
## Summary
Fix keypair-auth: Add ECDSA key support for key-pair authentication

## Squashed commits (5)
- 3d23f3a Add ECDSA key support for key-pair authentication (#2744)
- 74a310f SNOW-298756: use balanced parsing for VALUES instead of regex (#2852)
- f962945 Fix bug in okta url validation (#2855)
- 3128e7c Removed dynamic class deserialization from the OCSP response validati… (#2856)
- 5dc9ed1 Correct minor typo in version.py (#2770)

🤖 Created by stack_create.py