### PR TITLE
NO-SNOW: pin pip<26 in dependency env to fix pip-tools stdlib_pkgs incompatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,7 @@ commands = pre-commit run --all-files
 [testenv:dependency]
 description = Check if there is conflicting dependency
 deps =
+    pip<26
     pip-tools
     typing_extensions
 skip_install = True


### PR DESCRIPTION
## Summary

- `pip-tools 7.6.0` imports `pip._internal.utils.compat.stdlib_pkgs` which was removed in pip 26.0.
- GitHub Actions runners recently upgraded to pip 26.2, causing `[testenv:dependency]` to fail with `ImportError: cannot import name 'stdlib_pkgs'`.
- Fix: pin `pip<26` in the `[testenv:dependency]` deps list so pip-tools always runs against a compatible pip version.

## Test plan
- [ ] Verify `dependency` tox env passes in CI after this change
- [ ] Confirm no other tox envs are affected (only `[testenv:dependency]` has `skip_install = True` with pip-tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)