### PR TITLE
NO-SNOW: Reduce CI flakiness with pytest --lf retry and drop rerunfailures

### DIFF
--- a/ci/test_fips.sh
+++ b/ci/test_fips.sh
@@ -46,7 +46,11 @@ pip freeze
 
 cd $CONNECTOR_DIR
 
-# Run tests in parallel using pytest-xdist
-pytest -n auto -vvv --cov=snowflake.connector --cov-report=xml:coverage.xml test --ignore=test/integ/aio_it --ignore=test/unit/aio --ignore=test/wif/test_wif_async.py
+# Full run first; on failure, --lf --maxfail=5 once to retry potential flakes
+# https://docs.pytest.org/en/stable/how-to/cache.html
+pytest -n auto -vvv --cov=snowflake.connector --cov-report=xml:coverage.xml test \
+  --ignore=test/integ/aio_it --ignore=test/unit/aio --ignore=test/wif/test_wif_async.py \
+  || pytest --lf --maxfail=5 --last-failed-no-failures none -n auto -vvv --cov=snowflake.connector --cov-report=xml:coverage.xml test \
+  --ignore=test/integ/aio_it --ignore=test/unit/aio --ignore=test/wif/test_wif_async.py
 
 deactivate

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,6 @@ development =
     pytest<7.5.0
     pytest-asyncio
     pytest-cov
-    pytest-rerunfailures<16.0
     pytest-timeout
     pytest-xdist
     pytzdata

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import socket
 import sys
 from contextlib import contextmanager
 from logging import getLogger
@@ -187,27 +186,6 @@ def pytest_runtest_setup(item) -> None:
     if "wif" in test_tags:
         if os.getenv("RUN_WIF_TESTS") != "true":
             pytest.skip("Skipping WIF test in current environment")
-
-
-def pytest_unconfigure(config) -> None:
-    """Shut down the pytest-rerunfailures socket server to prevent session hangs.
-
-    The ServerStatusDB.run_server thread blocks forever on socket.accept()
-    with no shutdown mechanism. Closing the socket here unblocks it so the
-    interpreter can exit cleanly instead of deadlocking during teardown.
-    See: https://github.com/pytest-dev/pytest-rerunfailures/issues/295
-    """
-    db = getattr(config, "failures_db", None)
-    sock = getattr(db, "sock", None)
-    if sock is not None:
-        try:
-            sock.shutdown(socket.SHUT_RDWR)
-        except OSError:
-            pass
-        try:
-            sock.close()
-        except OSError:
-            pass
 
 
 def get_server_parameter_value(connection, parameter_name: str) -> str | None:

--- a/test/integ/aio_it/test_put_get_medium_async.py
+++ b/test/integ/aio_it/test_put_get_medium_async.py
@@ -437,7 +437,6 @@ max_file_size=10000000
     await run_test(aio_connection, "drop table if exists {name}")
 
 
-@pytest.mark.flaky(reruns=3)
 async def test_put_copy_many_files(tmpdir, aio_connection, db_parameters):
     """Puts and Copies many_files."""
     # generates N files
@@ -533,7 +532,6 @@ ratio number(6,2))
 
 @pytest.mark.aws
 @pytest.mark.azure
-@pytest.mark.flaky(reruns=3)
 async def test_put_copy_duplicated_files_s3(tmpdir, aio_connection, db_parameters):
     """[s3] Puts and Copies duplicated files."""
     # generates N files

