### PR TITLE
SNOW-4011646: preserve underscore SANs during TLS hostname verification

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -7,6 +7,9 @@ https://docs.snowflake.com/
 Source code is also available at: https://github.com/snowflakedb/snowflake-connector-python
 
 # Release Notes
+- NEXT_RELEASE(TBD)
+  - Fixed TLS hostname verification rejecting matching certificate SANs when a Snowflake account locator contains an underscore (SNOW-4011646).
+
 - v3.18.1(July 15,2026)
   - Improved verification of TLS connections (SNOW-3675579).
   - Fixed FIPS environments md5 hash issues with multipart upload on Azure.

--- a/src/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py
+++ b/src/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py
@@ -198,20 +198,36 @@ def _dnsname_to_stdlib(name: str) -> str | None:
 
     def idna_encode(name: str) -> bytes | None:
         """
-        Borrowed wholesale from the Python Cryptography Project. It turns out
+        Based on the Python Cryptography Project implementation. It turns out
         that we can't just safely call `idna.encode`: it can explode for
-        wildcard names. This avoids that problem.
+        wildcard names. This avoids that problem and preserves Snowflake's
+        ASCII account-locator underscores.
         """
         import idna
 
+        prefix = ""
+        for candidate in ["*.", "."]:
+            if name.startswith(candidate):
+                prefix = candidate
+                name = name[len(candidate) :]
+                break
+
         try:
-            for prefix in ["*.", "."]:
-                if name.startswith(prefix):
-                    name = name[len(prefix) :]
-                    return prefix.encode("ascii") + idna.encode(name)
-            return idna.encode(name)
+            return prefix.encode("ascii") + idna.encode(name)
         except idna.core.IDNAError:
-            return None
+            # Snowflake account locators may contain underscores. Although an
+            # underscore is not valid IDNA, these ASCII names are valid DNS
+            # labels and can appear verbatim in both the requested hostname and
+            # its certificate SAN. Retain the name only when replacing the
+            # underscores makes the otherwise-unchanged name valid IDNA; this
+            # keeps rejecting names with any additional IDNA violation.
+            if not name.isascii() or "_" not in name:
+                return None
+            try:
+                idna.encode(name.replace("_", "a"))
+            except idna.core.IDNAError:
+                return None
+            return prefix.encode("ascii") + name.encode("ascii")
 
     # Don't send IPv6 addresses through the IDNA encoder.
     if ":" in name:

--- a/test/integ/test_cursor.py
+++ b/test/integ/test_cursor.py
@@ -1792,6 +1792,11 @@ def test_describe(conn_cnx):
 
 @pytest.mark.skipolddriver
 def test_fetch_batches_with_sessions(conn_cnx):
+    """Verify result-batch downloads use the connection's sessions.
+
+    Patch the connection-level wrapper because OCSP checks reuse the underlying
+    session manager during TLS handshakes and must not count as batch downloads.
+    """
     rowcount = 250_000
     with conn_cnx() as con:
         with con.cursor() as cur:
@@ -1802,8 +1807,8 @@ def test_fetch_batches_with_sessions(conn_cnx):
             num_batches = len(cur.get_result_batches())
 
             with mock.patch(
-                "snowflake.connector.session_manager.SessionManager.use_requests_session",
-                side_effect=con._rest.session_manager.use_requests_session,
+                "snowflake.connector.network.SnowflakeRestful.use_requests_session",
+                side_effect=con._rest.use_requests_session,
             ) as get_session_mock:
                 result = cur.fetchall()
                 # all but one batch is downloaded using a session

--- a/test/unit/test_ssl_hostname_verification.py
+++ b/test/unit/test_ssl_hostname_verification.py
@@ -16,6 +16,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 import snowflake.connector.ssl_wrap_socket as ssw  # pylint: disable=import-error
 from snowflake.connector.constants import OCSPMode  # pylint: disable=import-error
+from snowflake.connector.vendored.urllib3.contrib.pyopenssl import _dnsname_to_stdlib
 from snowflake.connector.vendored.urllib3.util.ssl_match_hostname import (
     CertificateError,
 )
@@ -135,6 +136,21 @@ def _client_context_trusting(cert):
     return ctx
 
 
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("foo_bar.example.com", "foo_bar.example.com"),
+        ("*.foo_bar.example.com", "*.foo_bar.example.com"),
+        ("foo_bär.example.com", None),
+        ("foo_bar..example.com", None),
+        ("foo_bar-.example.com", None),
+    ],
+)
+def test_underscore_san_idna_conversion(name, expected):
+    """Only otherwise-valid ASCII SANs get the underscore compatibility path."""
+    assert _dnsname_to_stdlib(name) == expected
+
+
 def test_hostname_mismatch_is_rejected():
     """A valid chain with the wrong hostname must be rejected."""
     # Certificate is valid and trusted, but its SAN is 'localhost' only.
@@ -172,6 +188,48 @@ def test_hostname_match_succeeds():
         ssl_context=ctx,
     )
     assert hasattr(ws, "connection")
+    s.close()
+    stop_evt.wait(5)
+
+
+def test_hostname_with_underscore_matches_san():
+    """An ASCII SAN containing an account-locator underscore must be retained."""
+    hostname = "foo_bar.example.com"
+    cert, key = _create_self_signed_cert(hostname, [hostname])
+    (host, port), stop_evt = _start_server(cert, key)
+
+    ctx = _client_context_trusting(cert)
+    s = socket.socket()
+    s.settimeout(5)
+    s.connect((host, port))
+
+    ws = ssw.ssl_wrap_socket_with_ocsp(
+        sock=s,
+        server_hostname=hostname,
+        ssl_context=ctx,
+    )
+    assert hasattr(ws, "connection")
+    s.close()
+    stop_evt.wait(5)
+
+
+def test_hostname_with_underscore_rejects_mismatch():
+    """Retaining underscore SANs must not weaken hostname matching."""
+    cert_hostname = "foo_bar.example.com"
+    cert, key = _create_self_signed_cert(cert_hostname, [cert_hostname])
+    (host, port), stop_evt = _start_server(cert, key)
+
+    ctx = _client_context_trusting(cert)
+    s = socket.socket()
+    s.settimeout(5)
+    s.connect((host, port))
+
+    with pytest.raises(CertificateError):
+        ssw.ssl_wrap_socket_with_ocsp(
+            sock=s,
+            server_hostname="different_name.example.com",
+            ssl_context=ctx,
+        )
     s.close()
     stop_evt.wait(5)
 


### PR DESCRIPTION
Python connector 3.18.1 includes the TLS hostname verification added in
4.7.1 and rejects mTLS connections to hosts whose account-locator label
contains `_`. The matching certificate SAN is passed through strict IDNA
conversion and discarded before post-handshake verification, making the
certificate appear to have no matching DNS SAN.

This backports #3009 to `release/3.18` for 3.18.2. It preserves ASCII
underscore SANs only when replacing `_` proves the rest of the name is
valid IDNA; non-ASCII and otherwise malformed names remain rejected, and
CN fallback remains disabled. Tests use the release branch's
`ssl_wrap_socket_with_ocsp` entry point and cover conversion boundaries
plus end-to-end matching and mismatching certificates. The focused TLS
hostname, context-hardening, and partial-chain suites pass with 17 tests.
