### PR TITLE
Cherry-pick CI fixes onto release/3.18

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -329,7 +329,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cloud-provider: [aws]
+        cloud-provider: [aws, azure, gcp]
     steps:
       - uses: actions/checkout@v4
       - name: Setup parameters file

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 - v3.18.1(July 15,2026)
   - Improved verification of TLS connections (SNOW-3675579).
+  - Fixed FIPS environments md5 hash issues with multipart upload on Azure.
 
 - v3.18.0(October 03,2025)
   - Added support for pandas conversion for Day-time and Year-Month Interval types

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -10,6 +10,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 - v3.18.1(July 15,2026)
   - Improved verification of TLS connections (SNOW-3675579).
   - Fixed FIPS environments md5 hash issues with multipart upload on Azure.
+  - Fixed a bug where Azure GET commands would incorrectly set the file status to UPLOADED instead of preserving the DOWNLOADED status during metadata retrieval.
 
 - v3.18.0(October 03,2025)
   - Added support for pandas conversion for Day-time and Year-Month Interval types

--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -14,7 +14,7 @@ from .compat import quote
 from .constants import FileHeader, ResultStatus
 from .encryption_util import EncryptionMetadata
 from .storage_client import SnowflakeStorageClient
-from .util_text import get_md5
+from .util_text import get_md5_for_integrity
 from .vendored import requests
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -241,9 +241,9 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
                 fd.close()
         headers = {
             "x-ms-blob-content-encoding": "utf-8",
-            "x-ms-blob-content-md5": base64.b64encode(get_md5(file_content)).decode(
-                "utf-8"
-            ),
+            "x-ms-blob-content-md5": base64.b64encode(
+                get_md5_for_integrity(file_content)
+            ).decode("utf-8"),
         }
         azure_metadata = self._prepare_file_metadata()
         headers.update(azure_metadata)

--- a/src/snowflake/connector/azure_storage_client.py
+++ b/src/snowflake/connector/azure_storage_client.py
@@ -124,7 +124,9 @@ class SnowflakeAzureRestClient(SnowflakeStorageClient):
         self.retry_count[retry_id] = 0
         r = self._send_request_with_authentication_and_retry("HEAD", url, retry_id)
         if r.status_code == 200:
-            meta.result_status = ResultStatus.UPLOADED
+            # If we are in download path, do not update to UPLOADED
+            if meta.result_status != ResultStatus.DOWNLOADED:
+                meta.result_status = ResultStatus.UPLOADED
             enc_data_str = r.headers.get(ENCRYPTION_DATA)
             encryption_data = None if enc_data_str is None else json.loads(enc_data_str)
             encryption_metadata = (

--- a/src/snowflake/connector/pandas_tools.py
+++ b/src/snowflake/connector/pandas_tools.py
@@ -408,7 +408,7 @@ def write_pandas(
     ):
         warnings.warn(
             "Dataframe contains a datetime with timezone column, but "
-            f"'{use_logical_type=}'. This can result in dateimes "
+            f"'{use_logical_type=}'. This can result in datetimes "
             "being incorrectly written to Snowflake. Consider setting "
             "'use_logical_type = True'",
             UserWarning,

--- a/src/snowflake/connector/util_text.py
+++ b/src/snowflake/connector/util_text.py
@@ -293,9 +293,11 @@ def _base64_bytes_to_str(x) -> str | None:
     return base64.b64encode(x).decode("utf-8") if x else None
 
 
-def get_md5(text: str | bytes) -> bytes:
+def get_md5_for_integrity(text: str | bytes) -> bytes:
+    # MD5 should not be used for security reasons - only integrity is safe and allowed
     if isinstance(text, str):
         text = text.encode("utf-8")
-    md5 = hashlib.md5()
+    # Usedforsecurity=False added to support FIPS envs as well
+    md5 = hashlib.md5(usedforsecurity=False)
     md5.update(text)
     return md5.digest()

--- a/test/integ/pandas_it/test_pandas_tools.py
+++ b/test/integ/pandas_it/test_pandas_tools.py
@@ -972,7 +972,12 @@ def test_all_pandas_types(
     with conn_cnx() as cnx:
         try:
             success, nchunks, nrows, _ = write_pandas(
-                cnx, df, table_name, quote_identifiers=True, auto_create_table=True
+                cnx,
+                df,
+                table_name,
+                quote_identifiers=True,
+                auto_create_table=True,
+                use_logical_type=True,
             )
 
             # Check write_pandas output
@@ -980,7 +985,8 @@ def test_all_pandas_types(
             assert nrows == len(df_data)
             assert nchunks == 1
             # Check table's contents
-            result = cnx.cursor(DictCursor).execute(select_sql).fetchall()
+            cur = cnx.cursor(DictCursor).execute(select_sql)
+            result = cur.fetchall()
             for row, data in zip(result, df_data):
                 for c in columns:
                     # TODO: check values of timestamp data after SNOW-667350 is fixed


### PR DESCRIPTION
## Summary

Cherry-picks three fixes from `main` to resolve CI failures on `release/3.18`:

- **`SNOW-2743401`**: Rename `get_md5` → `get_md5_for_integrity` with `usedforsecurity=False` for FIPS environment support (prerequisite for the Azure fix)
- **Azure GET status bug**: `azure_storage_client.py` was unconditionally overwriting status to `UPLOADED` during `_get_remote_file_metadata`, clobbering the `DOWNLOADED` status in the download path — causing `test_put_get_with_azure_token.py` failures on all Azure jobs
- **Pandas 2.3.x test fix**: `test_all_pandas_types` was calling `write_pandas` without `use_logical_type=True`, causing pandas 2.3.x to write the `TIME` column as raw integer microseconds — failing the round-trip assertion on all platforms

## Original commits from main

- `1680c6cb` SNOW-2743401: added usedforsecurity argument to md5 hash for multipart upload
- `7c969cd3` NO-SNOW: Fix Azure GET returning UPLOADED instead of DOWNLOADED status
- `6f48c9e6` NO-SNOW: Fix pandas type test

## Test plan

- [ ] Verify `test_put_get_with_azure_token.py` passes on Azure jobs
- [ ] Verify `test_all_pandas_types` passes across all platforms