### PR TITLE
Fix TokenKey host and user argument order in auth cache

### DIFF
--- a/src/snowflake/connector/auth/_auth.py
+++ b/src/snowflake/connector/auth/_auth.py
@@ -559,7 +559,9 @@ class Auth:
         user: str,
         cred_type: TokenType,
     ) -> str | None:
-        return self.get_token_cache().retrieve(TokenKey(host, user, cred_type))
+        return self.get_token_cache().retrieve(
+            TokenKey(user=user, host=host, tokenType=cred_type)
+        )
 
     def read_temporary_credentials(
         self,
@@ -603,7 +605,9 @@ class Auth:
                 "no credential is given when try to store temporary credential"
             )
             return
-        self.get_token_cache().store(TokenKey(host, user, cred_type), cred)
+        self.get_token_cache().store(
+            TokenKey(user=user, host=host, tokenType=cred_type), cred
+        )
 
     def write_temporary_credentials(
         self,
@@ -637,7 +641,9 @@ class Auth:
     def _delete_temporary_credential(
         self, host: str, user: str, cred_type: TokenType
     ) -> None:
-        self.get_token_cache().remove(TokenKey(host, user, cred_type))
+        self.get_token_cache().remove(
+            TokenKey(user=user, host=host, tokenType=cred_type)
+        )
 
     def get_token_cache(self) -> TokenCache:
         if self._token_cache is None:

--- a/test/integ/aio_it/sso_it/test_connection_manual_async.py
+++ b/test/integ/aio_it/sso_it/test_connection_manual_async.py
@@ -89,9 +89,9 @@ async def test_connect_externalbrowser(token_validity_test_values):
 
     TokenCache.make().remove(
         TokenKey(
-            CONNECTION_PARAMETERS_SSO["host"],
-            CONNECTION_PARAMETERS_SSO["user"],
-            TokenType.ID_TOKEN,
+            user=CONNECTION_PARAMETERS_SSO["user"],
+            host=CONNECTION_PARAMETERS_SSO["host"],
+            tokenType=TokenType.ID_TOKEN,
         )
     )
     # delete existing temporary credential

--- a/test/integ/aio_it/sso_it/test_unit_mfa_cache_async.py
+++ b/test/integ/aio_it/sso_it/test_unit_mfa_cache_async.py
@@ -125,7 +125,11 @@ async def test_mfa_cache(mockSnowflakeRestfulPostRequest):
         from snowflake.connector.token_cache import TokenCache, TokenKey, TokenType
 
         TokenCache.make().remove(
-            TokenKey(conn_cfg["host"], conn_cfg["user"], TokenType.MFA_TOKEN)
+            TokenKey(
+                user=conn_cfg["user"],
+                host=conn_cfg["host"],
+                tokenType=TokenType.MFA_TOKEN,
+            )
         )
 
         # first connection, no mfa token cache

--- a/test/integ/sso_it/test_unit_mfa_cache.py
+++ b/test/integ/sso_it/test_unit_mfa_cache.py
@@ -121,7 +121,11 @@ def test_mfa_cache(mockSnowflakeRestfulPostRequest):
         from snowflake.connector.token_cache import TokenCache, TokenKey, TokenType
 
         TokenCache.make().remove(
-            TokenKey(conn_cfg["host"], conn_cfg["user"], TokenType.MFA_TOKEN)
+            TokenKey(
+                user=conn_cfg["user"],
+                host=conn_cfg["host"],
+                tokenType=TokenType.MFA_TOKEN,
+            )
         )
 
         # first connection, no mfa token cache

--- a/test/unit/test_auth.py
+++ b/test/unit/test_auth.py
@@ -497,3 +497,34 @@ def test_oauth_token_invalid_error_handling(auth_instance, expected_exc_type):
     auth = Auth(rest)
     with pytest.raises(expected_exc_type):
         auth.authenticate(auth_instance, account, user)
+
+
+def test_temporary_credential_token_key_field_order():
+    """Auth temporary credential helpers must build TokenKey as (user, host)."""
+    from unittest.mock import MagicMock
+
+    from snowflake.connector.token_cache import TokenKey, TokenType
+
+    host = "MYACCOUNT.EU-CENTRAL-1.SNOWFLAKECOMPUTING.COM"
+    user = "ALICE"
+    auth = Auth(MagicMock())
+    cache = MagicMock()
+    auth._token_cache = cache
+
+    auth._write_temporary_credential(host, user, TokenType.ID_TOKEN, "dummy_id_token")
+    stored_key = cache.store.call_args[0][0]
+    assert isinstance(stored_key, TokenKey)
+    assert stored_key.user == user
+    assert stored_key.host == host
+    assert stored_key.string_key() == f"{host}:{user}:ID_TOKEN"
+
+    cache.retrieve.return_value = None
+    auth._read_temporary_credential(host, user, TokenType.ID_TOKEN)
+    retrieved_key = cache.retrieve.call_args[0][0]
+    assert retrieved_key.user == user
+    assert retrieved_key.host == host
+
+    auth._delete_temporary_credential(host, user, TokenType.ID_TOKEN)
+    removed_key = cache.remove.call_args[0][0]
+    assert removed_key.user == user
+    assert removed_key.host == host


### PR DESCRIPTION
Fixes #2931

`TokenKey` is declared as `(user, host, tokenType)`, but the temporary credential helpers in `auth/_auth.py` built it positionally as `TokenKey(host, user, cred_type)`. That swapped the fields, so ID and MFA cache entries used `USER:HOST:TOKEN_TYPE` while OAuth used the intended `HOST:USER:TOKEN_TYPE`.

This change builds those keys with keyword arguments and updates matching integ cleanup call sites. A unit test asserts store, retrieve, and delete all use `user` and `host` in the declared order.

Note: existing ID/MFA tokens stored under the swapped layout will not be found after upgrade, so users may see one extra authentication prompt while the cache repopulates.