### PR TITLE
SNOW-3984430: retry transient OAuth token-request HTTP failures

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -8,6 +8,7 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
 
 # Release Notes
 - NEXT_RELEASE(TBD)
+  - Fixed missing retries on transient HTTP failures when fetching an OAuth access token from the IdP token endpoint (`OAUTH_CLIENT_CREDENTIALS` and `OAUTH_AUTHORIZATION_CODE`). Token requests now retry transport errors, HTTP 408/429, and 5xx responses (SNOW-3984430, #3003).
 
 - v4.7.3(Sep 3,2026)
   - Added experimental Python 3.14t (free-threaded CPython) wheel support. **Experimental — not intended for production use.**

--- a/src/snowflake/connector/auth/_oauth_base.py
+++ b/src/snowflake/connector/auth/_oauth_base.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import time
 import urllib.parse
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 from urllib.error import HTTPError, URLError
 
+from ..backoff_policies import exponential_backoff
 from ..errorcode import (
     ER_FAILED_TO_REQUEST,
     ER_IDP_CONNECTION_ERROR,
@@ -25,6 +27,7 @@ from ..secret_detector import SecretDetector
 from ..token_cache import TokenCache, TokenKey, TokenType
 from ..vendored import urllib3
 from ..vendored.requests.utils import get_environ_proxies, select_proxy
+from ..vendored.urllib3.exceptions import HTTPError as Urllib3HTTPError
 from ..vendored.urllib3.poolmanager import ProxyManager
 from .by_plugin import AuthByPlugin, AuthType
 
@@ -32,6 +35,12 @@ if TYPE_CHECKING:
     from .. import SnowflakeConnection
 
 logger = logging.getLogger(__name__)
+
+# Total POSTs to the IdP token endpoint, including the first attempt. This is
+# independent of AuthByPlugin._retry_ctx, which is reserved for the later
+# Snowflake login-request retries in SnowflakeConnection._authenticate().
+_OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS = 3
+_RETRYABLE_OAUTH_TOKEN_HTTP_STATUSES = frozenset({408, 429})
 
 
 class _OAuthTokensMixin:
@@ -470,19 +479,7 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
             fields["scope"] = self._scope
         try:
             # TODO(SNOW-2229411) Session manager should be used here. It may require additional security validation (since we would transition from PoolManager to requests.Session) and some parameters would be passed implicitly. OAuth token exchange must NOT reuse pooled HTTP sessions. We should create a fresh SessionManager with use_pooling=False for each call.
-            proxy_url = self._resolve_proxy_url(conn, self._token_request_url)
-            http_client = (
-                ProxyManager(proxy_url=proxy_url)
-                if proxy_url
-                else urllib3.PoolManager()
-            )
-            return http_client.request_encode_body(
-                "POST",
-                self._token_request_url,
-                encode_multipart=False,
-                headers=self._create_token_request_headers(),
-                fields=fields,
-            )
+            return self._post_token_request(conn, fields)
         except HTTPError as e:
             self._handle_failure(
                 conn=conn,
@@ -516,17 +513,7 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
         fields: dict[str, str],
     ) -> (str | None, str | None):
         # TODO(SNOW-2229411) Session manager should be used here. It may require additional security validation (since we would transition from PoolManager to requests.Session) and some parameters would be passed implicitly. Token request must bypass HTTP connection pools.
-        proxy_url = self._resolve_proxy_url(connection, self._token_request_url)
-        http_client = (
-            ProxyManager(proxy_url=proxy_url) if proxy_url else urllib3.PoolManager()
-        )
-        resp = http_client.request_encode_body(
-            "POST",
-            self._token_request_url,
-            headers=self._create_token_request_headers(),
-            encode_multipart=False,
-            fields=fields,
-        )
+        resp = self._post_token_request(connection, fields)
         try:
             logger.debug("OAuth IdP response received, try to parse it")
             json_resp: dict = json.loads(resp.data)
@@ -551,6 +538,69 @@ class AuthByOAuthBase(AuthByPlugin, _OAuthTokensMixin, ABC):
                 },
             )
         return None, None
