### PR TITLE
Fix build on FreeBSD/OpenBSD: ENODATA not defined in errno.h

### DIFF
--- a/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/nanoarrow_ipc.c
+++ b/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/nanoarrow_ipc.c
@@ -31039,6 +31039,12 @@ static inline int org_apache_arrow_flatbuf_Tensor_verify_as_root_with_type_hash(
 #include <stdio.h>
 #include <string.h>
 
+// ENODATA is an XSI extension and is not defined by all libcs (e.g., FreeBSD
+// and OpenBSD). See https://github.com/apache/arrow-nanoarrow/pull/906.
+#if !defined(ENODATA)
+#define ENODATA 120
+#endif
+
 // For thread safe shared buffers we need C11 + stdatomic.h
 // Can compile with -DNANOARROW_IPC_USE_STDATOMIC=0 or 1 to override
 // automatic detection


### PR DESCRIPTION
ENODATA is an XSI/SVID extension and is not guaranteed by POSIX; FreeBSD and OpenBSD do not define it in errno.h, breaking the build of the vendored nanoarrow_ipc.c (nanoarrow 0.3.0) on those platforms.

Add a portable fallback definition, matching the fix proposed upstream in apache/arrow-nanoarrow#906. This is a stopgap until Snowflake re-vendors a nanoarrow release containing that fix.

Upstream-PR: https://github.com/apache/arrow-nanoarrow/pull/906

This fixes #2967

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2967

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Makes compile and run.