### PR TITLE
SNOW-3891419: Report Okta login timeout instead of passing a negative timeout

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -9,6 +9,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 # Release Notes
 - NEXT_RELEASE(TBD)
   - Fixed `split_statements` treating `//` as SQL instead of a line comment, which could merge multiple statements when a `//` comment contained an apostrophe (SNOW-3772985).
+  - Fixed Okta/SAML authentication reporting an exhausted `login_timeout` as `250003: Failed to execute request: Attempted to set connect timeout to <negative value>`. Obtaining the one-time token in step 4 can overshoot the login deadline, which made the remaining budget negative; it was then passed to the HTTP layer, which rejected it with an opaque `ValueError`. A timed-out SAML login now raises `250006` with a message naming `login_timeout`. Running out of budget while retrying on `RefreshTokenError` reports the same error instead of failing later with an `AttributeError` on an empty response (SNOW-3891419).
 
 - v4.7.1(Jul 15,2026)
   - Added support for Python 3.14t (free-threaded).

--- a/src/snowflake/connector/aio/auth/_okta.py
+++ b/src/snowflake/connector/aio/auth/_okta.py
@@ -212,7 +212,7 @@ class AuthByOkta(AuthByPluginAsync, AuthByOktaSync):
     ) -> dict[Any, Any]:
         logger.debug("step 4: query IDP URL snowflake app to get SAML " "response")
         timeout_time = time.time() + conn.login_timeout if conn.login_timeout else None
-        response_html = {}
+        response_html = None
         origin_sso_url = sso_url
         while timeout_time is None or time.time() < timeout_time:
             try:
@@ -225,6 +225,12 @@ class AuthByOkta(AuthByPluginAsync, AuthByOktaSync):
                     HTTP_HEADER_ACCEPT: "*/*",
                 }
                 remaining_timeout = timeout_time - time.time() if timeout_time else None
+                if remaining_timeout is not None and remaining_timeout <= 0:
+                    # Obtaining the one time token consumed the whole login budget.
+                    # The HTTP layer rejects a non-positive timeout with an opaque
+                    # ValueError, so stop here and report the timeout that actually
+                    # happened.
+                    break
                 response_html = await conn.rest.fetch(
                     "get",
                     sso_url,
@@ -237,6 +243,10 @@ class AuthByOkta(AuthByPluginAsync, AuthByOktaSync):
                 break
             except RefreshTokenError:
                 logger.debug("step4: refresh token for re-authentication")
+        if response_html is None:
+            # Every way out of the loop above without a response means the
+            # login_timeout budget ran out.
+            AuthByOktaSync._handle_login_timeout(conn)
         return response_html
 
     async def _step5(

--- a/src/snowflake/connector/auth/okta.py
+++ b/src/snowflake/connector/auth/okta.py
@@ -15,7 +15,7 @@ from ..constants import (
     HTTP_HEADER_USER_AGENT,
 )
 from ..errorcode import ER_IDP_CONNECTION_ERROR, ER_INCORRECT_DESTINATION
-from ..errors import DatabaseError, Error, RefreshTokenError
+from ..errors import DatabaseError, Error, OperationalError, RefreshTokenError
 from ..network import CONTENT_TYPE_APPLICATION_JSON, PYTHON_CONNECTOR_USER_AGENT
 from ..sqlstate import SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
 from . import Auth
@@ -276,7 +276,7 @@ class AuthByOkta(AuthByPlugin):
     ) -> dict[Any, Any]:
         logger.debug("step 4: query IDP URL snowflake app to get SAML " "response")
         timeout_time = time.time() + conn.login_timeout if conn.login_timeout else None
-        response_html = {}
+        response_html = None
         origin_sso_url = sso_url
         while timeout_time is None or time.time() < timeout_time:
             try:
@@ -289,6 +289,12 @@ class AuthByOkta(AuthByPlugin):
                     HTTP_HEADER_ACCEPT: "*/*",
                 }
                 remaining_timeout = timeout_time - time.time() if timeout_time else None