--- a/test/integ/aio_it/test_put_get_user_stage_async.py
+++ b/test/integ/aio_it/test_put_get_user_stage_async.py
@@ -280,7 +280,6 @@ credentials=(
 
 
 @pytest.mark.aws
-@pytest.mark.flaky(reruns=3)
 async def test_put_get_duplicated_data_user_stage(
     is_public_test,
     tmpdir,

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1805,9 +1805,12 @@ def test_fetch_batches_with_sessions(conn_cnx):
 
             num_batches = len(cur.get_result_batches())
 
+            # Patch SnowflakeRestful (not SessionManager): OCSP also calls
+            # SessionManager.use_session during TLS handshakes to cloud storage,
+            # which would inflate the count beyond remote result batches.
             with mock.patch(
-                "snowflake.connector.session_manager.SessionManager.use_session",
-                side_effect=con._rest.session_manager.use_session,
+                "snowflake.connector.network.SnowflakeRestful.use_requests_session",
+                side_effect=con._rest.use_requests_session,
             ) as get_session_mock:
                 result = cur.fetchall()
                 # all but one batch is downloaded using a session

--- a/test/integ/test_put_get.py
+++ b/test/integ/test_put_get.py
@@ -240,7 +240,6 @@ put file://{test_data.test_data_dir}/ExecPlatform/Database/data/orders_10*.csv @
             cur.execute("drop table pytest_putget_t1")
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.skipif(
     not CONNECTION_PARAMETERS_ADMIN, reason="Snowflake admin account is not accessible."
 )

--- a/test/integ/test_put_get_medium.py
+++ b/test/integ/test_put_get_medium.py
@@ -397,7 +397,6 @@ max_file_size=10000000
         run(cnx, "drop table if exists {name}")
 
 
-@pytest.mark.flaky(reruns=3)
 def test_put_copy_many_files(tmpdir, conn_cnx, db_parameters):
     """Puts and Copies many_files."""
     # generates N files
@@ -488,7 +487,6 @@ ratio number(6,2))
 
 @pytest.mark.aws
 @pytest.mark.azure
-@pytest.mark.flaky(reruns=3)
 def test_put_copy_duplicated_files_s3(tmpdir, conn_cnx, db_parameters):
     """[s3] Puts and Copies duplicated files."""
     # generates N files

--- a/test/integ/test_put_get_user_stage.py
+++ b/test/integ/test_put_get_user_stage.py
@@ -279,7 +279,6 @@ credentials=(
 
 
 @pytest.mark.aws
-@pytest.mark.flaky(reruns=3)
 def test_put_get_duplicated_data_user_stage(
     is_public_test,
     tmpdir,

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,12 @@ setenv =
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
     SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.connector --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=
+    # Follow-up --lf --maxfail=5 re-runs failures once, capped to potential flakes:
+    # https://docs.pytest.org/en/stable/how-to/cache.html
     SNOWFLAKE_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_OPTS:} {env:SNOWFLAKE_PYTEST_COV_CMD}
+    SNOWFLAKE_PYTEST_LF_CMD = pytest --lf --maxfail=5 --last-failed-no-failures none {env:SNOWFLAKE_PYTEST_OPTS:} {env:SNOWFLAKE_PYTEST_COV_CMD}
     SNOWFLAKE_PYTEST_CMD_IGNORE_AIO = {env:SNOWFLAKE_PYTEST_CMD} --ignore=test/integ/aio_it --ignore=test/unit/aio --ignore=test/wif/test_wif_async.py
+    SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO = {env:SNOWFLAKE_PYTEST_LF_CMD} --ignore=test/integ/aio_it --ignore=test/unit/aio --ignore=test/wif/test_wif_async.py
     SNOWFLAKE_TEST_MODE = true
 passenv =
     AWS_ACCESS_KEY_ID
@@ -68,10 +72,15 @@ commands_pre =
 commands =
     # Test environments
     # Note: make sure to have a default env and all the other special ones
-    !pandas-!sso-!lambda-!extras-!single: {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and not sso and not pandas and not lambda and not aio" {posargs:} test
-    pandas: {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and pandas" {posargs:} test
-    sso: {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and sso" {posargs:} test
-    lambda: {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and lambda" {posargs:} test
+    # Leading "-" ignores the first-run exit code so the --lf pass can clear flakes.
+    !pandas-!sso-!lambda-!extras-!single: - {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and not sso and not pandas and not lambda and not aio" {posargs:} test
+    !pandas-!sso-!lambda-!extras-!single: {env:SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and not sso and not pandas and not lambda and not aio" {posargs:} test
+    pandas: - {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and pandas" {posargs:} test
+    pandas: {env:SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and pandas" {posargs:} test
+    sso: - {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and sso" {posargs:} test
+    sso: {env:SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and sso" {posargs:} test
+    lambda: - {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and lambda" {posargs:} test
+    lambda: {env:SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO} -m "{env:SNOWFLAKE_TEST_TYPE} and lambda" {posargs:} test
     extras: python -m test.extras.run {posargs:}
     single: {env:SNOWFLAKE_PYTEST_CMD} -s "{env:SINGLE_TEST_NAME}" {posargs:}
 
@@ -88,7 +97,6 @@ deps =
     pendulum!=2.1.1
     pytest<6.1.0
     pytest-cov<6.2.0
-    pytest-rerunfailures
     pytest-timeout
     pytest-xdist
     mock
@@ -101,7 +109,8 @@ passenv = {[testenv]passenv}
 commands =
     # Unit and pandas tests are already skipped for the old driver (see test/conftest.py). Avoid walking those
     # directories entirely to avoid loading any potentially incompatible subdirectories' own conftest.py files.
-    {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} --ignore=test/unit --ignore=test/pandas -m "not skipolddriver" -vvv {posargs:} test
+    - {env:SNOWFLAKE_PYTEST_CMD_IGNORE_AIO} --ignore=test/unit --ignore=test/pandas -m "not skipolddriver" -vvv {posargs:} test
+    {env:SNOWFLAKE_PYTEST_LF_CMD_IGNORE_AIO} --ignore=test/unit --ignore=test/pandas -m "not skipolddriver" -vvv {posargs:} test
 
 [testenv:noarrowextension]
 basepython = python3.10
@@ -121,8 +130,8 @@ extras=
     pandas
     secure-local-storage
 commands =
-    {env:SNOWFLAKE_PYTEST_CMD} -n auto -m "aio and unit and not sso and not pandas and not lambda" -vvv {posargs:} test
-    {env:SNOWFLAKE_PYTEST_CMD} -n auto -m "aio and unit and not sso and not pandas and not lambda" -vvv {posargs:} test
+    - {env:SNOWFLAKE_PYTEST_CMD} -n auto -m "aio and unit and not sso and not pandas and not lambda" -vvv {posargs:} test
+    {env:SNOWFLAKE_PYTEST_LF_CMD} -n auto -m "aio and unit and not sso and not pandas and not lambda" -vvv {posargs:} test
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report


### PR DESCRIPTION
## Summary
- Replace `pytest-rerunfailures` / `@pytest.mark.flaky` with a tox/FIPS follow-up pass using `pytest --lf --maxfail=5 --last-failed-no-failures none` to retry a small number of potential flakes.
- Remove the `pytest_unconfigure` socket workaround that existed only for rerunfailures shutdown hangs.
- Fix `test_fetch_batches_with_sessions` to mock `SnowflakeRestful.use_requests_session` so OCSP `SessionManager.use_session` calls during cloud chunk downloads do not inflate `call_count`.

## Test plan
- [ ] Confirm Build and Test no longer hits `pytest_rerunfailures` / `_enter_buffered_busy` shutdown aborts
- [ ] Confirm `test_fetch_batches_with_sessions` is stable across GCP/AWS/Azure jobs
- [ ] Spot-check that a real multi-failure run still fails (follow-up `--maxfail=5` does not greenwash widespread breakage)

Made with [Cursor](https://cursor.com)