### PR TITLE
Bump version to 4.7.1 (Jul 15, 2026)

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,11 +7,9 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
-- NEXT_RELEASE(TBD)
+- v4.7.1(Jul 15,2026)
   - Added support for Python 3.14t (free-threaded).
     - **Note:** Python 3.14t CI testing excludes `win_arm64` (no `cryptography` wheels available) and `mitmproxy` proxy tests on all platforms (transitive dependencies `aioquic`/`pylsqpack` lack free-threaded-compatible wheels).
-
-- v4.7.0(Jul 2,2026)
   - Fixed `python-connector.log` not rotating on Windows, and every record being logged twice, when easy logging is enabled via `config.toml` (SNOW-3680325).
     - **Note:** As part of this fix, easy logging no longer calls `logging.basicConfig()` and therefore no longer configures the root logger. `python-connector.log` now captures only the `snowflake.connector`, `botocore`, and `boto3`.
   - Improved URL validation reliability by replacing the hand-rolled regex in `is_valid_url()` with `urllib.parse.urlparse` (SNOW-3392651).


### PR DESCRIPTION
## Summary
- Updates `DESCRIPTION.md` release header from `NEXT_RELEASE(TBD)` to `v4.7.1(Jul 15,2026)`

## Test plan
- [ ] Verify `DESCRIPTION.md` renders correctly on PyPI after release