### PR TITLE
SNOW-3258702: Include libc family/version in client session metadata.

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,6 +16,9 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
   - Added support for AWS outbound JWT token attestation for Workload Identity Federation (WIF). This can be enabled by setting the `SNOWFLAKE_ENABLE_AWS_WIF_OUTBOUND_TOKEN` environment variable to `true`. Note: This environment variable will be removed in a future release.
   - Removed dynamic class deserialization from the OCSP response validation cache to prevent arbitrary code execution via crafted cache files (SNOW-2439940). The `SNOWFLAKE_ENABLE_CUSTOM_REVOCATION_ERRORS` environment variable is now a no-op.
   - Updated SPCS token injection to gate on `SNOWFLAKE_RUNNING_INSIDE_SPCS` environment variable, trim whitespace, and remove configurable token path.
+  - GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address, so it works on IPv6-only GCP VMs.
+  - Fixed a bug where `write_pandas()` with `auto_create_table=False` and `overwrite=True` would execute `CREATE TABLE IF NOT EXISTS`, which required unnecessary `OWNERSHIP` privilege on the table. Now only `TRUNCATE TABLE` is executed in this case. Note: users who relied on the table being implicitly created despite `auto_create_table=False` should set `auto_create_table=True` instead.
+  - Added validation of the `account` connection parameter so malformed identifiers (for example path-like values or labels outside letters, digits, `_`, and `-`) are rejected with `ProgrammingError` before login (SNOW-1902886).
 
 - v4.4.0(March 25,2026)
   - Bump the lower boundary of cryptography to 46.0.5 due to CVE-2026-26007.

--- a/src/snowflake/connector/_utils.py
+++ b/src/snowflake/connector/_utils.py
@@ -184,12 +184,33 @@ class _CoreLoader:
             return "unknown"
 
     @staticmethod
+    def _libc_ver() -> tuple[str, str]:
+        """Return (libc_name, libc_version) from the platform."""
+        return platform.libc_ver()
+
+    @staticmethod
     def _detect_libc() -> str:
         """Detect libc type on Linux (glibc vs musl)."""
-        lib, _ = platform.libc_ver()
+        lib, _ = _CoreLoader._libc_ver()
         if lib == "glibc":
             return "glibc"
         return "musl"
+
+    @staticmethod
+    def get_libc_version() -> str | None:
+        """Return libc version from :func:`platform.libc_ver`, or None if unknown."""
+        _, version = _CoreLoader._libc_ver()
+        if not version:
+            return None
+        stripped = version.strip()
+        return stripped or None
+
+    @staticmethod
+    def get_libc_family() -> str | None:
+        """Return libc family for Linux (glibc or musl), otherwise None."""
+        if _CoreLoader._detect_os() != "linux":
+            return None
+        return _CoreLoader._detect_libc()
 
     @staticmethod
     def _get_platform_subdir() -> str:
@@ -329,6 +350,8 @@ def build_minicore_usage_for_session() -> dict[str, str | None]:
         "ISA": ISA,
         "CORE_VERSION": _core_loader.get_core_version(),
         "CORE_FILE_NAME": _core_loader.get_file_name(),
+        "LIBC_FAMILY": _CoreLoader.get_libc_family(),
+        "LIBC_VERSION": _CoreLoader.get_libc_version(),
     }
 
 

--- a/src/snowflake/connector/aio/_pandas_tools.py
+++ b/src/snowflake/connector/aio/_pandas_tools.py
@@ -443,7 +443,7 @@ async def write_pandas(
             quote_identifiers,
         )
 
-        if auto_create_table or overwrite:
+        if auto_create_table:
             iceberg = "ICEBERG " if iceberg_config else ""
             iceberg_config_statement = _iceberg_config_statement_helper(
                 iceberg_config or {}

--- a/src/snowflake/connector/aio/_wif_util.py
+++ b/src/snowflake/connector/aio/_wif_util.py
@@ -27,9 +27,7 @@ from ._session_manager import SessionManager, SessionManagerFactory
 
 logger = logging.getLogger(__name__)
 
-GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default"
-)
+GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 
 
 async def get_aws_region() -> str:

--- a/src/snowflake/connector/config_manager.py
+++ b/src/snowflake/connector/config_manager.py
@@ -29,7 +29,14 @@ LOGGER = logging.getLogger(__name__)
 READABLE_BY_OTHERS = stat.S_IRGRP | stat.S_IROTH
 WRITABLE_BY_OTHERS = stat.S_IWGRP | stat.S_IWOTH
 
+# NOTE: For historical and compatibility reasons, three environment variables are recognized:
+# - The skip warning mechanism was originally for internal use (only within SPCS containers).
+# - SPCS containers set SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION.
+# - SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION is the documented/public way to disable the warning.
+# - In the Universal driver, this warning will become unskippable and the message will clarify:
+#   "SNOWFLAKE_RUNNING_INSIDE_SPCS is detected, skipping permission checks."
 DEPRECATED_SKIP_WARNING_ENV_VAR = "SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE"
+SPCS_INJECTED_SKIP_WARNING_ENV_VAR = "SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION"
 SKIP_WARNING_ENV_VAR = "SF_SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION"
 
 
@@ -37,6 +44,8 @@ def _should_skip_warning_for_read_permissions_on_config_file() -> bool:
     """Check if the warning should be skipped based on environment variable."""
     if SKIP_WARNING_ENV_VAR in os.environ:
         return os.getenv(SKIP_WARNING_ENV_VAR, "false").lower() == "true"
+    if SPCS_INJECTED_SKIP_WARNING_ENV_VAR in os.environ:
+        return os.getenv(SPCS_INJECTED_SKIP_WARNING_ENV_VAR, "false").lower() == "true"
     # Else fallback to old value
     if DEPRECATED_SKIP_WARNING_ENV_VAR in os.environ:
         warn(

--- a/src/snowflake/connector/connection.py
+++ b/src/snowflake/connector/connection.py
@@ -142,7 +142,13 @@ from .sqlstate import SQLSTATE_CONNECTION_NOT_EXISTS, SQLSTATE_FEATURE_NOT_SUPPO
 from .telemetry import TelemetryClient, TelemetryData, TelemetryField
 from .time_util import HeartBeatTimer, get_time_millis
 from .url_util import extract_top_level_domain_from_hostname
-from .util_text import construct_hostname, expand_tilde, parse_account, split_statements
+from .util_text import (
+    construct_hostname,
+    expand_tilde,
+    is_valid_account_identifier,
+    parse_account,
+    split_statements,
+)
 from .wif_util import AttestationProvider
 
 if sys.version_info >= (3, 13) or typing.TYPE_CHECKING:
@@ -699,6 +705,18 @@ class SnowflakeConnection:
         # Set up the file operation parser and stream downloader.
         self._file_operation_parser = FileOperationParser(self)
         self._stream_downloader = StreamDownloader(self)
+
+    def _validate_account(self, account_str):
+        if not is_valid_account_identifier(account_str):
+            Error.errorhandler_wrapper(
+                self,
+                None,
+                ProgrammingError,
+                {
+                    "msg": "Invalid account identifier: only letters, digits, '_' and '-' allowed; no dots or slashes",
+                    "errno": ER_NO_ACCOUNT_NAME,
+                },
+            )
 
     # Deprecated
     @property
@@ -1832,8 +1850,11 @@ class SnowflakeConnection:
                 ProgrammingError,
                 {"msg": "Account must be specified", "errno": ER_NO_ACCOUNT_NAME},
             )
