### PR TITLE
SNOW-4058589: retry SSLError "Unexpected EOF" during TLS handshake

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - NEXT_RELEASE(TBD)
+  - Fixed a bug where a TLS handshake terminated by the peer (`SSLError` containing `SysCallError(-1, 'Unexpected EOF')`) was classified as non-retryable and surfaced as an `OperationalError`, unlike `ECONNRESET`. Such handshake `Unexpected EOF` errors are now retried, on both the sync and async request paths (SNOW-4058589).
 
 - v4.7.3(Sep 3,2026)
   - Added experimental Python 3.14t (free-threaded CPython) wheel support. **Experimental — not intended for production use.**

--- a/src/snowflake/connector/aio/_network.py
+++ b/src/snowflake/connector/aio/_network.py
@@ -816,7 +816,7 @@ class SnowflakeRestful(SnowflakeRestfulSync):
             finally:
                 raw_ret.close()  # ensure response is closed
         except (aiohttp.ClientSSLError, aiohttp.ClientConnectorSSLError) as se:
-            if is_econnreset_exception(se):
+            if is_econnreset_exception(se) or "Unexpected EOF" in repr(se):
                 raise RetryRequest(se.os_error)
             msg = f"Hit non-retryable SSL error, {str(se)}.\n{_CONNECTIVITY_ERR_MSG}"
             logger.debug(msg)

--- a/src/snowflake/connector/aio/_network.py
+++ b/src/snowflake/connector/aio/_network.py
@@ -79,6 +79,7 @@ from ..network import (
     is_econnreset_exception,
     is_login_request,
     is_retryable_http_code,
+    is_unexpected_eof_exception,
 )
 from ..secret_detector import SecretDetector
 from ..sqlstate import (
@@ -816,7 +817,7 @@ class SnowflakeRestful(SnowflakeRestfulSync):
             finally:
                 raw_ret.close()  # ensure response is closed
         except (aiohttp.ClientSSLError, aiohttp.ClientConnectorSSLError) as se:
-            if is_econnreset_exception(se) or "Unexpected EOF" in repr(se):
+            if is_econnreset_exception(se) or is_unexpected_eof_exception(se):
                 raise RetryRequest(se.os_error)
             msg = f"Hit non-retryable SSL error, {str(se)}.\n{_CONNECTIVITY_ERR_MSG}"
             logger.debug(msg)

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -283,6 +283,10 @@ def is_econnreset_exception(e: Exception) -> bool:
     return "ECONNRESET" in repr(e)
 
 
+def is_unexpected_eof_exception(e: Exception) -> bool:
+    return "Unexpected EOF" in repr(e)
+
+
 class RetryRequest(Exception):
     """Signal to retry request."""
 
@@ -1222,7 +1226,7 @@ class SnowflakeRestful:
             finally:
                 raw_ret.close()  # ensure response is closed
         except SSLError as se:
-            if is_econnreset_exception(se) or "Unexpected EOF" in repr(se):
+            if is_econnreset_exception(se) or is_unexpected_eof_exception(se):
                 raise RetryRequest(se)
             msg = f"Hit non-retryable SSL error, {str(se)}.\n{_CONNECTIVITY_ERR_MSG}"
             logger.debug(msg)

--- a/src/snowflake/connector/network.py
+++ b/src/snowflake/connector/network.py
@@ -1222,7 +1222,7 @@ class SnowflakeRestful:
             finally:
                 raw_ret.close()  # ensure response is closed
         except SSLError as se:
-            if is_econnreset_exception(se):
+            if is_econnreset_exception(se) or "Unexpected EOF" in repr(se):
                 raise RetryRequest(se)
             msg = f"Hit non-retryable SSL error, {str(se)}.\n{_CONNECTIVITY_ERR_MSG}"
             logger.debug(msg)

--- a/test/unit/aio/test_retry_network_async.py
+++ b/test/unit/aio/test_retry_network_async.py
@@ -510,8 +510,8 @@ async def test_sslerror_with_econnreset_retries():
         await rest._request_exec(session=session, **default_parameters)
 
 
-async def test_sslerror_without_econnreset_does_not_retry():
-    """Test that SSLError without ECONNRESET does not retry but raises OperationalError."""
+async def test_sslerror_without_econnreset_or_unexpected_eof_does_not_retry():
+    """Test that an SSLError with neither ECONNRESET nor 'Unexpected EOF' does not retry but raises OperationalError."""
     connection = mock_connection()
     connection.errorhandler = Error.default_errorhandler
     rest = SnowflakeRestful(
@@ -535,6 +535,34 @@ async def test_sslerror_without_econnreset_does_not_retry():
 
     # This should raise OperationalError, not RetryRequest
     with pytest.raises(OperationalError):
+        await rest._request_exec(session=session, **default_parameters)
+
+
+async def test_sslerror_with_unexpected_eof_retries():
+    """Test that SSLError with 'Unexpected EOF' raises RetryRequest."""
+    connection = mock_connection()
+    connection.errorhandler = Error.default_errorhandler
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com",
+        port=443,
+        connection=connection,
+    )
+
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": '{"code": 12345}',
+        "token": None,
+    }
+
+    unexpected_eof_ssl_error = ClientSSLError(
+        MagicMock(), SSLError("bad handshake: SysCallError(-1, 'Unexpected EOF')")
+    )
+    session = MagicMock()
+    session.request = Mock(side_effect=unexpected_eof_ssl_error)
+
+    with pytest.raises(RetryRequest, match="Unexpected EOF"):
         await rest._request_exec(session=session, **default_parameters)
 
 

