### PR TITLE
SNOW-3192362: migrate all Docker builds from manylinux2014 to manylinux_2_28

### DIFF
--- a/.github/workflows/create_req_files.yml
+++ b/.github/workflows/create_req_files.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - NEXT_RELEASE(TBD)
+  - Added experimental Python 3.14t (free-threaded CPython) wheel support. **Experimental — not intended for production use.**
   - Fixed `split_statements` treating `//` as SQL instead of a line comment, which could merge multiple statements when a `//` comment contained an apostrophe (SNOW-3772985).
 
 - v4.7.1(Jul 15,2026)

--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -3,7 +3,7 @@
 # Build Snowflake Python Connector on Mac
 # NOTES:
 #   - To compile only a specific version(s) pass in versions like: `./build_darwin.sh "3.10 3.11"`
-PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14}"
+PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14 3.14t}"
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -18,9 +18,11 @@ arch=$(uname -p)
 echo "[Info] Building docker image"
 if [[ "$arch" == "aarch64" ]]; then
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014AARCH64
+  AUDITWHEEL_PLAT=manylinux_2_28_aarch64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
 else
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014
+  AUDITWHEEL_PLAT=manylinux_2_28_x86_64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
 fi
 
@@ -32,6 +34,7 @@ docker run \
     -e TERM=vt102 \
     -e PIP_DISABLE_PIP_VERSION_CHECK=1 \
     -e LOCAL_USER_ID=${user_id} \
+    -e AUDITWHEEL_PLAT=${AUDITWHEEL_PLAT} \
     --mount type=bind,source="${CONNECTOR_DIR}",target=/home/user/snowflake-connector-python \
     ${CONTAINER_NAME}:1.0 \
     /home/user/snowflake-connector-python/ci/build_linux.sh $1

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -16,11 +16,25 @@ CONTAINER_NAME=build_pyconnector
 arch=$(uname -p)
 
 echo "[Info] Building docker image"
-if [[ "$arch" == "aarch64" ]]; then
+# Free-threaded builds require manylinux_2_28 (cp314t is not in manylinux2014).
+# On Jenkins this depends on BASE_IMAGE_MANYLINUX2_28 being mirrored in Artifactory.
+if [[ "${1}" == *"3.14t"* ]]; then
+  if [[ "$arch" == "aarch64" ]]; then
+    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28AARCH64
+    AUDITWHEEL_PLAT=manylinux_2_28_aarch64
+    GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
+  else
+    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28
+    AUDITWHEEL_PLAT=manylinux_2_28_x86_64
+    GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
+  fi
+elif [[ "$arch" == "aarch64" ]]; then
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014AARCH64
+  AUDITWHEEL_PLAT=manylinux2014_aarch64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
 else
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014
+  AUDITWHEEL_PLAT=manylinux2014_x86_64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
 fi
 
@@ -32,6 +46,7 @@ docker run \
     -e TERM=vt102 \
     -e PIP_DISABLE_PIP_VERSION_CHECK=1 \
     -e LOCAL_USER_ID=${user_id} \
+    -e AUDITWHEEL_PLAT=${AUDITWHEEL_PLAT} \
     --mount type=bind,source="${CONNECTOR_DIR}",target=/home/user/snowflake-connector-python \
     ${CONTAINER_NAME}:1.0 \
     /home/user/snowflake-connector-python/ci/build_linux.sh $1

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -16,15 +16,16 @@ CONTAINER_NAME=build_pyconnector
 arch=$(uname -p)
 
 echo "[Info] Building docker image"
-# Free-threaded builds require manylinux_2_28 (cp314t is not in manylinux2014).
-# On Jenkins this depends on BASE_IMAGE_MANYLINUX2_28 being mirrored in Artifactory.
+# Free-threaded builds use the public manylinux_2_28 image directly (quay.io/pypa).
+# This bypasses Artifactory, so cp314t builds work on Jenkins without waiting for
+# an Artifactory mirror. Standard builds keep using the Artifactory-backed image.
 if [[ "${1}" == *"3.14t"* ]]; then
   if [[ "$arch" == "aarch64" ]]; then
-    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28AARCH64
+    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28_PUBLIC_AARCH64
     AUDITWHEEL_PLAT=manylinux_2_28_aarch64
     GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
   else