-        if self._account and "." in self._account:
-            self._account = parse_account(self._account)
+
+        if self._account:
+            self._validate_account(self._account)
+            if "." in self._account:
+                self._account = parse_account(self._account)
 
         if not isinstance(self._backoff_policy, Callable) or not isinstance(
             self._backoff_policy(), Iterator

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -528,7 +528,7 @@ def write_pandas(
             quote_identifiers,
         )
 
-        if auto_create_table or overwrite:
+        if auto_create_table:
             iceberg = "ICEBERG " if iceberg_config else ""
             iceberg_config_statement = _iceberg_config_statement_helper(
                 iceberg_config or {}

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -327,6 +327,24 @@ def construct_hostname(region: str | None, account: str) -> str:
     return host
 
 
+ACCOUNT_ID_VALIDATOR_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def is_valid_account_identifier(account: str) -> bool:
+    """Validate the Snowflake account identifier format.
+
+    The account identifier must be a single label (no dots or slashes) composed
+    only of ASCII letters, digits, underscores, or hyphens.
+    """
+    if not isinstance(account, str) or not account:
+        return False
+
+    if "/" in account or "\\" in account:
+        return False
+
+    return all(bool(ACCOUNT_ID_VALIDATOR_RE.fullmatch(p)) for p in account.split("."))
+
+
 def parse_account(account):
     url_parts = account.split(".")
     # if this condition is true, then we have some extra

--- a/src/snowflake/connector/wif_util.py
+++ b/src/snowflake/connector/wif_util.py
@@ -23,9 +23,7 @@ from .session_manager import SessionManager, SessionManagerFactory
 logger = logging.getLogger(__name__)
 SNOWFLAKE_AUDIENCE = "snowflakecomputing.com"
 DEFAULT_ENTRA_SNOWFLAKE_RESOURCE = "api://fd3f753b-eed3-462c-b6a7-a4b5bb650aad"
-GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = (
-    "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default"
-)
+GCP_METADATA_SERVICE_ACCOUNT_BASE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
 
 
 @unique

--- a/test/csp_helpers.py
+++ b/test/csp_helpers.py
@@ -263,7 +263,7 @@ class FakeGceMetadataService(FakeMetadataService):
 
     @property
     def expected_hostnames(self):
-        return ["169.254.169.254", "metadata.google.internal"]
+        return ["metadata.google.internal"]
 
     def handle_request(self, method, parsed_url, headers, timeout):
         query_string = parse_qs(parsed_url.query)

--- a/test/unit/aio/test_pandas_tools_async.py
+++ b/test/unit/aio/test_pandas_tools_async.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from snowflake.connector.options import pandas
+
+# Fake COPY INTO result row: (file, status, rows_parsed, rows_loaded, ...)
+_COPY_RESULT = [("file0.txt", "LOADED", 1, 1, 0, 0, None, None, None, None)]
+# Fake infer_schema result
+_INFER_SCHEMA_RESULT = [("name", "VARCHAR"), ("points", "NUMBER")]
+
+
+@pytest.fixture
+def mock_connection():
+    conn = MagicMock()
+    conn._session_parameters = {}
+    return conn
+
+
+@pytest.fixture
+def mock_cursor(mock_connection):
+    cursor = AsyncMock()
+    mock_connection.cursor.return_value = cursor
+
+    async def _execute_side_effect(sql, *args, **kwargs):
+        result = AsyncMock()
+        if "infer_schema" in sql:
+            result.fetchall.return_value = _INFER_SCHEMA_RESULT
+        elif "COPY INTO" in sql:
+            result.fetchall.return_value = _COPY_RESULT
+        return result
+
+    cursor.execute = AsyncMock(side_effect=_execute_side_effect)
+    return cursor
+
+
+def _get_executed_sqls(mock_cursor):
+    """Extract the SQL strings from all cursor.execute calls."""
+    return [c.args[0] for c in mock_cursor.execute.call_args_list]
+
+
+class TestWritePandasAsyncOverwriteWithoutAutoCreate:
+    """Tests for SNOW-1184290: async write_pandas() with auto_create_table=False and
+    overwrite=True should NOT execute CREATE TABLE IF NOT EXISTS."""
+
+    @pytest.mark.asyncio
+    @patch(
+        "snowflake.connector.aio._pandas_tools._create_temp_stage",
+        new_callable=AsyncMock,
+        return_value="tmp_stage",
+    )
+    @patch(
+        "snowflake.connector.aio._pandas_tools._create_temp_file_format",
+        new_callable=AsyncMock,
+        return_value="tmp_fmt",
+    )
+    async def test_overwrite_without_auto_create_does_not_create_table(
+        self, mock_file_format, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.aio._pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        await write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=False,
+            overwrite=True,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert not any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Should not CREATE TABLE when auto_create_table=False"
+        assert any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Expected TRUNCATE TABLE when overwrite=True and auto_create_table=False"
+
+    @pytest.mark.asyncio
+    @patch(
+        "snowflake.connector.aio._pandas_tools._create_temp_stage",
+        new_callable=AsyncMock,
+        return_value="tmp_stage",
+    )
+    @patch(
+        "snowflake.connector.aio._pandas_tools._create_temp_file_format",
+        new_callable=AsyncMock,
+        return_value="tmp_fmt",
+    )
+    async def test_overwrite_with_auto_create_does_create_table(
+        self, mock_file_format, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.aio._pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        await write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=True,
+            overwrite=True,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Expected CREATE TABLE when auto_create_table=True"
+        assert not any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Should not TRUNCATE when auto_create_table=True (uses drop+rename instead)"
+
+    @pytest.mark.asyncio
+    @patch(
+        "snowflake.connector.aio._pandas_tools._create_temp_stage",
+        new_callable=AsyncMock,
+        return_value="tmp_stage",
+    )
+    async def test_no_overwrite_no_auto_create_no_create_table(
+        self, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.aio._pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        await write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=False,
+            overwrite=False,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert not any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Should not CREATE TABLE when auto_create_table=False"
+        assert not any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Should not TRUNCATE when overwrite=False"

--- a/test/unit/test_pandas_tools.py
+++ b/test/unit/test_pandas_tools.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pandas = pytest.importorskip("pandas")
+
+# Fake COPY INTO result row: (file, status, rows_parsed, rows_loaded, ...)
+_COPY_RESULT = [("file0.txt", "LOADED", 1, 1, 0, 0, None, None, None, None)]
+# Fake infer_schema result
+_INFER_SCHEMA_RESULT = [("name", "VARCHAR"), ("points", "NUMBER")]
+
+
+@pytest.fixture
+def mock_connection():
+    conn = MagicMock()
+    conn._session_parameters = {}
+    return conn
+
+
+@pytest.fixture
+def mock_cursor(mock_connection):
+    cursor = MagicMock()
+    mock_connection.cursor.return_value = cursor
+
+    def _execute_side_effect(sql, *args, **kwargs):
+        result = MagicMock()
+        if "infer_schema" in sql:
+            result.fetchall.return_value = _INFER_SCHEMA_RESULT
+        elif "COPY INTO" in sql:
+            result.fetchall.return_value = _COPY_RESULT
+        return result
+
+    cursor.execute.side_effect = _execute_side_effect
+    return cursor
+
+
+def _get_executed_sqls(mock_cursor):
+    """Extract the SQL strings from all cursor.execute calls."""
+    return [c.args[0] for c in mock_cursor.execute.call_args_list]
+
+
+@pytest.mark.pandas
+@pytest.mark.unit
+class TestWritePandasOverwriteWithoutAutoCreate:
+    """Tests for SNOW-1184290: write_pandas() with auto_create_table=False and
+    overwrite=True should NOT execute CREATE TABLE IF NOT EXISTS."""
+
+    @patch(
+        "snowflake.connector.pandas_tools._create_temp_stage", return_value="tmp_stage"
+    )
+    @patch(
+        "snowflake.connector.pandas_tools._create_temp_file_format",
+        return_value="tmp_fmt",
+    )
+    def test_overwrite_without_auto_create_does_not_create_table(
+        self, mock_file_format, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=False,
+            overwrite=True,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert not any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Should not CREATE TABLE when auto_create_table=False"
+        assert any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Expected TRUNCATE TABLE when overwrite=True and auto_create_table=False"
+
+    @patch(
+        "snowflake.connector.pandas_tools._create_temp_stage", return_value="tmp_stage"
+    )
+    @patch(
+        "snowflake.connector.pandas_tools._create_temp_file_format",
+        return_value="tmp_fmt",
+    )
+    def test_overwrite_with_auto_create_does_create_table(
+        self, mock_file_format, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=True,
+            overwrite=True,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Expected CREATE TABLE when auto_create_table=True"
+        assert not any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Should not TRUNCATE when auto_create_table=True (uses drop+rename instead)"
+
+    @patch(
+        "snowflake.connector.pandas_tools._create_temp_stage", return_value="tmp_stage"
+    )
+    def test_no_overwrite_no_auto_create_no_create_table(
+        self, mock_stage, mock_connection, mock_cursor
+    ):
+        from snowflake.connector.pandas_tools import write_pandas
+
+        df = pandas.DataFrame([("Mark", 10)], columns=["name", "points"])
+
+        write_pandas(
+            mock_connection,
+            df,
+            "test_table",
+            auto_create_table=False,
+            overwrite=False,
+        )
+
+        executed_sqls = _get_executed_sqls(mock_cursor)
+        assert not any(
+            "CREATE" in sql and "TABLE IF NOT EXISTS" in sql for sql in executed_sqls
+        ), "Should not CREATE TABLE when auto_create_table=False"
+        assert not any(
+            "TRUNCATE" in sql for sql in executed_sqls
+        ), "Should not TRUNCATE when overwrite=False"

--- a/test/unit/test_parse_account.py
+++ b/test/unit/test_parse_account.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-from snowflake.connector.util_text import parse_account
+import pytest
+
+from snowflake.connector import ProgrammingError, connect
+from snowflake.connector.util_text import is_valid_account_identifier, parse_account
 
 
 def test_parse_account_basic():
@@ -12,3 +15,45 @@ def test_parse_account_basic():
     assert (
         parse_account("account1-jkabfvdjisoa778wqfgeruishafeuw89q.global") == "account1"
     )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "abc",
+        "aaa.bbb.ccc",
+        "aaa.bbb.ccc.ddd" "ABC",
+        "a_b-c1",
+        "account1",
+        "my_account",
+        "my-account",
+        "account_123",
+        "ACCOUNT_NAME",
+    ],
+)
+def test_is_valid_account_identifier(value):
+    assert is_valid_account_identifier(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "a/b",
+        "a\\b",
+        "aa.bb.ccc/dddd",
+        "account@domain",
+        "account name",
+        "account\ttab",
+        "account\nnewline",
+        "account:port",
+        "account;semicolon",
+        "account'quote",
+        'account"doublequote',
+    ],
+)
+def test_is_invalid_account_identifier(value):
+    assert is_valid_account_identifier(value) is False
+    with pytest.raises(ProgrammingError) as err:
+        connect(account=value, user="jdoe", password="***")
+
+    assert "Invalid account identifier" in str(err)

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -95,6 +95,31 @@ class TestCoreLoader:
         with mock.patch("platform.libc_ver", return_value=("", "")):
             assert _CoreLoader._detect_libc() == "musl"
 
+    def test_get_libc_version(self):
+        """Test get_libc_version returns the version string from platform.libc_ver."""
+        with mock.patch("platform.libc_ver", return_value=("glibc", "2.31")):
+            assert _CoreLoader.get_libc_version() == "2.31"
+
+    def test_get_libc_version_strips_whitespace(self):
+        with mock.patch("platform.libc_ver", return_value=("glibc", "  2.35 \n")):
+            assert _CoreLoader.get_libc_version() == "2.35"
+
+    def test_get_libc_version_empty_returns_none(self):
+        with mock.patch("platform.libc_ver", return_value=("glibc", "")):
+            assert _CoreLoader.get_libc_version() is None
+        with mock.patch("platform.libc_ver", return_value=("", "")):
+            assert _CoreLoader.get_libc_version() is None
+
+    def test_get_libc_family_linux(self):
+        with mock.patch.object(_CoreLoader, "_detect_os", return_value="linux"):
+            with mock.patch.object(_CoreLoader, "_detect_libc", return_value="glibc"):
+                assert _CoreLoader.get_libc_family() == "glibc"
+
+    def test_get_libc_family_non_linux(self):
+        with mock.patch.object(_CoreLoader, "_detect_os", return_value="macos"):
+            with mock.patch.object(_CoreLoader, "_detect_libc", return_value="glibc"):
+                assert _CoreLoader.get_libc_family() is None
+
     @pytest.mark.parametrize(
         "os_name,arch,libc,expected_subdir",
         [
@@ -595,6 +620,8 @@ class TestBuildMinicoreUsage:
         assert "ISA" in result
         assert "CORE_VERSION" in result
         assert "CORE_FILE_NAME" in result
+        assert "LIBC_FAMILY" in result
+        assert "LIBC_VERSION" in result
 
     def test_build_minicore_usage_for_session_isa_matches_platform(self):
         """Test that ISA value matches platform.machine()."""
@@ -603,6 +630,27 @@ class TestBuildMinicoreUsage:
         result = build_minicore_usage_for_session()
 
         assert result["ISA"] == platform.machine()
+
+    def test_build_minicore_usage_for_session_libc_version_matches_platform(self):
+        """Test that LIBC_VERSION matches platform.libc_ver (normalized)."""
+        import platform
+
+        _, libc_version = platform.libc_ver()
+        result = build_minicore_usage_for_session()
+        stripped = libc_version.strip() if libc_version else ""
+        assert result["LIBC_VERSION"] == (stripped or None)
+
+    def test_build_minicore_usage_for_session_libc_family_matches_platform(self):
+        """Test that LIBC_FAMILY is set on Linux and omitted elsewhere."""
+        import platform
+
+        result = build_minicore_usage_for_session()
+        if platform.system().lower() == "linux":
+            lib, _ = platform.libc_ver()
+            expected = "glibc" if lib == "glibc" else "musl"
+            assert result["LIBC_FAMILY"] == expected
+        else:
+            assert result["LIBC_FAMILY"] is None
 
     def test_build_minicore_usage_for_session_with_mocked_core_loader(self):
         """Test build_minicore_usage_for_session with mocked core loader values."""
@@ -647,6 +695,8 @@ class TestBuildMinicoreUsage:
         assert "ISA" in result
         assert "CORE_VERSION" in result
         assert "CORE_FILE_NAME" in result
+        assert "LIBC_FAMILY" in result
+        assert "LIBC_VERSION" in result
 
     def test_build_minicore_usage_for_telemetry_os_matches_platform(self):
         """Test that OS value matches platform.system()."""

--- a/test/wif/test_wif.py
+++ b/test/wif/test_wif.py
@@ -125,7 +125,7 @@ def get_gcp_access_token() -> str:
     try:
         command = (
             'curl -H "Metadata-Flavor: Google" '
-            '"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
+            '"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com"'
         )
 
         result = subprocess.run(


### PR DESCRIPTION
## Summary
Fix async: Include libc family/version in client session metadata.

## Squashed commits (5)
- b395c4c SNOW-3258702: include libc family/version in client session metadata. (#2860)
- d036627 SNOW-1794102 Fix SKIP_TOKEN_FILE_PERMISSIONS_VERIFICATION (#2861)
- 68d12a3 SNOW-2875919 Use metadata.google.internal for GCP WIF to support IPv6-only instances (#2857)
- b14f940 SNOW-1184290: Skip CREATE TABLE IF NOT EXISTS when auto_create_table (#2791)
- f4fa78d SNOW-1902886: Validate account input (#2591)

🤖 Created by stack_create.py