+
+    def _post_token_request(
+        self,
+        connection: SnowflakeConnection,
+        fields: dict[str, str],
+    ) -> urllib3.BaseHTTPResponse:
+        """POST to the IdP token endpoint, retrying transient transport and HTTP errors.
+
+        SnowflakeConnection._authenticate() calls prepare() (and therefore this
+        POST) once, outside the GS login retry loop. Transient IdP failures
+        (connection reset, timeout, 5xx, 429) must be retried here
+        (SNOW-3984430). Auth errors such as HTTP 400 invalid_grant are not retried.
+        """
+        backoff = exponential_backoff()()
+        last_exc: BaseException | None = None
+        for attempt in range(1, _OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS + 1):
+            proxy_url = self._resolve_proxy_url(connection, self._token_request_url)
+            http_client = (
+                ProxyManager(proxy_url=proxy_url)
+                if proxy_url
+                else urllib3.PoolManager()
+            )
+            try:
+                resp = http_client.request_encode_body(
+                    "POST",
+                    self._token_request_url,
+                    headers=self._create_token_request_headers(),
+                    encode_multipart=False,
+                    fields=fields,
+                )
+            except (Urllib3HTTPError, OSError) as exc:
+                last_exc = exc
+                logger.debug(
+                    "OAuth token request failed on attempt %s/%s: %s",
+                    attempt,
+                    _OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS,
+                    exc,
+                )
+                if attempt >= _OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS:
+                    raise
+                time.sleep(float(next(backoff)))
+                continue
+
+            if (
+                self._is_retryable_oauth_token_http_status(resp.status)
+                and attempt < _OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS
+            ):
+                logger.debug(
+                    "OAuth token request returned HTTP %s on attempt %s/%s; retrying",
+                    resp.status,
+                    attempt,
+                    _OAUTH_TOKEN_REQUEST_MAX_ATTEMPTS,
+                )
+                time.sleep(float(next(backoff)))
+                continue
+            return resp
+
+        assert last_exc is not None
+        raise last_exc
+
+    @staticmethod
+    def _is_retryable_oauth_token_http_status(status: int) -> bool:
+        return status >= 500 or status in _RETRYABLE_OAUTH_TOKEN_HTTP_STATUSES
 
     def _create_token_request_headers(self) -> dict[str, str]:
         return {

--- a/test/unit/test_auth_oauth_credentials.py
+++ b/test/unit/test_auth_oauth_credentials.py
@@ -4,12 +4,15 @@
 #
 
 
+import json
 from test.helpers import apply_auth_class_update_body, create_mock_auth_body
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from snowflake.connector.auth import AuthByOauthCredentials
 from snowflake.connector.errors import ProgrammingError
+from snowflake.connector.vendored.urllib3.exceptions import ProtocolError
 
 
 def test_auth_oauth_credentials_oauth_type():
@@ -182,6 +185,126 @@ def test_oauth_client_credentials_allows_empty_user(monkeypatch):
     assert isinstance(conn.auth_class, AuthByOauthCredentials)
 
     conn.close()
+
+
+def _oauth_credentials_auth_and_conn():
+    auth = AuthByOauthCredentials(
+        "app",
+        "clientId",
+        "clientSecret",
+        "https://example.com/oauth/token",
+        "scope",
+    )
+    conn = MagicMock()
+    conn.proxy_host = None
+    conn.proxy_port = None
+    conn.proxy_user = None
+    conn.proxy_password = None
+    return auth, conn
+
+
+def _token_http_response(body: dict, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status = status
+    resp.data = json.dumps(body).encode()
+    return resp
+
+
+@pytest.mark.skipolddriver
+def test_oauth_token_request_retries_transient_http_failure(monkeypatch):
+    """SNOW-3984430: a transient IdP token-request failure should be retried."""
+    monkeypatch.setattr(
+        "snowflake.connector.auth._oauth_base.time.sleep", lambda _: None
+    )
+    success_resp = _token_http_response({"access_token": "ACCESS"})
+    mock_http = MagicMock()
+    mock_http.request_encode_body.side_effect = [
+        ProtocolError("Connection aborted."),
+        success_resp,
+    ]
+    auth, conn = _oauth_credentials_auth_and_conn()
+
+    with patch(
+        "snowflake.connector.auth._oauth_base.urllib3.PoolManager",
+        return_value=mock_http,
+    ):
+        access_token, refresh_token = auth._get_request_token_response(
+            conn, {"grant_type": "client_credentials", "scope": "scope"}
+        )
+
+    assert access_token == "ACCESS"
+    assert refresh_token is None
+    assert mock_http.request_encode_body.call_count == 2
+
+
+@pytest.mark.skipolddriver
+def test_oauth_token_request_retries_http_503(monkeypatch):
+    """SNOW-3984430: HTTP 503 from the IdP token endpoint should be retried."""
+    monkeypatch.setattr(
+        "snowflake.connector.auth._oauth_base.time.sleep", lambda _: None
+    )
+    mock_http = MagicMock()
+    mock_http.request_encode_body.side_effect = [
+        _token_http_response({"error": "unavailable"}, status=503),
+        _token_http_response({"access_token": "ACCESS"}),
+    ]
+    auth, conn = _oauth_credentials_auth_and_conn()
+
+    with patch(
+        "snowflake.connector.auth._oauth_base.urllib3.PoolManager",
+        return_value=mock_http,
+    ):
+        access_token, _ = auth._get_request_token_response(
+            conn, {"grant_type": "client_credentials"}
+        )
+
+    assert access_token == "ACCESS"
+    assert mock_http.request_encode_body.call_count == 2
+
+
+@pytest.mark.skipolddriver
+def test_oauth_token_request_does_not_retry_http_400(monkeypatch):
+    """SNOW-3984430: IdP auth errors must not be retried."""
+    monkeypatch.setattr(
+        "snowflake.connector.auth._oauth_base.time.sleep", lambda _: None
+    )
+    mock_http = MagicMock()
+    mock_http.request_encode_body.return_value = _token_http_response(
+        {"error": "invalid_grant"}, status=400
+    )
+    auth, conn = _oauth_credentials_auth_and_conn()
+    conn.errorhandler = MagicMock()
+
+    with patch(
+        "snowflake.connector.auth._oauth_base.urllib3.PoolManager",
+        return_value=mock_http,
+    ):
+        try:
+            auth._get_request_token_response(conn, {"grant_type": "client_credentials"})
+        except Exception:
+            pass
+
+    assert mock_http.request_encode_body.call_count == 1
+
+
+@pytest.mark.skipolddriver
+def test_oauth_token_request_gives_up_after_retries(monkeypatch):
+    """SNOW-3984430: transport errors are re-raised after the attempt budget."""
+    monkeypatch.setattr(
+        "snowflake.connector.auth._oauth_base.time.sleep", lambda _: None
+    )
+    mock_http = MagicMock()
+    mock_http.request_encode_body.side_effect = ProtocolError("Connection aborted.")
+    auth, conn = _oauth_credentials_auth_and_conn()
+
+    with patch(
+        "snowflake.connector.auth._oauth_base.urllib3.PoolManager",
+        return_value=mock_http,
+    ):
+        with pytest.raises(ProtocolError):
+            auth._get_request_token_response(conn, {"grant_type": "client_credentials"})
+
+    assert mock_http.request_encode_body.call_count == 3
 
 
 def test_oauth_credentials_missing_client_id_raises_error():


### PR DESCRIPTION
## Summary
- Retry transient HTTP failures when fetching an OAuth access token from the IdP (`OAUTH_CLIENT_CREDENTIALS` and `OAUTH_AUTHORIZATION_CODE`), including refresh-token exchange.
- Token POSTs retry transport errors, HTTP 408/429, and 5xx (up to 3 attempts with exponential backoff). Auth errors such as HTTP 400 `invalid_grant` are not retried.
- Fixes #3003 / SNOW-3984430. `prepare()` still runs outside the GS login retry loop; retries live at the IdP POST so urllib3 errors are actually caught.

## Test plan
- [x] `test/unit/test_auth_oauth_credentials.py` — retry on `ProtocolError` and HTTP 503, no retry on HTTP 400, give up after 3 transport failures
- [ ] Connect with `OAUTH_CLIENT_CREDENTIALS` against a flaky IdP (or proxy that resets once) and confirm `connect()` succeeds
- [ ] Confirm a real invalid client/secret still fails on the first 400 without extra token requests


Made with [Cursor](https://cursor.com)