-    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28
+    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28_PUBLIC
     AUDITWHEEL_PLAT=manylinux_2_28_x86_64
     GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
   fi

--- a/ci/build_docker.sh
+++ b/ci/build_docker.sh
@@ -16,26 +16,11 @@ CONTAINER_NAME=build_pyconnector
 arch=$(uname -p)
 
 echo "[Info] Building docker image"
-# Free-threaded builds use the public manylinux_2_28 image directly (quay.io/pypa).
-# This bypasses Artifactory, so cp314t builds work on Jenkins without waiting for
-# an Artifactory mirror. Standard builds keep using the Artifactory-backed image.
-if [[ "${1}" == *"3.14t"* ]]; then
-  if [[ "$arch" == "aarch64" ]]; then
-    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28_PUBLIC_AARCH64
-    AUDITWHEEL_PLAT=manylinux_2_28_aarch64
-    GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
-  else
-    BASE_IMAGE=$BASE_IMAGE_MANYLINUX2_28_PUBLIC
-    AUDITWHEEL_PLAT=manylinux_2_28_x86_64
-    GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
-  fi
-elif [[ "$arch" == "aarch64" ]]; then
+if [[ "$arch" == "aarch64" ]]; then
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014AARCH64
-  AUDITWHEEL_PLAT=manylinux2014_aarch64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
 else
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014
-  AUDITWHEEL_PLAT=manylinux2014_x86_64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
 fi
 
@@ -47,7 +32,6 @@ docker run \
     -e TERM=vt102 \
     -e PIP_DISABLE_PIP_VERSION_CHECK=1 \
     -e LOCAL_USER_ID=${user_id} \
