### PR TITLE
SNOW-3691001: Fix connect() slowdown from inspect.stack() in get_application_path()

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - NEXT_RELEASE(TBD)
+  - Fixed `connect()` being significantly slower on deep call stacks (e.g. Django apps with several middleware/decorator layers) because `get_application_path()` used `inspect.stack()`, which reads and parses the source file of every frame on the stack. It now walks frame references directly instead (SNOW-3691001, #2908).
   - Fixed a thread leak in the file transfer agent by properly shutting down ThreadPoolExecutors after PUT/GET transfers (SNOW-3556240, #2878).
   - Fixed `split_statements` treating `//` as SQL instead of a line comment, which could merge multiple statements when a `//` comment contained an apostrophe (SNOW-3772985).
   - Fixed large-file PUT uploads to internal Azure stages failing against the Azure 50,000-block-per-blob limit. The Azure multipart chunk size is now scaled up dynamically for very large files (mirroring the existing S3 behavior), and the default Azure chunk size was raised from 4 MB to 8 MB (consistent with S3) for better throughput (SNOW-3839943).

--- a/src/snowflake/connector/_utils.py
+++ b/src/snowflake/connector/_utils.py
@@ -9,7 +9,7 @@ import string
 import threading
 import time
 from enum import Enum
-from inspect import stack
+from inspect import currentframe
 from secrets import choice
 from threading import Timer
 from uuid import UUID
@@ -101,12 +101,24 @@ class _TrackedQueryCancellationTimer(Timer):
 
 
 def get_application_path() -> str:
-    """Get the path of the application script using the connector."""
+    """Get the path of the application script using the connector.
+
+    Walks frame.f_back directly instead of using inspect.stack(), which
+    reads and parses the source file of every frame on the call stack.
+    That per-frame disk I/O made connect() take hundreds of milliseconds
+    on deep call stacks (see SNOW-3691001 / GH-2908).
+    """
+    frame = currentframe()
     try:
-        outermost_frame = stack()[-1]
-        return outermost_frame.filename
+        if frame is None:
+            return "unknown"
+        while frame.f_back is not None:
+            frame = frame.f_back
+        return frame.f_code.co_filename
     except Exception:
         return "unknown"
+    finally:
+        del frame
 
 
 _SPCS_ENV_VAR = "SNOWFLAKE_RUNNING_INSIDE_SPCS"

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -1,5 +1,7 @@
 import ctypes
 import os
+import sys
+import time
 from importlib import reload
 from time import sleep
 from unittest import mock
@@ -13,9 +15,61 @@ from snowflake.connector._utils import (
     build_minicore_usage_for_session,
     build_minicore_usage_for_telemetry,
     build_nanoarrow_usage_for_telemetry,
+    get_application_path,
 )
 
 pytestmark = pytest.mark.skipolddriver
+
+
+def test_get_application_path_is_fast_on_deep_call_stacks():
+    """Regression test for GH-2908 / SNOW-3691001.
+
+    get_application_path() used to call inspect.stack(), which reads and
+    parses the source file of every frame on the call stack. Real-world
+    call stacks (e.g. a Django app with several middleware/decorator
+    layers) can be 100+ frames deep, which made connect() take hundreds
+    of milliseconds to over half a second just to compute the
+    application path. A correct implementation only walks frame.f_back
+    pointers and stays in the microsecond range regardless of depth.
+    """
+    depth = 150
+    n_runs = 5
+    threshold_ms = 1.0
+
+    def recurse(n):
+        if n == 0:
+            t0 = time.perf_counter()
+            get_application_path()
+            return time.perf_counter() - t0
+        return recurse(n - 1)
+
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, depth + 500))
+    try:
+        durations = [recurse(depth) for _ in range(n_runs)]
+    finally:
+        sys.setrecursionlimit(old_limit)
+
+    avg_ms = sum(durations) / len(durations) * 1000
+    assert avg_ms < threshold_ms, (
+        f"get_application_path() averaged {avg_ms:.3f} ms over {n_runs} "
+        f"runs at stack depth {depth} (threshold {threshold_ms} ms). This "
+        "indicates a regression to a slow, per-frame-source-reading "
+        "implementation (see GH-2908)."
+    )
+
+
+def test_get_application_path_matches_inspect_stack_behavior():
+    """The fast frame-walk must return the same filename inspect.stack()[-1] would."""
+    from inspect import stack
+
+    def recurse(n):
+        if n == 0:
+            return get_application_path(), stack()[-1].filename
+        return recurse(n - 1)
+
+    fast_result, reference_result = recurse(20)
+    assert fast_result == reference_result
 
 
 def test_timer():


### PR DESCRIPTION
## Summary
- `get_application_path()` used `inspect.stack()`, which reads and parses the source file of every frame on the call stack. This runs on every `connect()` call (via `auth/_auth.py`).
- On deep call stacks (e.g. a Django app with several middleware/decorator layers, ~100+ frames), this made `connect()` take hundreds of milliseconds to over half a second purely client-side. Reported customer impact: ~2.5s on 4.0.0 vs ~222ms on 3.16.0, with server-side login only ~0.13s.
- Replaced the implementation with a direct `frame.f_back` walk via `inspect.currentframe()`, which returns the same outermost-frame filename without any per-frame source file I/O. Verified ~150-300x speedup locally (1.6-3.3ms -> ~0.01ms at 100-200 simulated stack frames).

## Test plan
- [x] Added `test_get_application_path_is_fast_on_deep_call_stacks` in `test/unit/test_util.py`: builds a 150-frame synthetic call stack, averages timing over 5 runs, asserts it stays under 1ms. Verified this fails (~10ms avg) against the old `inspect.stack()`-based implementation and passes against the fix.
- [x] Added `test_get_application_path_matches_inspect_stack_behavior`: confirms the new implementation returns the exact same filename as `inspect.stack()[-1].filename` would have.
- [x] `hatch run python -m pytest test/unit/test_util.py test/unit/test_base_auth_data.py test/unit/test_auth.py` — 118 passed.
- [x] `pre-commit run` on changed files — all hooks pass.

Fixes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)