+                if remaining_timeout is not None and remaining_timeout <= 0:
+                    # Obtaining the one time token consumed the whole login budget.
+                    # The HTTP layer rejects a non-positive timeout with an opaque
+                    # ValueError, so stop here and report the timeout that actually
+                    # happened.
+                    break
                 response_html = conn.rest.fetch(
                     "get",
                     sso_url,
@@ -301,7 +307,28 @@ class AuthByOkta(AuthByPlugin):
                 break
             except RefreshTokenError:
                 logger.debug("step4: refresh token for re-authentication")
+        if response_html is None:
+            # Every way out of the loop above without a response means the
+            # login_timeout budget ran out.
+            AuthByOkta._handle_login_timeout(conn)
         return response_html
+
+    @staticmethod
+    def _handle_login_timeout(conn: SnowflakeConnection) -> None:
+        Error.errorhandler_wrapper(
+            conn._rest._connection,
+            None,
+            OperationalError,
+            {
+                "msg": (
+                    f"Timed out after {conn.login_timeout} second(s) waiting for "
+                    "the identity provider to return a SAML response. Consider "
+                    "increasing login_timeout."
+                ),
+                "errno": ER_IDP_CONNECTION_ERROR,
+                "sqlstate": SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED,
+            },
+        )
 
     def _step5(
         self,

--- a/test/unit/aio/test_auth_okta_async.py
+++ b/test/unit/aio/test_auth_okta_async.py
@@ -271,6 +271,62 @@ async def test_auth_okta_step4_negative(caplog):
         assert not rest._connection.errorhandler.called
 
 
+async def test_auth_okta_step4_login_timeout_exhausted_by_token_generation():
+    """An exhausted login budget must surface as a clean timeout, not a negative timeout.
+
+    _step4 checks the login deadline before generating the one time token, but the
+    token generation itself performs a network round trip. When that round trip
+    overshoots the deadline, the remaining budget goes negative. It used to be
+    passed straight to the HTTP layer, which rejected it with an opaque
+    "connect timeout <= 0" ValueError reported as error 250003.
+    """
+    from snowflake.connector.errorcode import ER_IDP_CONNECTION_ERROR
+    from snowflake.connector.errors import OperationalError
+
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    headers, sso_url, token_url = await auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    await auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    login_timeout = rest._connection.login_timeout
+    clock = 1000.0
+
+    async def get_one_time_token():
+        # the token round trip overshoots the login deadline by 0.8s, which is what
+        # made the remaining budget negative
+        nonlocal clock
+        clock += login_timeout + 0.8
+        return "1token1"
+
+    async def fail_fetch(*args, **kwargs):
+        pytest.fail("no request should be issued once the login budget is exhausted")
+
+    rest.fetch = fail_fetch
+    with patch(
+        "snowflake.connector.aio.auth._okta.time.time", side_effect=lambda: clock
+    ):
+        response_html = await auth._step4(rest._connection, get_one_time_token, sso_url)
+
+    assert response_html is None
+    assert rest._connection.errorhandler.called
+    _, _, error_class, error_value = rest._connection.errorhandler.call_args[0]
+    assert error_class is OperationalError
+    assert error_value["errno"] == ER_IDP_CONNECTION_ERROR
+    assert "Timed out" in error_value["msg"]
+
+
 @pytest.mark.parametrize("disable_saml_url_check", [True, False])
 async def test_auth_okta_step5_negative(disable_saml_url_check):
     """Authentication by OKTA step5 negative test case."""

--- a/test/unit/test_auth_okta.py
+++ b/test/unit/test_auth_okta.py
@@ -409,6 +409,112 @@ def test_auth_okta_step4_negative(caplog):
         assert not rest._connection.errorhandler.called
 
 
+@pytest.mark.skipolddriver
+def test_auth_okta_step4_login_timeout_exhausted_by_token_generation():
+    """An exhausted login budget must surface as a clean timeout, not a negative timeout.
+
+    _step4 checks the login deadline before generating the one time token, but the
+    token generation itself performs a network round trip. When that round trip
+    overshoots the deadline, the remaining budget goes negative. It used to be
+    passed straight to the HTTP layer, which rejected it with an opaque
+    "connect timeout <= 0" ValueError reported as error 250003.
+    """
+    from snowflake.connector.errorcode import ER_IDP_CONNECTION_ERROR
+    from snowflake.connector.errors import OperationalError
+
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    login_timeout = rest._connection.login_timeout
+    clock = 1000.0
+
+    def get_one_time_token():
+        # the token round trip overshoots the login deadline by 0.8s, which is what
+        # made the remaining budget negative
+        nonlocal clock
+        clock += login_timeout + 0.8
+        return "1token1"
+
+    def fail_fetch(*args, **kwargs):
+        pytest.fail("no request should be issued once the login budget is exhausted")
+
+    rest.fetch = fail_fetch
+    with patch("snowflake.connector.auth.okta.time.time", side_effect=lambda: clock):
+        response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+
+    assert response_html is None
+    assert rest._connection.errorhandler.called
+    _, _, error_class, error_value = rest._connection.errorhandler.call_args[0]
+    assert error_class is OperationalError
+    assert error_value["errno"] == ER_IDP_CONNECTION_ERROR
+    assert "Timed out" in error_value["msg"]
+
+
+@pytest.mark.skipolddriver
+def test_auth_okta_step4_login_timeout_while_refreshing_token():
+    """Running out of budget while retrying on RefreshTokenError must report a clean timeout.
+
+    Previously the loop simply fell through and returned the initial empty dict, so
+    _step5 failed later with an AttributeError on that dict instead of reporting
+    the timeout.
+    """
+    from snowflake.connector.errorcode import ER_IDP_CONNECTION_ERROR
+    from snowflake.connector.errors import OperationalError, RefreshTokenError
+
+    authenticator = "https://testsso.snowflake.net/"
+    application = "testapplication"
+    account = "testaccount"
+    user = "testuser"
+    service_name = ""
+
+    ref_sso_url = "https://testsso.snowflake.net/sso"
+    ref_token_url = "https://testsso.snowflake.net/token"
+    rest = _init_rest(ref_sso_url, ref_token_url)
+
+    auth = AuthByOkta(application)
+    headers, sso_url, token_url = auth._step1(
+        rest._connection, authenticator, service_name, account, user
+    )
+    auth._step2(rest._connection, authenticator, sso_url, token_url)
+    assert not rest._connection.errorhandler.called  # no error
+
+    login_timeout = rest._connection.login_timeout
+    clock = 1000.0
+
+    def get_one_time_token():
+        return "1token1"
+
+    def refresh_token_fetch(*args, **kwargs):
+        # the IdP keeps asking for a fresh token until the budget runs out
+        nonlocal clock
+        clock += login_timeout / 2
+        raise RefreshTokenError(msg="refresh token")
+
+    rest.fetch = refresh_token_fetch
+    with patch("snowflake.connector.auth.okta.time.time", side_effect=lambda: clock):
+        response_html = auth._step4(rest._connection, get_one_time_token, sso_url)
+
+    assert response_html is None
+    assert rest._connection.errorhandler.called
+    _, _, error_class, error_value = rest._connection.errorhandler.call_args[0]
+    assert error_class is OperationalError
+    assert error_value["errno"] == ER_IDP_CONNECTION_ERROR
+
+
 @pytest.mark.parametrize("disable_saml_url_check", [True, False])
 def test_auth_okta_step5_negative(disable_saml_url_check):
     """Authentication by OKTA step5 negative test case."""


### PR DESCRIPTION
## Description

Fixes [SNOW-3891419](https://snowflakecomputing.atlassian.net/browse/SNOW-3891419) — customer hitting intermittent `250003` during Okta SSO login:

```
OperationalError: 250003: Failed to execute request: Attempted to set connect
timeout to -0.7327196598052979, but the timeout cannot be set to a value less
than or equal to 0.
```

`AuthByOkta._step4` checks the login deadline before generating the one-time token, but generating the token is itself a network round trip that gets its own *full* `login_timeout` budget (step 3), not the remaining one. When it overshoots the deadline, `remaining_timeout` goes negative and is passed straight to the HTTP layer as `socket_timeout`.

The full chain, all in this repo:

1. `_step4` sets `timeout_time = time.time() + conn.login_timeout`.
2. `generate_one_time_token()` → `_step3` → `fetch(timeout=login_timeout)` — can return successfully *after* `timeout_time`.
3. `remaining_timeout = timeout_time - time.time()` → negative, unclamped.
4. Passed as `socket_timeout`; since it isn't `None`, `_request_exec` skips the default and hands it to `session.request(timeout=...)` → urllib3 `_validate_timeout` → `ValueError`.
5. `ValueError` is in the retryable tuple; `is_login_request()` is `False` for the Okta SSO host, so it becomes `RetryRequest`.
6. `retry_ctx.timeout` is the *same* negative value → `should_retry` is `False` → reported as `ER_FAILED_TO_REQUEST` (250003).

This also explains the consistently small magnitudes reported (-0.72 to -0.97s): step 3's deadline and step 4's deadline start at nearly the same instant, so the overshoot is only however long step 3's final attempt ran past the boundary.

## Changes

- `_step4` skips the request when the remaining budget is non-positive and reports the timeout that actually happened — `250006` with a message naming `login_timeout` — instead of letting the HTTP layer reject a negative value.
- `response_html` is initialized to `None` instead of `{}`, and every exit from the loop without a response routes through the same error. This also fixes a secondary bug: exhausting the budget while retrying on `RefreshTokenError` used to return the empty dict, which then failed in `_step5` with `AttributeError: 'dict' object has no attribute 'find'`.
- Applied to both the sync (`auth/okta.py`) and async (`aio/auth/_okta.py`) paths.

Errno `250006` (`ER_IDP_CONNECTION_ERROR`) matches the rest of `okta.py`. I deliberately avoided `ER_CONNECTION_TIMEOUT` (251011), which `network.py` uses as an internal "will be handled by authenticator" signal. `prepare()` is called outside the retry `try/except` in `connection.py`, so this propagates cleanly to the caller.

## Scope note

This makes a genuine login timeout report accurately; it does **not** make the customer's logins succeed. Reaching this point means the configured `login_timeout` was really consumed by the Okta legs, which points at IdP/network latency in their batch window. Key-pair auth remains the recommended fix for the affected service account.

Also left alone deliberately: steps 1 and 3 each get a fresh full `login_timeout` rather than the remaining budget, so a login can legitimately run past the configured value. Fixing that changes timeout semantics for every Okta user and belongs in its own change.

## Testing

Three regression tests added covering the token-generation-overshoot path and the `RefreshTokenError` path, sync and async, using a controlled clock so they are deterministic.

**Verified all three fail against the unfixed code** — one with `Failed: no request should be issued once the login budget is exhausted`, one with `assert {} is None`.

The auth/connection unit subset goes from 923 to 926 passing with an identical set of pre-existing environment failures (oauth/proxy tests needing local servers) before and after.

## Pre-review checklist

- [x] This change has passed precommit
- [x] I have reviewed my own code
- [x] I have added tests, or explained why they are unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SNOW-3891419]: https://snowflakecomputing.atlassian.net/browse/SNOW-3891419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