### PR TITLE
SNOW-3839943: Scale Azure PUT chunk size to respect the 50,000-block limit

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 - NEXT_RELEASE(TBD)
   - Fixed `split_statements` treating `//` as SQL instead of a line comment, which could merge multiple statements when a `//` comment contained an apostrophe (SNOW-3772985).
+  - Fixed large-file PUT uploads to internal Azure stages failing against the Azure 50,000-block-per-blob limit. The Azure multipart chunk size is now scaled up dynamically for very large files (mirroring the existing S3 behavior), and the default Azure chunk size was raised from 4 MB to 8 MB (consistent with S3) for better throughput (SNOW-3839943).
 
 - v4.7.1(Jul 15,2026)
   - Added support for Python 3.14t (free-threaded).

--- a/src/snowflake/connector/constants.py
+++ b/src/snowflake/connector/constants.py
@@ -430,7 +430,13 @@ S3_MIN_PART_SIZE = 5 * 1024**2
 S3_MAX_PARTS = 10000
 
 S3_CHUNK_SIZE = 8388608  # boto3 default
-AZURE_CHUNK_SIZE = 4 * megabyte
+
+# Azure Block Blob multipart upload limits
+# https://learn.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
+AZURE_CHUNK_SIZE = 8 * megabyte  # kept consistent with S3_DEFAULT_CHUNK_SIZE
+AZURE_MAX_BLOCKS = 50000
+AZURE_MAX_BLOCK_SIZE = 4000 * megabyte
+AZURE_MAX_OBJECT_SIZE = AZURE_MAX_BLOCKS * AZURE_MAX_BLOCK_SIZE
 
 # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
 REQUEST_CONNECTION_TIMEOUT = 10