--- a/test/unit/test_retry_network.py
+++ b/test/unit/test_retry_network.py
@@ -535,8 +535,8 @@ def test_sslerror_with_econnreset_retries():
         rest._request_exec(session=session, **default_parameters)
 
 
-def test_sslerror_without_econnreset_does_not_retry():
-    """Test that SSLError without ECONNRESET does not retry but raises OperationalError."""
+def test_sslerror_without_econnreset_or_unexpected_eof_does_not_retry():
+    """Test that an SSLError with neither ECONNRESET nor 'Unexpected EOF' does not retry but raises OperationalError."""
     connection = mock_connection()
     connection.errorhandler = Error.default_errorhandler
     rest = SnowflakeRestful(
@@ -560,6 +560,34 @@ def test_sslerror_without_econnreset_does_not_retry():
 
     # This should raise OperationalError, not RetryRequest
     with pytest.raises(OperationalError):
+        rest._request_exec(session=session, **default_parameters)
+
+
+def test_sslerror_with_unexpected_eof_retries():
+    """Test that SSLError with 'Unexpected EOF' raises RetryRequest."""
+    connection = mock_connection()
+    connection.errorhandler = Error.default_errorhandler
+    rest = SnowflakeRestful(
+        host="testaccount.snowflakecomputing.com",
+        port=443,
+        connection=connection,
+    )
+
+    default_parameters = {
+        "method": "POST",
+        "full_url": "https://testaccount.snowflakecomputing.com/",
+        "headers": {},
+        "data": '{"code": 12345}',
+        "token": None,
+    }
+
+    unexpected_eof_ssl_error = SSLError(
+        "bad handshake: SysCallError(-1, 'Unexpected EOF')"
+    )
+    session = MagicMock()
+    session.request = Mock(side_effect=unexpected_eof_ssl_error)
+
+    with pytest.raises(RetryRequest, match="Unexpected EOF"):
         rest._request_exec(session=session, **default_parameters)
 
 


### PR DESCRIPTION
## Problem
`SnowflakeRestful._request_exec` only retries an `SSLError` when its `repr()` contains `ECONNRESET`. A TLS handshake aborted by the peer surfaces (via pyOpenSSL) as `SSLError("bad handshake: SysCallError(-1, 'Unexpected EOF')")`, which does not match — so it is treated as non-retryable and raised as `OperationalError` (errno 250003).

## Impact
When the peer closes the connection mid-TLS-handshake — a transient, retryable condition — the request fails immediately instead of being retried, surfacing as a hard connection error. Affects both the sync and async request paths.

We got a customer complaint due to this. 

## Fix
Retry when `"Unexpected EOF"` is present in `repr(se)`, alongside the existing `ECONNRESET` check, in `network.py` (sync) and `aio/_network.py` (async).

## Tests
- Added `test_sslerror_with_unexpected_eof_retries` (sync + async), asserting `RetryRequest`.
- Renamed the negative test to `test_sslerror_without_econnreset_or_unexpected_eof_does_not_retry`.
- All `test_retry_network` unit tests pass (43, sync + async).
