### PR TITLE
🐛 fix(aio): avoid RuntimeError constructing AuthByWebBrowser on Py 3.14

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -459,7 +459,7 @@ jobs:
            download_name: macosx_x86_64
          - image_name: windows-latest
            download_name: win_amd64
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.14"]
         cloud-provider: [aws, azure, gcp]
     steps:
       - uses: actions/checkout@v7

--- a/src/snowflake/connector/aio/auth/_webbrowser.py
+++ b/src/snowflake/connector/aio/auth/_webbrowser.py
@@ -65,7 +65,6 @@ class AuthByWebBrowser(AuthByPluginAsync, AuthByWebBrowserSync):
             port,
             **kwargs,
         )
-        self._event_loop = asyncio.get_event_loop()
 
     async def reset_secrets(self) -> None:
         AuthByWebBrowserSync.reset_secrets(self)
@@ -212,7 +211,7 @@ class AuthByWebBrowser(AuthByPluginAsync, AuthByWebBrowserSync):
 
                     if read_sockets[0] is not None:
                         # Receive the data in small chunks and retransmit it
-                        socket_client, _ = await self._event_loop.sock_accept(
+                        socket_client, _ = await asyncio.get_running_loop().sock_accept(
                             socket_connection
                         )
 
@@ -226,7 +225,9 @@ class AuthByWebBrowser(AuthByPluginAsync, AuthByWebBrowserSync):
                             #  https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.sock_recv
                             socket_client.setblocking(False)
                             raw_data = await asyncio.wait_for(
-                                self._event_loop.sock_recv(socket_client, BUF_SIZE),
+                                asyncio.get_running_loop().sock_recv(
+                                    socket_client, BUF_SIZE
+                                ),
                                 timeout=(
                                     DEFAULT_SOCKET_CONNECT_TIMEOUT
                                     if conn.socket_timeout is None
@@ -288,7 +289,7 @@ class AuthByWebBrowser(AuthByPluginAsync, AuthByWebBrowserSync):
             "",
             "",
         ]
-        await self._event_loop.sock_sendall(
+        await asyncio.get_running_loop().sock_sendall(
             socket_client, "\r\n".join(content).encode("utf-8")
         )
         return True
@@ -321,7 +322,7 @@ You can close this window now and go back where you started from.
         content.append("")
         content.append(msg)
 
-        await self._event_loop.sock_sendall(
+        await asyncio.get_running_loop().sock_sendall(
             socket_client, "\r\n".join(content).encode("utf-8")
         )
 

--- a/test/unit/aio/test_auth_webbrowser_async.py
+++ b/test/unit/aio/test_auth_webbrowser_async.py
@@ -155,13 +155,13 @@ async def test_auth_webbrowser_get(_, disable_console_login):
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -229,13 +229,13 @@ async def test_auth_webbrowser_post(_, disable_console_login):
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -295,13 +295,15 @@ async def test_auth_webbrowser_fail_webbrowser(
         socket_pkg=mock_socket_pkg,
     )
     with patch("builtins.input", return_value=input_text), patch.object(
-        auth._event_loop,
+        asyncio.get_running_loop(),
         "sock_accept",
         side_effect=_mock_event_loop_sock_accept(),
     ), mock.patch.object(
-        auth._event_loop, "sock_sendall", return_value=None
+        asyncio.get_running_loop(), "sock_sendall", return_value=None
     ), mock.patch.object(
-        auth._event_loop, "sock_recv", side_effect=_mock_event_loop_sock_recv(recv_func)
+        asyncio.get_running_loop(),
+        "sock_recv",
+        side_effect=_mock_event_loop_sock_recv(recv_func),
     ):
         await auth.prepare(
             conn=rest._connection,
@@ -360,13 +362,13 @@ async def test_auth_webbrowser_fail_webserver(_, capsys, disable_console_login):
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -527,13 +529,13 @@ async def test_auth_webbrowser_socket_recv_retries_up_to_15_times_on_empty_bytea
             socket_pkg=mock_socket_pkg,
         )
         with patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -581,11 +583,11 @@ async def test_auth_webbrowser_socket_recv_loop_fails_after_15_attempts():
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -636,13 +638,13 @@ async def test_auth_webbrowser_socket_recv_does_not_block_with_env_var(monkeypat
         )
 
         with mock.patch.object(
-            auth._event_loop, "sock_recv", new=sock_recv_timeout
+            asyncio.get_running_loop(), "sock_recv", new=sock_recv_timeout
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ):
             await auth.prepare(
                 conn=rest._connection,
@@ -692,11 +694,11 @@ async def test_auth_webbrowser_socket_recv_blocking_stops_retries_after_15_attem
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop, "sock_recv", new=sock_recv_timeout
+            asyncio.get_running_loop(), "sock_recv", new=sock_recv_timeout
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ):
@@ -743,13 +745,13 @@ async def test_auth_webbrowser_socket_reuseport_with_env_flag(monkeypatch):
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -799,13 +801,13 @@ async def test_auth_webbrowser_socket_reuseport_option_not_set_with_false_flag(
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -848,13 +850,13 @@ async def test_auth_webbrowser_socket_reuseport_option_not_set_with_no_flag(
             socket_pkg=mock_socket_pkg,
         )
         with mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_accept",
             side_effect=_mock_event_loop_sock_accept(),
         ), mock.patch.object(
-            auth._event_loop, "sock_sendall", return_value=None
+            asyncio.get_running_loop(), "sock_sendall", return_value=None
         ), mock.patch.object(
-            auth._event_loop,
+            asyncio.get_running_loop(),
             "sock_recv",
             side_effect=_mock_event_loop_sock_recv(recv_func),
         ):
@@ -906,13 +908,13 @@ async def test_auth_webbrowser_force_auth_server(_, monkeypatch, force_auth_serv
         if force_auth_server:
             # When SNOWFLAKE_AUTH_FORCE_SERVER is true, should continue with server flow even if browser fails
             with mock.patch.object(
-                auth._event_loop,
+                asyncio.get_running_loop(),
                 "sock_accept",
                 side_effect=_mock_event_loop_sock_accept(),
             ), mock.patch.object(
-                auth._event_loop, "sock_sendall", return_value=None
+                asyncio.get_running_loop(), "sock_sendall", return_value=None
             ), mock.patch.object(
-                auth._event_loop,
+                asyncio.get_running_loop(),
                 "sock_recv",
                 side_effect=_mock_event_loop_sock_recv(recv_func),
             ):
@@ -937,13 +939,13 @@ async def test_auth_webbrowser_force_auth_server(_, monkeypatch, force_auth_serv
                 "builtins.input",
                 return_value=f"http://example.com/sso?token={ref_token}",
             ), mock.patch.object(
-                auth._event_loop,
+                asyncio.get_running_loop(),
                 "sock_accept",
                 side_effect=_mock_event_loop_sock_accept(),
             ), mock.patch.object(
-                auth._event_loop, "sock_sendall", return_value=None
+                asyncio.get_running_loop(), "sock_sendall", return_value=None
             ), mock.patch.object(
-                auth._event_loop,
+                asyncio.get_running_loop(),
                 "sock_recv",
                 side_effect=_mock_event_loop_sock_recv(recv_func),
             ):


### PR DESCRIPTION
The old "cache asyncio.get_event_loop() as a member, reuse it" idiom is incorrect (between time-of-cache and time-of-use the active event loop can change). As a result of this behavior Python deprecated `asyncio.get_event_loop()` and the event-loop policy system, and started raising a RuntimeError in Python 3.14 when there is no running (or previously-set) event loop, instead of silently creating one.

Previously the call was unconditional in a constructor, so constructing outside of a coroutine/event loop now crashes (e.g. in a test).

Drop the cached `self._event_loop` entirely and call `asyncio.get_running_loop()` inline at the relevant call-sites that are all only reachable from coroutines anyway.

Update every mock within `test/unit/aio/test_auth_webbrowser_async.py` to patch the right method call.

Add python 3.14 to the test-aio CI matrix (job is currently disabled as of 7d1356c5a5d9859f93c26a61d6f16097b569a965 / #2718, so this has no effect until it's re-enabled).

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #2988 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
     - I don't know if this counts or not because some of these test are disabled in CI but some downstream consumers end up running your tests anyway.
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [x] I am modifying authorization mechanisms
   - [ ] I am adding new credentials
   - [ ] I am modifying OCSP code
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Uses the new idiom for acting on the running event loop.

4. (Optional) PR for stored-proc connector:
N/A