--- a/src/snowflake/connector/file_transfer_agent.py
+++ b/src/snowflake/connector/file_transfer_agent.py
@@ -21,6 +21,8 @@ from .compat import IS_WINDOWS
 from .constants import (
     AZURE_CHUNK_SIZE,
     AZURE_FS,
+    AZURE_MAX_BLOCKS,
+    AZURE_MAX_OBJECT_SIZE,
     CMD_TYPE_DOWNLOAD,
     CMD_TYPE_UPLOAD,
     GCS_FS,
@@ -186,24 +188,31 @@ def _update_progress(
     return progress == 1.0
 
 
-def _chunk_size_calculator(file_size: int) -> int:
-    # S3 has limitation on the num of parts to be uploaded, this helper method recalculate the num of parts
-    if file_size > S3_MAX_OBJECT_SIZE:
-        # check if we don't exceed the allowed S3 max file size 5 TiB
+def _chunk_size_calculator(
+    file_size: int,
+    default_chunk_size: int = S3_DEFAULT_CHUNK_SIZE,
+    max_parts: int = S3_MAX_PARTS,
+    min_part_size: int = S3_MIN_PART_SIZE,
+    max_object_size: int = S3_MAX_OBJECT_SIZE,
+) -> int:
+    # Cloud providers cap the number of parts/blocks per object (S3: 10,000 parts,
+    # Azure: 50,000 blocks). This helper scales the chunk size up so the resulting
+    # number of parts stays within that limit; otherwise it keeps the default chunk size.
+    if file_size > max_object_size:
         raise ValueError(
-            f"File size {file_size} exceeds the maximum file size {S3_MAX_OBJECT_SIZE} allowed in S3."
+            f"File size {file_size} exceeds the maximum allowed file size {max_object_size}."
         )
 
     # num_parts = math.ceil(file_size / default_chunk_size)
-    # if num_parts is greater than the allowed S3_MAX_PARTS, we update our chunk_size, otherwise we use the default one
+    # if num_parts is greater than the allowed max_parts, we update our chunk_size, otherwise we use the default one
     calculated_chunk_size = (
-        max(math.ceil(file_size / S3_MAX_PARTS), S3_MIN_PART_SIZE)
-        if math.ceil(file_size / S3_DEFAULT_CHUNK_SIZE) > S3_MAX_PARTS
-        else S3_DEFAULT_CHUNK_SIZE
+        max(math.ceil(file_size / max_parts), min_part_size)
+        if math.ceil(file_size / default_chunk_size) > max_parts
+        else default_chunk_size
     )
-    if calculated_chunk_size != S3_DEFAULT_CHUNK_SIZE:
+    if calculated_chunk_size != default_chunk_size:
         logger.debug(
-            f"Setting chunksize to {calculated_chunk_size} instead of the default {S3_DEFAULT_CHUNK_SIZE}."
+            f"Setting chunksize to {calculated_chunk_size} instead of the default {default_chunk_size}."
         )
     return calculated_chunk_size
 
@@ -709,7 +718,13 @@ class SnowflakeFileTransferAgent:
             return SnowflakeAzureRestClient(
                 meta,
                 self._credentials,
-                AZURE_CHUNK_SIZE,
+                _chunk_size_calculator(
+                    meta.src_file_size,
+                    default_chunk_size=AZURE_CHUNK_SIZE,
+                    max_parts=AZURE_MAX_BLOCKS,
+                    min_part_size=AZURE_CHUNK_SIZE,
+                    max_object_size=AZURE_MAX_OBJECT_SIZE,
+                ),
                 self._stage_info,
                 unsafe_file_write=self._unsafe_file_write,
             )

--- a/test/unit/test_compute_chunk_size.py
+++ b/test/unit/test_compute_chunk_size.py
@@ -26,9 +26,117 @@ def test_check_chunk_size():
     with pytest.raises(ValueError) as exc:
         _chunk_size_calculator(sample_file_size_6tb)
     assert (
-        f"File size {sample_file_size_6tb} exceeds the maximum file size {S3_MAX_OBJECT_SIZE} allowed in S3."
+        f"File size {sample_file_size_6tb} exceeds the maximum allowed file size {S3_MAX_OBJECT_SIZE}."
         in str(exc)
     )
 
     chunk_size_1 = _chunk_size_calculator(sample_chunk_size_4mb)
     assert chunk_size_1 >= S3_MIN_PART_SIZE
+
+
+def test_check_azure_chunk_size():
+    import math
+
+    from snowflake.connector.constants import (
+        AZURE_CHUNK_SIZE,
+        AZURE_MAX_BLOCKS,
+        AZURE_MAX_OBJECT_SIZE,
+    )
+    from snowflake.connector.file_transfer_agent import _chunk_size_calculator
+
+    def azure_chunk_size(file_size: int) -> int:
+        return _chunk_size_calculator(
+            file_size,
+            default_chunk_size=AZURE_CHUNK_SIZE,
+            max_parts=AZURE_MAX_BLOCKS,
+            min_part_size=AZURE_CHUNK_SIZE,
+            max_object_size=AZURE_MAX_OBJECT_SIZE,
+        )
+
+    gigabyte = 1024**3
+
+    # Small/medium files keep the default 8 MB chunk size.
+    assert azure_chunk_size(1 * gigabyte) == AZURE_CHUNK_SIZE
+
+    # 300 GB used to require ~78,600 blocks at 4 MB (over the 50,000 limit); at
+    # 8 MB it stays well under the limit without any scaling.
+    chunk_size_300gb = azure_chunk_size(300 * gigabyte)
+    assert chunk_size_300gb == AZURE_CHUNK_SIZE
+    assert math.ceil(300 * gigabyte / chunk_size_300gb) <= AZURE_MAX_BLOCKS
+
+    # Very large files scale the chunk size up so the block count stays within
+    # the Azure 50,000-block limit.
+    chunk_size_1tb = azure_chunk_size(1024 * gigabyte)
+    assert chunk_size_1tb > AZURE_CHUNK_SIZE
+    assert math.ceil(1024 * gigabyte / chunk_size_1tb) <= AZURE_MAX_BLOCKS
+
+    # Files above the Azure block-blob ceiling are rejected.
+    with pytest.raises(ValueError):
+        azure_chunk_size(AZURE_MAX_OBJECT_SIZE + 1)
+
+
+def test_azure_client_wired_with_scaled_chunk_size():
+    """The Azure branch of ``_create_file_transfer_client`` should construct the
+    storage client with a chunk size that keeps the number of blocks within the
+    Azure 50,000-block-per-blob limit, scaling it up for very large files.
+    """
+    import math
+    from unittest.mock import MagicMock
+
+    from snowflake.connector import SnowflakeConnection
+    from snowflake.connector.constants import (
+        AZURE_CHUNK_SIZE,
+        AZURE_FS,
+        AZURE_MAX_BLOCKS,
+    )
+    from snowflake.connector.file_transfer_agent import (
+        SnowflakeFileMeta,
+        SnowflakeFileTransferAgent,
+        StorageCredential,
+    )
+
+    gigabyte = 1024**3
+
+    stage_info = {
+        "locationType": "AZURE",
+        "location": "container/path",
+        "storageAccount": "storageaccount",
+        "endPoint": "blob.core.windows.net",
+        "creds": {"AZURE_SAS_TOKEN": "sas_token"},
+    }
+    credentials = StorageCredential(
+        stage_info["creds"],
+        MagicMock(autospec=SnowflakeConnection),
+        "PUT file:///tmp/file @~",
+    )
+
+    # Build a bare agent and populate only the attributes the Azure branch reads,
+    # so we can exercise the wiring without a live connection or a real upload.
+    agent = object.__new__(SnowflakeFileTransferAgent)
+    agent._stage_location_type = AZURE_FS
+    agent._stage_info = stage_info
+    agent._credentials = credentials
+    agent._unsafe_file_write = False
+
+    def azure_client_for(file_size: int):
+        meta = SnowflakeFileMeta(
+            name="big_file",
+            src_file_name="big_file",
+            stage_location_type=AZURE_FS,
+            src_file_size=file_size,
+            dst_file_name="big_file",
+        )
+        return agent._create_file_transfer_client(meta)
+
+    # Normal-sized file: default chunk size, comfortably within the block limit.
+    small_client = azure_client_for(1 * gigabyte)
+    assert small_client.chunk_size == AZURE_CHUNK_SIZE
+    assert math.ceil(1 * gigabyte / small_client.chunk_size) <= AZURE_MAX_BLOCKS
+
+    # Very large file (1 TB): the chunk size scales up so the block count stays
+    # within the Azure limit. At the old hardcoded 4 MB this file would have
+    # required ~262,000 blocks and failed the upload outright.
+    large_file_size = 1024 * gigabyte
+    large_client = azure_client_for(large_file_size)
+    assert large_client.chunk_size > AZURE_CHUNK_SIZE
+    assert math.ceil(large_file_size / large_client.chunk_size) <= AZURE_MAX_BLOCKS


### PR DESCRIPTION
## Description

Large single-file `PUT` uploads to **internal Azure stages** could fail because the multipart chunk size was hardcoded at **4 MB** (`AZURE_CHUNK_SIZE`) with no upper bound on the number of blocks. Azure Block Blob caps a blob at **50,000 blocks**, so a ~300 GB file needs ~78,600 blocks at 4 MB — over the limit, so the upload **fails outright** rather than just running slowly.

S3 already guards against its own 10,000-part limit via `_chunk_size_calculator`, which scales the part size up for large files. Azure had no equivalent — it just passed the flat `AZURE_CHUNK_SIZE` constant.

### Changes
- Generalize `_chunk_size_calculator` to be **cloud-aware** — parameterized by `default_chunk_size`, `max_parts`, `min_part_size`, and `max_object_size`, all defaulting to the existing S3 values so the S3 call site is behaviorally unchanged.
- Use it for the Azure client (`max_parts = AZURE_MAX_BLOCKS = 50000`) so the chunk size scales up for very large files.
- Raise the default Azure chunk size from **4 MB → 8 MB**, consistent with `S3_DEFAULT_CHUNK_SIZE`, for better and more predictable throughput.
- Add `AZURE_MAX_BLOCKS`, `AZURE_MAX_BLOCK_SIZE`, `AZURE_MAX_OBJECT_SIZE` constants.

### Resulting behavior (Azure)
| File size | Chunk | Blocks | Within 50k? |
|---|---|---|---|
| 300 GB | 8 MB | 38,400 | ✅ (was ~78,600 at 4 MB → **failed**) |
| 400 GB | 8 MB | 50,000 | ✅ |
| 1 TB | ~20 MB (scaled) | 50,000 | ✅ |

S3 path is unchanged (8 MB default, scales to keep ≤ 10,000 parts).

## Testing
`test/unit/test_compute_chunk_size.py`:
- `test_check_chunk_size` — S3 calculator (updated for new error-message wording).
- `test_check_azure_chunk_size` — Azure calculator math: default kept for normal/300 GB files, scaling for very large files, over-ceiling `ValueError`.
- `test_azure_client_wired_with_scaled_chunk_size` — **wiring**: builds the Azure branch of `_create_file_transfer_client` with a mocked `src_file_size` and asserts the constructed `SnowflakeAzureRestClient.chunk_size` scales so the block count stays ≤ 50,000. No network / no live account / no giant file.

> Note: a true 300 GB+ Azure e2e upload is impractical to run in CI (cost/time; Azure integ tests are gated behind `@pytest.mark.azure`). The unit tests cover the deterministic parts — the calculator math and the wiring.

## Scope
This is a pure internal fix — **no public API change**, consistent with how the Go and C/C++ (ODBC) drivers already handle Azure. The secondary ask in the ticket (skipping the SHA256 digest when `overwrite=True`) is intentionally **out of scope** here — the digest also feeds server-side `sfc-digest` integrity, so it needs separate investigation (overlaps SNOW-3766021).

Fixes SNOW-3839943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)