### PR TITLE
NO-SNOW: Use pandas 3+ on 3.14t testing pipelines

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -219,13 +219,7 @@ jobs:
       - name: Run tests
        # To run a single test on GHA use the below command:
 #        run: python -m tox run -e `echo py${PYTHON_VERSION/\./}-single-ci | sed 's/ /,/g'`
-        run: |
-          ENVS=`echo py${PYTHON_VERSION/\./}-{extras,unit-parallel,integ-parallel,pandas-parallel,sso}-ci | sed 's/ /,/g'`
-          if [[ "${PYTHON_VERSION}" == 3.14* ]]; then
-            python -m tox run -x "testenv.commands_pre=python -m pip install --no-deps pandas>=3.0.0" -e $ENVS
-          else
-            python -m tox run -e $ENVS
-          fi
+        run: python -m tox run -e `echo py${PYTHON_VERSION/\./}-{extras,unit-parallel,integ-parallel,pandas-parallel,sso}-ci | sed 's/ /,/g'`
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -219,7 +219,13 @@ jobs:
       - name: Run tests
        # To run a single test on GHA use the below command:
 #        run: python -m tox run -e `echo py${PYTHON_VERSION/\./}-single-ci | sed 's/ /,/g'`
-        run: python -m tox run -e `echo py${PYTHON_VERSION/\./}-{extras,unit-parallel,integ-parallel,pandas-parallel,sso}-ci | sed 's/ /,/g'`
+        run: |
+          ENVS=`echo py${PYTHON_VERSION/\./}-{extras,unit-parallel,integ-parallel,pandas-parallel,sso}-ci | sed 's/ /,/g'`
+          if [[ "${PYTHON_VERSION}" == 3.14* ]]; then
+            python -m tox run -x "testenv.commands_pre=python -m pip install --no-deps pandas>=3.0.0" -e $ENVS
+          else
+            python -m tox run -e $ENVS
+          fi
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,6 +110,7 @@ development =
 pandas =
     pandas>=1.0.0,<3.0.0; python_version < '3.13'
     pandas>=2.1.2,<3.0.0; python_version >= '3.13'
-    pyarrow>=14.0.1
+    pyarrow>=14.0.1,<24; sys_platform == 'win32' and python_version >= '3.14'
+    pyarrow>=14.0.1; sys_platform != 'win32' or python_version < '3.14'
 secure-local-storage =
     keyring>=23.1.0,<26.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,7 @@ development =
 pandas =
     pandas>=1.0.0,<3.0.0; python_version < '3.13'
     pandas>=2.1.2,<3.0.0; python_version >= '3.13'
-    pyarrow>=14.0.1,<24; sys_platform == 'win32' and python_version >= '3.14'
-    pyarrow>=14.0.1; sys_platform != 'win32' or python_version < '3.14'
+    pyarrow>=14.0.1,<24; python_version >= '3.14'
+    pyarrow>=14.0.1; python_version < '3.14'
 secure-local-storage =
     keyring>=23.1.0,<26.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,8 @@ passenv =
     USERNAME
     CLIENT_LOG_DIR_PATH_DOCKER
     PYTEST_ADDOPTS
+commands_pre =
+    {py314,py314t}-pandas: python -m pip install "pandas>=3.0.0"
 commands =
     # Test environments
     # Note: make sure to have a default env and all the other special ones


### PR DESCRIPTION
## Summary

- pyarrow 24.0.0 + pandas 2.x (constrained to `<3.0.0` by #2922) causes a **Windows fatal access violation** in the `nanoarrow_arrow_iterator` C extension when running under free-threaded Python 3.14t (no GIL)
- The same pyarrow version works fine with pandas 3.x, and works on Linux/macOS regardless of pandas version
- Add a platform-conditional upper bound: `pyarrow<24` on `sys_platform == 'win32' and python_version >= '3.14'`; all other environments remain unconstrained

## Root cause (from #2922 CI analysis)

In the CI run for #2922, `Test win_amd64-3.14t-gcp` failed with `Windows fatal exception: access violation` in pandas integration tests. The passing main branch run had installed `pandas==3.0.3` + `pyarrow==24.0.0`; after #2922's `<3.0.0` constraint, the same job installed `pandas==2.3.3` + `pyarrow==24.0.0` and crashed.

## Test plan

- [ ] `Test win_amd64-3.14t-*` jobs should now install `pyarrow<24` and pass pandas tests
- [ ] All non-Windows and Python <3.14 environments continue to use the latest pyarrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)