-    -e AUDITWHEEL_PLAT=${AUDITWHEEL_PLAT} \
     --mount type=bind,source="${CONNECTOR_DIR}",target=/home/user/snowflake-connector-python \
     ${CONTAINER_NAME}:1.0 \
     /home/user/snowflake-connector-python/ci/build_linux.sh $1

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -81,9 +81,9 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
 arch=$(uname -p)
 auditwheel show ${BUILD_DIR}/*.whl
 if [[ $arch == x86_64 ]]; then
-  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux2014_x86_64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
+  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux_2_28_x86_64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
 else
-  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux2014_aarch64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
+  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux_2_28_aarch64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
 fi
 
     # Generate reqs files

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -69,14 +69,6 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     fi
     BUILD_DIR="${DIST_DIR}/$PYTHON_VERSION"
 
-    # Skip gracefully when the interpreter isn't in this container (e.g. 3.14t in manylinux2014).
-    # Allows the default PYTHON_VERSIONS to include future/free-threaded versions without
-    # breaking builds that run in an older image.
-    if [[ ! -x "${PYTHON}" ]]; then
-        echo "[WARN] Python not found for ${PYTHON_VERSION} at ${PYTHON} — skipping"
-        continue
-    fi
-
     # Build
     echo "[Info] Building for ${PYTHON_VERSION} with $PYTHON"
     # Clean up possible build artifacts

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -74,9 +74,9 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
 arch=$(uname -p)
 auditwheel show ${BUILD_DIR}/*.whl
 if [[ $arch == x86_64 ]]; then
-  auditwheel repair --plat manylinux2014_x86_64 ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
+  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux2014_x86_64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
 else
-  auditwheel repair --plat manylinux2014_aarch64 ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
+  auditwheel repair --plat ${AUDITWHEEL_PLAT:-manylinux2014_aarch64} ${BUILD_DIR}/*.whl -w ${REPAIRED_DIR}
 fi
 
     # Generate reqs files

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -7,7 +7,7 @@
 set -ox pipefail
 
 U_WIDTH=16
-PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14}"
+PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14 3.14t}"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTOR_DIR="$(dirname "${THIS_DIR}")"
 DIST_DIR="${CONNECTOR_DIR}/dist"

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -73,7 +73,7 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     # Allows the default PYTHON_VERSIONS to include future/free-threaded versions without
     # breaking builds that run in an older image.
     if [[ ! -x "${PYTHON}" ]]; then
-        echo "[WARN] Python not found for ${PYTHON_VERSION} at ${PYTHON} — skipping (use manylinux_2_28 image for free-threaded builds)"
+        echo "[WARN] Python not found for ${PYTHON_VERSION} at ${PYTHON} — skipping"
         continue
     fi
 

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -69,6 +69,14 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     fi
     BUILD_DIR="${DIST_DIR}/$PYTHON_VERSION"
 
+    # Skip gracefully when the interpreter isn't in this container (e.g. 3.14t in manylinux2014).
+    # Allows the default PYTHON_VERSIONS to include future/free-threaded versions without
+    # breaking builds that run in an older image.
+    if [[ ! -x "${PYTHON}" ]]; then
+        echo "[WARN] Python not found for ${PYTHON_VERSION} at ${PYTHON} — skipping (use manylinux_2_28 image for free-threaded builds)"
+        continue
+    fi
+
     # Build
     echo "[Info] Building for ${PYTHON_VERSION} with $PYTHON"
     # Clean up possible build artifacts

--- a/ci/build_linux.sh
+++ b/ci/build_linux.sh
@@ -59,7 +59,14 @@ source /home/user/multibuild/manylinux_utils.sh
 
 for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
     # Constants and setup
-    PYTHON="$(cpython_path ${PYTHON_VERSION} ${U_WIDTH})/bin/python"
+    # Free-threaded interpreters are stored as cp{base}-cp{base}t in manylinux images
+    # (e.g. cp314-cp314t), not cp{ver}-cp{ver} as cpython_path would produce.
+    if [[ "${PYTHON_VERSION}" == *t ]]; then
+        _BASE="${PYTHON_VERSION%t}"
+        PYTHON="/opt/python/cp${_BASE//./}-cp${PYTHON_VERSION//./}/bin/python"
+    else
+        PYTHON="$(cpython_path ${PYTHON_VERSION} ${U_WIDTH})/bin/python"
+    fi
     BUILD_DIR="${DIST_DIR}/$PYTHON_VERSION"
 
     # Build

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -10,7 +10,7 @@ if [[ -n "$JENKINS_HOME" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     export BASE_IMAGE_MANYLINUX2014=$INTERNAL_REPO/docker/manylinux2014_x86_64:latest
     export BASE_IMAGE_MANYLINUX2014AARCH64=$INTERNAL_REPO/docker/manylinux2014_aarch64:latest
-    # manylinux_2_28 — required for cp314t (free-threaded); available once IT mirrors quay.io/pypa/manylinux_2_28_*
+    # manylinux_2_28 via Artifactory — available once IT mirrors quay.io/pypa/manylinux_2_28_*
     export BASE_IMAGE_MANYLINUX2_28=$INTERNAL_REPO/docker/manylinux_2_28_x86_64:latest
     export BASE_IMAGE_MANYLINUX2_28AARCH64=$INTERNAL_REPO/docker/manylinux_2_28_aarch64:latest
     export BASE_IMAGE_ROCKYLINUX9=$INTERNAL_REPO/docker/rockylinux:9
@@ -22,3 +22,9 @@ else
     export BASE_IMAGE_MANYLINUX2_28AARCH64=quay.io/pypa/manylinux_2_28_aarch64
     export BASE_IMAGE_ROCKYLINUX9=rockylinux:9
 fi
+
+# Public manylinux_2_28 images — used for cp314t builds unconditionally.
+# quay.io/pypa is reachable from Jenkins Linux agents without Artifactory,
+# so these bypass the Artifactory mirror dependency for free-threaded wheels.
+export BASE_IMAGE_MANYLINUX2_28_PUBLIC=quay.io/pypa/manylinux_2_28_x86_64
+export BASE_IMAGE_MANYLINUX2_28_PUBLIC_AARCH64=quay.io/pypa/manylinux_2_28_aarch64

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -10,10 +10,15 @@ if [[ -n "$JENKINS_HOME" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     export BASE_IMAGE_MANYLINUX2014=$INTERNAL_REPO/docker/manylinux2014_x86_64:latest
     export BASE_IMAGE_MANYLINUX2014AARCH64=$INTERNAL_REPO/docker/manylinux2014_aarch64:latest
+    # manylinux_2_28 — required for cp314t (free-threaded); available once IT mirrors quay.io/pypa/manylinux_2_28_*
+    export BASE_IMAGE_MANYLINUX2_28=$INTERNAL_REPO/docker/manylinux_2_28_x86_64:latest
+    export BASE_IMAGE_MANYLINUX2_28AARCH64=$INTERNAL_REPO/docker/manylinux_2_28_aarch64:latest
     export BASE_IMAGE_ROCKYLINUX9=$INTERNAL_REPO/docker/rockylinux:9
 else
     echo "[INFO] Pull docker images from public registry"
     export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux2014_x86_64
     export BASE_IMAGE_MANYLINUX2014AARCH64=quay.io/pypa/manylinux2014_aarch64
+    export BASE_IMAGE_MANYLINUX2_28=quay.io/pypa/manylinux_2_28_x86_64
+    export BASE_IMAGE_MANYLINUX2_28AARCH64=quay.io/pypa/manylinux_2_28_aarch64
     export BASE_IMAGE_ROCKYLINUX9=rockylinux:9
 fi

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -8,12 +8,12 @@ set -o pipefail
 INTERNAL_REPO=artifactory.ci1.us-west-2.aws-dev.app.snowflake.com/internal-production-docker-snowflake-virtual
 if [[ -n "$JENKINS_HOME" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
-    export BASE_IMAGE_MANYLINUX2014=$INTERNAL_REPO/docker/manylinux2014_x86_64:latest
-    export BASE_IMAGE_MANYLINUX2014AARCH64=$INTERNAL_REPO/docker/manylinux2014_aarch64:latest
+    export BASE_IMAGE_MANYLINUX2014=$INTERNAL_REPO/docker/manylinux_2_28_x86_64:latest
+    export BASE_IMAGE_MANYLINUX2014AARCH64=$INTERNAL_REPO/docker/manylinux_2_28_aarch64:latest
     export BASE_IMAGE_ROCKYLINUX9=$INTERNAL_REPO/docker/rockylinux:9
 else
     echo "[INFO] Pull docker images from public registry"
-    export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux2014_x86_64
-    export BASE_IMAGE_MANYLINUX2014AARCH64=quay.io/pypa/manylinux2014_aarch64
+    export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux_2_28_x86_64
+    export BASE_IMAGE_MANYLINUX2014AARCH64=quay.io/pypa/manylinux_2_28_aarch64
     export BASE_IMAGE_ROCKYLINUX9=rockylinux:9
 fi

--- a/ci/set_base_image.sh
+++ b/ci/set_base_image.sh
@@ -10,21 +10,10 @@ if [[ -n "$JENKINS_HOME" ]]; then
     echo "[INFO] Pull docker images from $INTERNAL_REPO"
     export BASE_IMAGE_MANYLINUX2014=$INTERNAL_REPO/docker/manylinux2014_x86_64:latest
     export BASE_IMAGE_MANYLINUX2014AARCH64=$INTERNAL_REPO/docker/manylinux2014_aarch64:latest
-    # manylinux_2_28 via Artifactory — available once IT mirrors quay.io/pypa/manylinux_2_28_*
-    export BASE_IMAGE_MANYLINUX2_28=$INTERNAL_REPO/docker/manylinux_2_28_x86_64:latest
-    export BASE_IMAGE_MANYLINUX2_28AARCH64=$INTERNAL_REPO/docker/manylinux_2_28_aarch64:latest
     export BASE_IMAGE_ROCKYLINUX9=$INTERNAL_REPO/docker/rockylinux:9
 else
     echo "[INFO] Pull docker images from public registry"
     export BASE_IMAGE_MANYLINUX2014=quay.io/pypa/manylinux2014_x86_64
     export BASE_IMAGE_MANYLINUX2014AARCH64=quay.io/pypa/manylinux2014_aarch64
-    export BASE_IMAGE_MANYLINUX2_28=quay.io/pypa/manylinux_2_28_x86_64
-    export BASE_IMAGE_MANYLINUX2_28AARCH64=quay.io/pypa/manylinux_2_28_aarch64
     export BASE_IMAGE_ROCKYLINUX9=rockylinux:9
 fi
-
-# Public manylinux_2_28 images — used for cp314t builds unconditionally.
-# quay.io/pypa is reachable from Jenkins Linux agents without Artifactory,
-# so these bypass the Artifactory mirror dependency for free-threaded wheels.
-export BASE_IMAGE_MANYLINUX2_28_PUBLIC=quay.io/pypa/manylinux_2_28_x86_64
-export BASE_IMAGE_MANYLINUX2_28_PUBLIC_AARCH64=quay.io/pypa/manylinux_2_28_aarch64

--- a/ci/test_darwin.sh
+++ b/ci/test_darwin.sh
@@ -5,7 +5,7 @@
 #   - Versions to be tested should be passed in as the first argument, e.g: "3.10 3.11". If omitted 3.10-3.14 will be assumed.
 #   - This script uses .. to download the newest wheel files from S3
 
-PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14}"
+PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14 3.14t}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 PARAMETERS_DIR="${CONNECTOR_DIR}/.github/workflows/parameters/public"

--- a/ci/test_docker.sh
+++ b/ci/test_docker.sh
@@ -25,7 +25,7 @@ if [[ "$arch" == "aarch64" ]]; then
   BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014AARCH64
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
 else
-  BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014
+  BASE_IMAGE=$BASE_IMAGE_MANYLINUX2014  # points to manylinux_2_28 via set_base_image.sh
   GOSU_URL=https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
 fi
 

--- a/ci/test_fips.sh
+++ b/ci/test_fips.sh
@@ -17,7 +17,7 @@ fi
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck disable=SC1090
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
-CONNECTOR_WHL="$(ls $CONNECTOR_DIR/dist/*cp311*manylinux2014*.whl | sort -r | head -n 1)"
+CONNECTOR_WHL="$(ls $CONNECTOR_DIR/dist/*cp311*manylinux_2_28*.whl | sort -r | head -n 1)"
 
 # fetch wiremock
 WIREMOCK_VERSION=3.11.0

--- a/ci/test_fips_docker.sh
+++ b/ci/test_fips_docker.sh
@@ -4,10 +4,10 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 # In case this is not run locally and not on Jenkins
 
-if [[ ! -d "$CONNECTOR_DIR/dist/" ]] || [[ $(ls $CONNECTOR_DIR/dist/*cp311*manylinux2014*.whl) == '' ]]; then
+if [[ ! -d "$CONNECTOR_DIR/dist/" ]] || [[ $(ls $CONNECTOR_DIR/dist/*cp311*manylinux_2_28*.whl) == '' ]]; then
   echo "Missing wheel files, going to compile Python connector in Docker..."
   $THIS_DIR/build_docker.sh 3.11
-  cp $CONNECTOR_DIR/dist/repaired_wheels/*cp311*manylinux2014*.whl $CONNECTOR_DIR/dist/
+  cp $CONNECTOR_DIR/dist/repaired_wheels/*cp311*manylinux_2_28*.whl $CONNECTOR_DIR/dist/
 fi
 
 cd $THIS_DIR/docker/connector_test_fips

--- a/ci/test_lambda_docker.sh
+++ b/ci/test_lambda_docker.sh
@@ -6,10 +6,10 @@ PYTHON_VERSION="${1:-3.10}"
 PYTHON_SHORT_VERSION="$(echo "$PYTHON_VERSION" | tr -d .)"
 # In case this is not run locally and not on Jenkins
 
-if [[ ! -d "$CONNECTOR_DIR/dist/" ]] || [[ $(ls $CONNECTOR_DIR/dist/*cp${PYTHON_SHORT_VERSION}*manylinux2014*.whl) == '' ]]; then
+if [[ ! -d "$CONNECTOR_DIR/dist/" ]] || [[ $(ls $CONNECTOR_DIR/dist/*cp${PYTHON_SHORT_VERSION}*manylinux_2_28*.whl) == '' ]]; then
   echo "Missing wheel files, going to compile Python connector in Docker..."
   $THIS_DIR/build_docker.sh $PYTHON_VERSION
-  cp $CONNECTOR_DIR/dist/repaired_wheels/*cp${PYTHON_SHORT_VERSION}*manylinux2014*.whl $CONNECTOR_DIR/dist/
+  cp $CONNECTOR_DIR/dist/repaired_wheels/*cp${PYTHON_SHORT_VERSION}*manylinux_2_28*.whl $CONNECTOR_DIR/dist/
 fi
 
 cd $THIS_DIR/docker/connector_test_lambda

--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -46,7 +46,7 @@ else
     for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
         echo "[Info] Testing with ${PYTHON_VERSION}"
         SHORT_VERSION=$(python3.10 -c "print('${PYTHON_VERSION}'.replace('.', ''))")
-        CONNECTOR_WHL=$(ls $CONNECTOR_DIR/dist/snowflake_connector_python*cp${SHORT_VERSION}*manylinux2014*.whl | sort -r | head -n 1)
+        CONNECTOR_WHL=$(ls $CONNECTOR_DIR/dist/snowflake_connector_python*cp${SHORT_VERSION}*manylinux*.whl | sort -r | head -n 1)
         TEST_LIST=`echo py${PYTHON_VERSION/\./}-{unit-parallel,integ,pandas-parallel,sso}-ci | sed 's/ /,/g'`
         TEST_ENVLIST=fix_lint,$TEST_LIST,py${PYTHON_VERSION/\./}-coverage
         echo "[Info] Running tox for ${TEST_ENVLIST}"

--- a/ci/test_linux.sh
+++ b/ci/test_linux.sh
@@ -7,7 +7,7 @@
 #   - This is the script that test_docker.sh runs inside of the docker container
 
 
-PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14}"
+PYTHON_VERSIONS="${1:-3.10 3.11 3.12 3.13 3.14 3.14t}"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONNECTOR_DIR="$( dirname "${THIS_DIR}")"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires = [
 
 [tool.cibuildwheel]
 test-skip = "*"
-manylinux-x86_64-image = "manylinux2014"
-environment = {AUDITWHEEL_PLAT="manylinux2014_$(uname -m)"}
+manylinux-x86_64-image = "manylinux_2_28"
+environment = {AUDITWHEEL_PLAT="manylinux_2_28_$(uname -m)"}
 build-verbosity = 1
 # Opt in to free-threaded CPython wheel builds (cp313t, cp314t, ...).
 # Without this, cibuildwheel silently skips every `cp*t-*` target even when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires = [
 
 [tool.cibuildwheel]
 test-skip = "*"
-manylinux-x86_64-image = "manylinux_2_28"
-environment = {AUDITWHEEL_PLAT="manylinux_2_28_$(uname -m)"}
+manylinux-x86_64-image = "manylinux2014"
+environment = {AUDITWHEEL_PLAT="manylinux2014_$(uname -m)"}
 build-verbosity = 1
 # Opt in to free-threaded CPython wheel builds (cp313t, cp314t, ...).
 # Without this, cibuildwheel silently skips every `cp*t-*` target even when

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands = coverage combine
 ;           diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 depends = py310, py311, py312, py313, py314, py314t
 
-[testenv:py{310,311,312,313,314}-coverage]
+[testenv:py{310,311,312,313,314,314t}-coverage]
 # I hate doing this, but this env is for Jenkins, please keep it up-to-date with the one env above it if necessary
 description = [run locally after tests]: combine coverage data and create report specifically with {basepython}
 deps = {[testenv:coverage]deps}


### PR DESCRIPTION
## Summary

Follow-up to #2970. Migrates every Docker-based build and test script from `manylinux2014` to `manylinux_2_28` uniformly, removing the `3.14t`-only conditional introduced in the parent PR.

- `ci/set_base_image.sh`: `BASE_IMAGE_MANYLINUX2014` now resolves to `manylinux_2_28_*` on both Jenkins (Artifactory) and public paths
- `ci/build_docker.sh`: drops 3.14t-only conditional; `AUDITWHEEL_PLAT` always `manylinux_2_28_{arch}`
- `ci/build_linux.sh`: updates `AUDITWHEEL_PLAT` fallbacks
- `ci/test_docker.sh`, `test_lambda_docker.sh`, `test_fips.sh`, `test_fips_docker.sh`: wheel globs updated to `manylinux_2_28`

## Dependency

**Blocked on Artifactory mirror** — requires IT to mirror `quay.io/pypa/manylinux_2_28_{x86_64,aarch64}` into the internal Artifactory registry before Jenkins builds pick this up. See Jira ticket filed under SNOW-3192362.

## Why this aligns with the release

`ReleaseClientConnectorPythonSelf.groovy` already expects `manylinux_2_28` wheels for cp311–cp314t. This PR makes CI test builds consistent with the release target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)