### PR TITLE
SNOW-3559506: Fix RequestsDependencyWarning from vendored requests with chardet 7.x / charset-normalizer 3.x (#2883)

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 - NEXT_RELEASE(TBD)
   - Fixed `split_statements` treating `//` as SQL instead of a line comment, which could merge multiple statements when a `//` comment contained an apostrophe (SNOW-3772985).
+  - Fixed a spurious `RequestsDependencyWarning` emitted at import time by the vendored `requests` when a newer `chardet` (7.x) or `charset_normalizer` (3.x) is installed. The vendored `check_compatibility()` no longer enforces upper version bounds on `chardet`/`charset_normalizer` (SNOW-3559506).
 
 - v4.7.1(Jul 15,2026)
   - Added support for Python 3.14t (free-threaded).

--- a/src/snowflake/connector/vendored/requests/__init__.py
+++ b/src/snowflake/connector/vendored/requests/__init__.py
@@ -75,13 +75,11 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     if chardet_version:
         major, minor, patch = chardet_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, < 6.0.0
-        assert (3, 0, 2) <= (major, minor, patch) < (6, 0, 0)
+        assert (3, 0, 2) <= (major, minor, patch)
     elif charset_normalizer_version:
         major, minor, patch = charset_normalizer_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # charset_normalizer >= 2.0.0 < 4.0.0
-        assert (2, 0, 0) <= (major, minor, patch) < (4, 0, 0)
+        assert (2, 0, 0) <= (major, minor, patch)
     else:
         warnings.warn(
             "Unable to find acceptable character detection dependency "


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2883
   Related #1188 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Remove the upper bounds in `check_compatibility()` and keep only the minimum-supported-version checks:

   - `chardet`: `>= 3.0.2` (was `>= 3.0.2, < 6.0.0`)
   - `charset_normalizer`: `>= 2.0.0` (was `>= 2.0.0, < 4.0.0`)

   Dropping the upper bound avoids re-introducing this warning every time a new major version of either dependency is released, as recommended in https://iscinumpy.dev/post/bound-version-constraints/. Imho this is the correct way as this produces false alarms on perfectly working setups which trains people to ignore the warning entirely... Arguably worse than no check. Also the bound never actually protects against anything because chardet/charset_normalizer are already imported before the check runs. So even with breaking API change, the connector would break wether the warning fired or not.

   Verified `check_compatibility()` in isolation.

4. (Optional) PR for stored-proc connector:
