### PR TITLE
NO-SNOW: fix the Wiremock harness on Windows

### DIFF
--- a/test/test_utils/wiremock/wiremock_utils.py
+++ b/test/test_utils/wiremock/wiremock_utils.py
@@ -17,6 +17,7 @@ except ImportError:
 # Total budget for a Wiremock instance to become usable: the JVM has to boot,
 # report the ports it bound and answer the health endpoint within this time.
 WIREMOCK_START_TIMEOUT_SECONDS = 12
+WIREMOCK_STOP_TIMEOUT_SECONDS = 10
 # How long to wait between polls while waiting for the startup banner / health.
 _WIREMOCK_START_POLL_INTERVAL_SECONDS = 0.1
 # Only the tail of the startup log is quoted in error messages.
@@ -225,7 +226,9 @@ class WiremockClient:
         if self._startup_log_path is None:
             return ""
         try:
-            return self._startup_log_path.read_text(errors="replace")
+            # Explicit encoding: the default is locale-dependent, and on Windows
+            # (cp1252) java's UTF-8 output would decode into mojibake.
+            return self._startup_log_path.read_text(encoding="utf-8", errors="replace")
         except OSError as e:
             return (
                 f"<could not read wiremock startup log {self._startup_log_path}: {e}>"
@@ -273,8 +276,37 @@ class WiremockClient:
     def _remove_startup_log(self) -> None:
         if self._startup_log_path is None:
             return
-        self._startup_log_path.unlink(missing_ok=True)
+        try:
+            self._startup_log_path.unlink(missing_ok=True)
+        except OSError as e:
+            # Windows refuses to unlink a file while another process still holds a
+            # handle to it, so a JVM that has not fully exited yet would make this
+            # raise. Leaking one file in the OS temp directory is much better than
+            # failing teardown, which would mask the result of the test itself.
+            logger.debug(f"Could not remove wiremock startup log: {e}")
         self._startup_log_path = None
+
+    def _wait_for_process_exit(self) -> None:
+        """Wait for the JVM to actually exit, killing it if it overstays.
+
+        Deleting the startup log requires the process holding it to be gone on
+        Windows, and a lingering JVM would also keep its ports bound.
+        """
+        if self.wiremock_process is None:
+            return
+        try:
+            self.wiremock_process.wait(timeout=WIREMOCK_STOP_TIMEOUT_SECONDS)
+            return
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                f"Wiremock did not exit within {WIREMOCK_STOP_TIMEOUT_SECONDS}s, "
+                "killing it"
+            )
+        self.wiremock_process.kill()
+        try:
+            self.wiremock_process.wait(timeout=WIREMOCK_STOP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            logger.warning("Wiremock process is still alive after kill")
 
     def _stop_wiremock(self):
         if self.wiremock_process.poll() is not None:
@@ -295,6 +327,9 @@ class WiremockClient:
             logger.warning(f"Shutdown request failed: {e}. Killing process directly.")
             self.wiremock_process.kill()
         finally:
+            # Reap the JVM before touching its log: /__admin/shutdown returns as soon
+            # as the request is accepted, so the process is usually still running here.
+            self._wait_for_process_exit()
             self._remove_startup_log()
 
     def _wait_for_wiremock(self, deadline: float):

--- a/test/unit/test_wiremock_utils.py
+++ b/test/unit/test_wiremock_utils.py
@@ -43,9 +43,19 @@ class _FakeProcess:
 
     def __init__(self, return_code: int | None) -> None:
         self._return_code = return_code
+        self.wait_calls = 0
+        self.kill_calls = 0
 
     def poll(self) -> int | None:
         return self._return_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        self._return_code = 0
+        return 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
 
 
 def _client_for_startup_checks(
@@ -63,7 +73,9 @@ def _client_for_startup_checks(
     client.wiremock_http_port = 45161
     client.wiremock_https_port = None
     log_path = tmp_path / "wiremock-startup.log"
-    log_path.write_text(startup_output)
+    # Explicit encoding: the default is locale-dependent, and non-ASCII in a canned
+    # startup log is unwritable under Windows' cp1252.
+    log_path.write_text(startup_output, encoding="utf-8")
     client._startup_log_path = log_path
     client.wiremock_process = _FakeProcess(return_code)
     return client
@@ -140,3 +152,57 @@ def test_missing_banner_times_out_with_the_captured_output(tmp_path):
     message = str(excinfo.value)
     assert f"{WIREMOCK_START_TIMEOUT_SECONDS} seconds" in message
     assert "still booting" in message
+
+
+def test_startup_log_removal_survives_a_locked_file(tmp_path, monkeypatch):
+    """Teardown must not fail because the log file cannot be unlinked.
+
+    Windows refuses to unlink a file while another process holds a handle to it,
+    so a JVM that has not fully exited yet made ``__exit__`` raise
+    ``PermissionError`` and mask the result of the test that was running.
+    """
+    client = _client_for_startup_checks(BANNER, None, tmp_path)
+
+    def _locked_unlink(*args, **kwargs):
+        raise PermissionError(
+            32,
+            "The process cannot access the file because it is being used by "
+            "another process",
+        )
+
+    monkeypatch.setattr(pathlib.Path, "unlink", _locked_unlink)
+
+    client._remove_startup_log()
+
+    assert client._startup_log_path is None, "the path must be cleared regardless"
+
+
+def test_process_is_reaped_before_its_log_is_removed(tmp_path):
+    """``/__admin/shutdown`` returns before the JVM exits, so wait for it.
+
+    Removing the log while the process still holds it is what fails on Windows,
+    and a lingering JVM would also keep its ports bound.
+    """
+    client = _client_for_startup_checks(BANNER, None, tmp_path)
+    removal_order = []
+
+    def _record_removal():
+        removal_order.append("removed")
+
+    client._remove_startup_log = _record_removal
+    client._wiremock_post = lambda url: pytest.fail(
+        "shutdown should not be attempted in this test"
+    )
+    client.wiremock_process._return_code = 0  # already exited: skips the POST
+
+    client._stop_wiremock()
+
+    assert removal_order == ["removed"]
+
+    # And when the process is still alive, it is waited on before removal.
+    client = _client_for_startup_checks(BANNER, None, tmp_path)
+    client._wiremock_post = lambda url: type("R", (), {"status_code": 200})()
+    client._stop_wiremock()
+
+    assert client.wiremock_process.wait_calls >= 1, "the JVM must be reaped"
+    assert client._startup_log_path is None


### PR DESCRIPTION
Every Windows job started failing after the port-bind-race fix (#3018), which redirected Wiremock's startup output to a temp file and deleted it on exit. Two Windows-specific problems came with it.

Teardown could not delete the log. POSIX allows unlinking a file another process still has open; Windows does not. `/__admin/shutdown` returns as soon as the request is accepted, so the JVM was usually still holding its handle when `_remove_startup_log()` ran, and `__exit__` raised

    PermissionError: [WinError 32] The process cannot access the file because
    it is being used by another process

That is where the ~33 errors per job came from: they were teardown failures in test_oauth_token, test_ocsp, test_proxies and test_put_get, not failures of those tests. `_stop_wiremock` now reaps the process before touching its log, and removal is best-effort -- leaking one file in the OS temp directory beats failing teardown and masking the result of the test that was running.

Text I/O used the locale encoding. `Path.write_text`/`read_text` without an explicit encoding resolve to cp1252 on Windows, so the canned startup log in test_wiremock_utils.py (which contains U+2588 from Wiremock's banner art) was unwritable, and reading java's UTF-8 output back would have produced mojibake. Both sites now pass encoding="utf-8".

Added regression tests for both teardown behaviours. They are hermetic, so they run on every platform rather than only where java is available -- which is why this was not caught before: #3018 was verified against a real JVM on Linux, where neither failure mode exists.

Please answer these questions before submitting your pull requests. Thanks!
