### PR TITLE
SNOW-3192362: Fix pyenv version match for plain 3.x also matching free-threaded installs

### DIFF
--- a/ci/build_darwin.sh
+++ b/ci/build_darwin.sh
@@ -46,7 +46,7 @@ for PYTHON_VERSION in ${PYTHON_VERSIONS}; do
             PYENV_BASE="${PYTHON_VERSION%t}"
             PYENV_PATTERN="^${PYENV_BASE//./\\.}(\\.[0-9]+)?t\$"
         else
-            PYENV_PATTERN="^${PYTHON_VERSION//./\\.}"
+            PYENV_PATTERN="^${PYTHON_VERSION//./\\.}(\\.[0-9]+)?\$"
         fi
         PYENV_MATCH=$(pyenv versions --bare | grep -E "${PYENV_PATTERN}" | tail -1)
         if [ -n "$PYENV_MATCH" ]; then


### PR DESCRIPTION
## Summary
- `03630e74` anchored the free-threaded (`*t`) pyenv-version grep pattern in `ci/build_darwin.sh` but left the plain-version pattern unanchored.
- For `PYTHON_VERSION=3.14`, the resulting pattern `^3\.14` matches both `3.14.0` and `3.14.0t`. Combined with the `tail -1` selection (needed to prefer the highest free-threaded patch), the plain `3.14` loop iteration now silently resolves to the free-threaded interpreter.
- Both the `3.14` and `3.14t` iterations then build with the same interpreter and write the same-named `cp314-cp314t` wheel into the shared `dist/` dir — the second write overwrites the first, so the regular `cp314-cp314` wheel is never produced. This matches the observed S3 output for `main` build `03630e7414056fe455ef4d7416d57186b75df44c`, where every (arch, macOS version) combo has a `cp314-cp314t` wheel but no `cp314-cp314` wheel.
- Fix: anchor the plain-version pattern the same way the `*t` branch already is, so `3.14` only matches `3.14`/`3.14.x` and never `3.14.xt`.

## Test plan
- [x] `bash -n ci/build_darwin.sh` — syntax check passes
- [x] Regex simulation against a fake `pyenv versions --bare` list containing `3.14.0` and `3.14.0t`: plain pattern matches only `3.14.0`, `*t` pattern matches only `3.14.0t`
- [ ] On a mac node with pyenv, run `./ci/build_darwin.sh "3.14 3.14t"` and confirm two distinct wheels (`cp314-cp314` and `cp314-cp314t`) are produced
- [ ] Re-run the full matrix and confirm the S3 upload contains both wheel variants for every (arch, macOS version) combo

Marked as draft pending the on-node verification above.