### PR TITLE
SNOW-3772985: Recognize // line comments in split_statements

### DIFF
--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -86,6 +86,9 @@ def extract_values_clause(sql: str) -> str | None:
 COMMENT_PATTERN_RE = re.compile(r"^\s*\-\-")
 EMPTY_LINE_RE = re.compile(r"^\s*$")
 
+# Tokens that start a single-line comment running to the end of the line.
+COMMENTS = ("--", "//")
+
 _logger = logging.getLogger(__name__)
 
 
@@ -212,7 +215,9 @@ def split_statements(
                     statement.append((line[col0 : col + 1], True))
                     col += 1
                     col0 = col
-                elif line[col:].startswith("--"):
+                elif line[col:].startswith(COMMENTS) and not line[col0:].startswith(
+                    "file://"
+                ):
                     statement.append((line[col0:col], True))
                     if not remove_comments:
                         # keep the comment

--- a/test/unit/test_split_statement.py
+++ b/test/unit/test_split_statement.py
@@ -660,3 +660,23 @@ def test_sql_splitting_various(sql, delimiter, split_stmnts):
             s[0] for s in split_statements(sqlio, delimiter=SQLDelimiter(delimiter))
         )
     assert statements == split_stmnts
+
+
+@pytest.mark.parametrize("remove_comments", [True, False])
+def test_split_with_comment(remove_comments):
+    query = dedent(
+        """
+    use database test_db;
+    use schema public;
+    select
+    c1,
+    c2, // issues here?
+    c3
+    from test;
+    select current_timestamp() as ts;
+    """
+    )
+
+    with StringIO(query) as sqlio:
+        statements = list(split_statements(sqlio, remove_comments=remove_comments))
+    assert len(statements) == 4


### PR DESCRIPTION
## Summary
- Add a `COMMENTS` tuple (`--`, `//`) and use it in `split_statements` to recognize C-style line comments in addition to SQL `--` comments.
- Fix statement splitting when a `//` comment contains an apostrophe (e.g. `// issue's here?`). Previously the unrecognized `//` let the parser fall into the stray `'`, entering quote mode until EOF and merging all subsequent statements.
- Add a parametrized unit test covering multi-statement scripts with `//` comments (both `remove_comments` values).

## Test plan
- [x] `PYTHONPATH=src pytest test/unit/test_split_statement.py -q` (28 passed)
- [ ] CI green

Made with [Cursor](https://cursor.com)