### PR TITLE
NO-SNOW: Fix dependency check CI failure due to missing typing_extensions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -172,6 +172,7 @@ commands = pre-commit run --all-files
 description = Check if there is conflicting dependency
 deps =
     pip-tools
+    typing_extensions
 skip_install = True
 commands = pip-compile setup.py
 depends = py310, py311, py312, py313, py314, py314t


### PR DESCRIPTION
## Summary

- `pip-tools==7.6.0` introduced a new import of `typing_extensions` in `piptools/writer.py`
- The `[testenv:dependency]` tox env only installs `pip-tools` directly (no transitive deps) and uses `skip_install = True`, so `typing_extensions` was never present
- This caused `ModuleNotFoundError: No module named 'typing_extensions'` when running `pip-compile setup.py`, failing all "Check dependency" CI jobs

## Fix

Added `typing_extensions` to the `deps` list in `[testenv:dependency]` in `tox.ini`.

## Test plan

- [ ] Verify "Check dependency" jobs pass in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)